### PR TITLE
chore: Footer, AuthValidator, ClientComponents 마이그레이션

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next'
 import Providers from './providers'
-import ToastContainer from '@/components/commons/ToastContainer'
+import ClientComponents from '@/components/ClientComponents'
 import './globals.css'
 
 export const metadata: Metadata = {
@@ -18,7 +18,7 @@ export default function RootLayout({
       <body>
         <Providers>
           {children}
-          <ToastContainer />
+          <ClientComponents />
         </Providers>
       </body>
     </html>

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,8 +1,7 @@
 'use client'
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { useState, useEffect, type ReactNode } from 'react'
-import { useUserStore } from '@/store/userStore'
+import { useState, type ReactNode } from 'react'
 
 export default function Providers({ children }: { children: ReactNode }) {
   const [queryClient] = useState(
@@ -16,11 +15,6 @@ export default function Providers({ children }: { children: ReactNode }) {
         },
       }),
   )
-  const validateAuthState = useUserStore((state) => state.validateAuthState)
-
-  useEffect(() => {
-    validateAuthState()
-  }, [validateAuthState])
 
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
 }

--- a/src/components/AuthValidator.tsx
+++ b/src/components/AuthValidator.tsx
@@ -1,0 +1,18 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useUserStore } from '@/store/userStore'
+
+/**
+ * 앱 시작 시 인증 상태를 검증하는 컴포넌트
+ * 토큰과 유저 상태의 동기화를 담당
+ */
+export default function AuthValidator() {
+  const validateAuthState = useUserStore((state) => state.validateAuthState)
+
+  useEffect(() => {
+    validateAuthState()
+  }, [validateAuthState])
+
+  return null
+}

--- a/src/components/ClientComponents.tsx
+++ b/src/components/ClientComponents.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+
+// SSR 비활성화로 클라이언트에서만 렌더링
+const AuthValidator = dynamic(() => import('@/components/AuthValidator'), { ssr: false })
+// TODO: LoginModal 마이그레이션 후 추가 (#39-#41)
+// const LoginModal = dynamic(() => import('@/components/modal/LoginModal'), { ssr: false })
+const ToastContainer = dynamic(() => import('@/components/commons/ToastContainer'), { ssr: false })
+
+/**
+ * 클라이언트에서만 렌더링되는 전역 컴포넌트들
+ * - AuthValidator: 앱 시작 시 인증 상태 검증
+ * - LoginModal: 전역 로그인 모달 (TODO)
+ * - ToastContainer: 전역 토스트 알림
+ */
+export default function ClientComponents() {
+  return (
+    <>
+      <AuthValidator />
+      <ToastContainer />
+    </>
+  )
+}

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -1,0 +1,45 @@
+import Logo from '../Logo'
+import { ROUTES } from '@/constants/routes'
+import Link from 'next/link'
+
+export default function Footer() {
+  return (
+    <footer className="border-border bg-light border-t">
+      <div className="px-lg mx-auto max-w-7xl py-12">
+        <div className="flex flex-wrap justify-baseline gap-x-10 gap-y-5 md:justify-between md:gap-0">
+          <div className="flex flex-col gap-2">
+            <Logo logoClassname="h-12" textClassname="text-gray-400" />
+            <p className="text-gray-500">반려동물과 함께하는 행복한 반려동물 용품 거래를 경험하세요.</p>
+          </div>
+
+          <div className="flex flex-col gap-4">
+            <h4 className="font-semibold text-gray-500">커뮤니티</h4>
+            <ul className="flex flex-col gap-3 text-gray-500">
+              <li>
+                <Link href={`${ROUTES.COMMUNITY}?tab=tab-info`}>정보 공유해요</Link>
+              </li>
+              <li>
+                <Link href={`${ROUTES.COMMUNITY}?tab=tab-question`}>질문 있어요</Link>
+              </li>
+            </ul>
+          </div>
+
+          <div className="flex flex-col gap-4">
+            <h4 className="font-semibold text-gray-500">고객센터</h4>
+            <ul className="flex flex-col gap-3 text-gray-500">
+              <li>
+                <a href="mailto:support@cuddlemarket.com?subject=커들마켓 1:1 문의" aria-label="고객센터 이메일로 1:1 문의하기">
+                  1:1 문의
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
+
+        <div className="mt-6 border-t border-gray-300 pt-6">
+          <p className="text-center text-gray-500">© 2025 커들마켓. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  )
+}


### PR DESCRIPTION
## Summary
- `Footer.tsx`: 커뮤니티 링크, 고객센터, 저작권 표시 컴포넌트 생성
- `AuthValidator.tsx`: `providers.tsx`에서 인증 상태 검증 로직을 별도 컴포넌트로 분리
- `ClientComponents.tsx`: AuthValidator + ToastContainer를 `dynamic(ssr: false)`로 래핑 (LoginModal은 #39-#41 마이그레이션 후 추가 예정)
- `providers.tsx`: validateAuthState 제거 → QueryClient 관리만 담당
- `layout.tsx`: `<ToastContainer />` → `<ClientComponents />`로 교체

## Changed Files
| 파일 | 작업 |
|------|------|
| `src/components/footer/Footer.tsx` | 새 파일 |
| `src/components/AuthValidator.tsx` | 새 파일 |
| `src/components/ClientComponents.tsx` | 새 파일 |
| `src/app/providers.tsx` | 수정 |
| `src/app/layout.tsx` | 수정 |

## Test plan
- [x] `npm run build` 성공 확인

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)