### PR TITLE
chore: Header notification-section 컴포넌트 마이그레이션

### DIFF
--- a/src/components/header/components/notification-section/NotificationItem.tsx
+++ b/src/components/header/components/notification-section/NotificationItem.tsx
@@ -1,0 +1,43 @@
+import { cn } from '@/lib/utils/cn'
+import { Bell as BellIcon } from 'lucide-react'
+import type { NotificationItem as NotificationItemType } from '@/types/notifications'
+import { iconMap, NOTIFICATION_MESSAGES, type NotificationType } from '@/constants/constants'
+import { getTimeAgo } from '@/lib/utils/getTimeAgo'
+import { notificationIconClass, notificationIconStrokeClass } from './notificationIconClass'
+
+interface NotificationItemProps extends NotificationItemType {
+  setIsNotificationOpen: (isOpen: boolean) => void
+  handleReadNotification: (notification: NotificationItemType) => void
+}
+
+export default function NotificationItem({ handleReadNotification, setIsNotificationOpen, ...notification }: NotificationItemProps) {
+  const Icon = iconMap[notification.notificationType as NotificationType] || BellIcon
+
+  return (
+    <div
+      className={cn(
+        'flex cursor-pointer items-start gap-3 border-b border-gray-200 px-4 pt-[17px] pb-4 transition-colors hover:bg-gray-50',
+        !notification.isRead ? 'bg-primary-50' : 'bg-white',
+      )}
+      onClick={() => handleReadNotification(notification)}
+    >
+      <div className={cn(notificationIconClass({ type: notification.notificationType as NotificationType }))}>
+        <Icon className={cn('h-5 w-5', notificationIconStrokeClass({ type: notification.notificationType as NotificationType }))} />
+      </div>
+      <div className="flex min-w-72 justify-between gap-1">
+        <div className="flex flex-col gap-1">
+          <p className="line-clamp-2 text-left text-sm font-semibold text-gray-900">
+            {NOTIFICATION_MESSAGES[notification.notificationType] ?? '알림이 도착했습니다'}
+          </p>
+          <p className="line-clamp-2 text-left text-sm text-gray-900">{notification.content}</p>
+          <p className="flex items-center text-xs text-gray-500">{getTimeAgo(notification.createdAt)}</p>
+        </div>
+        {!notification.isRead && (
+          <div className="flex pt-2">
+            <div className="bg-primary-500 size-2 rounded-full" />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/header/components/notification-section/NotificationsDropdown.tsx
+++ b/src/components/header/components/notification-section/NotificationsDropdown.tsx
@@ -1,0 +1,136 @@
+'use client'
+
+import { useRef } from 'react'
+import { Z_INDEX } from '@/constants/ui'
+import { cn } from '@/lib/utils/cn'
+import { useIntersectionObserver } from '@/hooks/useIntersectionObserver'
+import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query'
+import { fetchNotifications, patchNotifications, readNotification } from '@/lib/api/notifications'
+import { useUserStore } from '@/store/userStore'
+import type { NotificationItem as NotificationItemType } from '@/types/notifications'
+import NotificationItem from './NotificationItem'
+import { useRouter, usePathname } from 'next/navigation'
+import { getNavigationPath } from '@/lib/utils/getNavigationPath'
+import { useOutsideClick } from '@/hooks/useOutsideClick'
+import NotificationsSkeleton from './NotificationsSkeleton'
+import { chatSocketStore } from '@/store/chatSocketStore'
+
+interface NotificationsDropdownProps {
+  isNotificationOpen: boolean
+  setIsNotificationOpen: (isNotificationOpen: boolean) => void
+}
+
+export default function NotificationsDropdown({ isNotificationOpen, setIsNotificationOpen }: NotificationsDropdownProps) {
+  const queryClient = useQueryClient()
+
+  const user = useUserStore((state) => state.user)
+  const router = useRouter()
+  const pathname = usePathname()
+  const modalRef = useRef<HTMLDivElement>(null)
+  useOutsideClick(isNotificationOpen, [modalRef], () => setIsNotificationOpen(false))
+  const {
+    data: notificationsData,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading,
+    refetch,
+  } = useInfiniteQuery({
+    queryKey: ['notifications'],
+    queryFn: ({ pageParam }) => fetchNotifications(pageParam),
+    getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.page + 1 : undefined),
+    initialPageParam: 0,
+    enabled: !!user,
+  })
+
+  const observerTargetRef = useIntersectionObserver({
+    enabled: hasNextPage ?? false,
+    hasNextPage: hasNextPage ?? false,
+    isFetchingNextPage,
+    onIntersect: () => fetchNextPage(),
+    threshold: 0.5,
+  })
+
+  const handleMarkAllAsRead = async () => {
+    await patchNotifications()
+    queryClient.setQueryData<{ unreadCount: number }>(['notifications', 'unreadCount'], {
+      unreadCount: 0,
+    })
+    refetch()
+  }
+
+  const handleReadNotification = async (notification: NotificationItemType) => {
+    if (!notification.isRead) {
+      queryClient.setQueryData<{ unreadCount: number }>(['notifications', 'unreadCount'], (prev) => ({
+        unreadCount: Math.max((prev?.unreadCount ?? 0) - 1, 0),
+      }))
+    }
+    // 채팅 알림인 경우 ChatRooms의 unreadCount도 감소
+    if (notification.relatedEntityType === 'CHAT_ROOM') {
+      chatSocketStore.getState().clearUnreadCount(notification.relatedEntityId)
+    }
+    const currentPath = pathname
+    const targetPath = getNavigationPath(notification)
+    setIsNotificationOpen(false)
+
+    if (currentPath === targetPath) {
+      // 같은 페이지 로직
+      if (notification.relatedEntityType === 'POST') {
+        queryClient.invalidateQueries({
+          queryKey: ['community', String(notification.relatedEntityId)],
+        })
+      }
+    } else {
+      router.push(targetPath)
+    }
+    await readNotification(notification.notificationId)
+    refetch()
+  }
+
+  return (
+    <div
+      ref={modalRef}
+      className={cn(
+        'absolute top-12 right-0 max-h-[819.2px] min-w-[364px] overflow-hidden rounded-lg border border-gray-200 bg-white',
+        Z_INDEX.DROPDOWN,
+      )}
+      onClick={(e) => e.stopPropagation()}
+    >
+      <div className="flex items-center justify-between border-b border-gray-200 px-4 pt-4 pb-[17px]">
+        <div className="flex items-center gap-1">
+          <h3 className="flex items-center justify-start text-lg font-semibold text-gray-900">알림</h3>
+        </div>
+        <button
+          type="button"
+          onClick={handleMarkAllAsRead}
+          className="text-primary-600 flex cursor-pointer items-center justify-center text-center text-sm"
+        >
+          모두 읽음
+        </button>
+      </div>
+
+      <div className="scrollbar-hide flex max-h-80 flex-col overflow-y-auto" role="tabpanel">
+        {isLoading ? (
+          <NotificationsSkeleton />
+        ) : notificationsData?.pages.some((page) => page.content.length > 0) ? (
+          <>
+            {notificationsData?.pages.flatMap((page) =>
+              page.content.map((notification: NotificationItemType) => (
+                <NotificationItem
+                  key={notification.notificationId}
+                  {...notification}
+                  setIsNotificationOpen={setIsNotificationOpen}
+                  handleReadNotification={handleReadNotification}
+                />
+              )),
+            )}
+            <div ref={observerTargetRef} className="h-1" />
+          </>
+        ) : (
+          <div className="flex h-32 items-center justify-center text-sm text-gray-500">표시할 알림이 없습니다.</div>
+        )}
+      </div>
+      <div className="flex h-[45px] border-t border-gray-200" />
+    </div>
+  )
+}

--- a/src/components/header/components/notification-section/NotificationsSkeleton.tsx
+++ b/src/components/header/components/notification-section/NotificationsSkeleton.tsx
@@ -1,0 +1,21 @@
+export default function NotificationsSkeleton() {
+  return (
+    <>
+      {[...Array(5)].map((_, index) => (
+        <div key={index} className="flex animate-pulse items-start gap-3 border-b border-gray-200 px-4 pt-[17px] pb-4">
+          {/* 아이콘 자리 */}
+          <div className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-gray-200" />
+
+          {/* 콘텐츠 자리 */}
+          <div className="flex min-w-72 gap-1">
+            <div className="flex flex-1 flex-col gap-1">
+              <div className="h-4 w-full rounded bg-gray-200" />
+              <div className="h-4 w-3/4 rounded bg-gray-200" />
+              <div className="mt-1 h-3 w-16 rounded bg-gray-200" />
+            </div>
+          </div>
+        </div>
+      ))}
+    </>
+  )
+}

--- a/src/components/header/components/notification-section/notificationIconClass.ts
+++ b/src/components/header/components/notification-section/notificationIconClass.ts
@@ -1,0 +1,37 @@
+import { cva } from 'class-variance-authority'
+
+export const notificationIconClass = cva('flex h-8 w-8 shrink-0 items-center justify-center rounded-full', {
+  variants: {
+    type: {
+      CHAT_NEW_ROOM: 'bg-blue-100',
+      CHAT_NEW_MESSAGE: 'bg-blue-100',
+      PRODUCT_FAVORITE_STATUS_CHANGED: 'bg-pink-100',
+      PRODUCT_FAVORITE_PRICE_CHANGED: 'bg-yellow-100',
+      ADMIN_SANCTION: 'bg-red-100',
+      POST_DELETED: 'bg-gray-100',
+      COMMENT_REPLY: 'bg-purple-100',
+      POST_COMMENT: 'bg-indigo-100',
+    },
+  },
+  defaultVariants: {
+    type: 'CHAT_NEW_ROOM',
+  },
+})
+
+export const notificationIconStrokeClass = cva('', {
+  variants: {
+    type: {
+      CHAT_NEW_ROOM: 'stroke-[#2563EB]',
+      CHAT_NEW_MESSAGE: 'stroke-[#2563EB]',
+      PRODUCT_FAVORITE_STATUS_CHANGED: 'stroke-[#EC4899]',
+      PRODUCT_FAVORITE_PRICE_CHANGED: 'stroke-[#EAB308]',
+      ADMIN_SANCTION: 'stroke-[#DC2626]',
+      POST_DELETED: 'stroke-gray-400',
+      COMMENT_REPLY: 'stroke-[#9333EA]',
+      POST_COMMENT: 'stroke-[#6366F1]',
+    },
+  },
+  defaultVariants: {
+    type: 'CHAT_NEW_ROOM',
+  },
+})


### PR DESCRIPTION
## Summary
- NotificationsDropdown.tsx: 무한스크롤 알림 드롭다운 (useNavigate → useRouter)
- NotificationItem.tsx: 개별 알림 아이템 (아이콘, 내용, 시간)
- NotificationsSkeleton.tsx: 로딩 스켈레톤
- notificationIconClass.ts: CVA 기반 알림 타입별 아이콘 색상

## Changed Files
- `src/components/header/components/notification-section/NotificationsDropdown.tsx` (새 파일)
- `src/components/header/components/notification-section/NotificationItem.tsx` (새 파일)
- `src/components/header/components/notification-section/NotificationsSkeleton.tsx` (새 파일)
- `src/components/header/components/notification-section/notificationIconClass.ts` (새 파일)

## Test plan
- [ ] `npm run build` 성공
- [ ] 알림 드롭다운 열기/닫기 동작 확인 (#37 UserControls 연동 후)
- [ ] 알림 무한스크롤 로딩 확인
- [ ] 알림 읽음 처리 및 페이지 이동 확인

Closes #36