### PR TITLE
chore: Badge 컴포넌트 마이그레이션

### DIFF
--- a/src/components/commons/badge/Badge.tsx
+++ b/src/components/commons/badge/Badge.tsx
@@ -1,0 +1,10 @@
+import { cn } from '@/lib/utils/cn'
+
+interface BadgeProps {
+  children: string
+  className?: string
+}
+
+export function Badge({ children, className }: BadgeProps) {
+  return <span className={cn('flex items-center justify-center rounded-md px-2 py-1 text-sm', className)}>{children}</span>
+}


### PR DESCRIPTION
## Summary
- `Badge.tsx`: 상태 표시용 뱃지 컴포넌트
- import 경로 `@src/` → `@/`로 변환
- 순수 렌더링 컴포넌트로 'use client' 불필요

## Changed Files
- `src/components/commons/badge/Badge.tsx` (신규)

## Test plan
- [ ] TypeScript 빌드 에러 없음 확인

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)