### PR TITLE
chore: 상품 수정 페이지 마이그레이션

### DIFF
--- a/src/app/(main)/products/[id]/edit/page.tsx
+++ b/src/app/(main)/products/[id]/edit/page.tsx
@@ -1,0 +1,12 @@
+import { Suspense } from 'react'
+import ProductPost from '@/features/product-post/ProductPost'
+
+export const dynamic = 'force-dynamic'
+
+export default function ProductEditPage() {
+  return (
+    <Suspense fallback={null}>
+      <ProductPost />
+    </Suspense>
+  )
+}


### PR DESCRIPTION
## Summary
- Vite → Next.js 상품 수정 페이지 라우트 마이그레이션
- `ProductPost` 컴포넌트 재사용 (`useParams`의 `id`로 수정 모드 자동 감지)

## Changed Files
- `src/app/(main)/products/[id]/edit/page.tsx` (신규)

## Test plan
- [x] `npm run build` 성공
- [ ] `/products/[id]/edit` 접근 시 수정 모드로 폼 렌더링 확인

Closes #54