### PR TITLE
fix: Claude re-review 시 PR 번호 누락 수정

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -32,7 +32,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
             REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
+            PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
 
             이 PR의 코드를 리뷰해주세요. 한국어로 답변해주세요.
 


### PR DESCRIPTION
- issue_comment 이벤트에서 github.event.issue.number fallback 추가
- re-review 요청 시 PR 번호가 비어있던 문제 해결

## 📌 개요

- PR의 목적과 해결하려는 문제를 간단히 설명해주세요.

## 🔧 작업 내용

- [ ] 구현/수정한 주요 기능을 항목별로 정리해주세요.
- [ ] 필요하다면 세부적인 변경 내역도 포함해주세요.

## 📎 관련 이슈

- Close #이슈번호  
  (ex: close #32)

## 📸 스크린샷 (선택)

| 변경 전 | 변경 후 |
| ------- | ------- |
| 이미지  | 이미지  |

## 💬 리뷰어 참고 사항

- 리뷰어가 중점적으로 봐주었으면 하는 부분
- 추가 논의가 필요한 부분
