### PR TITLE
docs: 개발 문서 정리

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
-# cuddle-market
+# CUDDLE MARKET
+
+## 프로젝트 소개
+
+<div>
+<img  alt="Image" src="https://github.com/user-attachments/assets/6ea2172e-9a39-454d-8e13-461cc12dc075" /> </div>
+<br/>
+
+**"더 이상 반려동물 용품은 한 번 쓰고 버리는 물건이 아닙니다."**
+
+아이처럼 빠르게 성장하는 우리 반려동물들. <br/>
+금세 작아진 옷, 흥미를 잃은 장난감, 한두 번 쓴 캐리어... <br/>
+집 한구석에 쌓여가는 용품들을 보며 아까운 마음이 드셨나요? <br/>
+
+**CUDDLE MARKET**은 반려동물을 사랑하는 모든 가족들이 모여
+따뜻한 마음을 나누는 동네 시장입니다.
+
+> 🚧 **Next.js 마이그레이션 진행 중** - [기존 Vite 버전](https://github.com/ExpectedAnnualSalaryOf4TrillionWon/Cuddle-Market-FE)
+
+## 기술 스택
+
+### Core
+
+![Next.js](https://img.shields.io/badge/Next.js_15-000000?style=for-the-badge&logo=nextdotjs&logoColor=white)
+![React](https://img.shields.io/badge/React_19-61DAFB?style=for-the-badge&logo=react&logoColor=black)
+![TypeScript](https://img.shields.io/badge/TypeScript_5.8-3178C6?style=for-the-badge&logo=typescript&logoColor=white)
+
+### State Management & Data Fetching
+
+![Zustand](https://img.shields.io/badge/Zustand-433E38?style=for-the-badge&logo=zustand&logoColor=white)
+![React Query](https://img.shields.io/badge/TanStack_Query-FF4154?style=for-the-badge&logo=reactquery&logoColor=white)
+
+### Styling & UI
+
+![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS_4-06B6D4?style=for-the-badge&logo=tailwindcss&logoColor=white)
+![Framer Motion](https://img.shields.io/badge/Framer_Motion-0055FF?style=for-the-badge&logo=framer&logoColor=white)
+
+## 문서
+
+- [마이그레이션 가이드](docs/migration-guide.md)
+- [컨벤션](docs/conventions.md)
+- [코드 컨벤션](docs/code-convention.md)
+- [Next.js 학습 컨텍스트](docs/nextjs-learning-context.md)

--- a/docs/code-convention.md
+++ b/docs/code-convention.md
@@ -1,0 +1,63 @@
+# 코드 컨벤션(Code Convention)
+
+## 1. 경로(Path)
+
+- 같은 폴더 내 파일을 import할 경우 → **상대경로 사용**
+- 그 외 경로 → **절대경로 사용**
+
+```ts
+// 같은 폴더 내
+import Button from './Button'
+
+// 다른 폴더
+import Header from 'components/Header'
+```
+
+---
+
+## 2. Export
+
+컴포넌트 생성 시 → Default Export 사용
+
+```ts
+// Default Export
+export default function MyComponent() {
+  return <div>MyComponent</div>
+}
+```
+
+constants 등 → Named Export 사용
+
+```ts
+// Named Export
+export const API_URL = 'https://example.com/api'
+```
+
+아이콘 import 시 → X as XIcon 형태 사용
+
+```ts
+import { Home as HomeIcon } from 'lucide-react'
+```
+
+---
+
+## 3. 함수 생성
+
+모든 함수는 화살표 함수(Arrow Function) 사용
+
+```ts
+const sum = (a: number, b: number) => a + b
+```
+
+---
+
+## 4. 타입 vs 인터페이스
+
+**인터페이스(Interface)**로 통일
+
+```ts
+interface User {
+  id: number
+  name: string
+}
+```

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,131 @@
+# 컨벤션(Convention)
+
+## 1. 브랜치 컨벤션
+
+- 브랜치 네이밍은 전부 소문자(종류/이슈번호--브랜치 이름)
+  `ex) feature/24--modal-ui`
+
+| 종류     | 설명                                       | 예시                          |
+| -------- | ------------------------------------------ | ----------------------------- |
+| main     | 메인 브랜치                                | main                          |
+| develop  | 배포 전 개발 브랜치                        | develop                       |
+| feature  | 새로운 기능 개발                           | feature/32--login-ui          |
+| hotfix   | 긴급 수정                                  | hotfix/101--critical-bug      |
+| release  | 배포용 브랜치                              | release/v1.2.0                |
+| fix      | 버그 수정 (이미 개발된 컴포넌트 기능 개선) | fix/45--button-click-bug      |
+| refactor | 코드 구조/네이밍 변경 (기능 유지)          | refactor/51--file-cleanup     |
+| chore    | 빌드, 환경, 설정, 정리 작업                | chore/12--update-dependencies |
+| test     | 테스트 코드 작성/수정                      | test/22--login-unit-test      |
+| docs     | 문서 작업만                                | docs/3--readme-update         |
+
+---
+
+## 2. 커밋 컨벤션
+
+- 커밋 타입(소문자): 한글로 된 내용
+- 타입: 커밋 내용(#이슈번호)
+  `ex) feat: 로그인 ui 작업(#32)`
+- 세부내용 필요하면 - 를 사용하면서 vim 으로 적기
+
+| Type     | 설명                                            |
+| -------- | ----------------------------------------------- |
+| feat     | 새로운 기능 추가                                |
+| fix      | 버그 수정                                       |
+| refactor | 리팩토링 (동작 변경 없음, 구조 개선)            |
+| design   | CSS 및 UI 디자인 변경                           |
+| style    | 코드 포맷팅, 세미콜론 누락 등 기능 변경 없음    |
+| test     | 테스트 코드 추가/수정/삭제                      |
+| chore    | 기타 변경사항 (빌드 스크립트, 패키지 매니저 등) |
+| init     | 프로젝트 초기 생성                              |
+| rename   | 파일/폴더명 수정 또는 이동                      |
+| remove   | 파일 삭제                                       |
+| docs     | 문서 작성/수정                                  |
+
+---
+
+## 3. PR 컨벤션
+
+- 타입: 이슈 내용
+  `ex) feat: 로그인 ui 작업`
+
+### 📌 개요
+
+- 내용
+
+### 🔧 작업 내용
+
+- 작업 내용
+
+### 📎 관련 이슈
+
+- Close #이슈번호
+
+### 📸 스크린샷 (선택)
+
+| 변경 전 | 변경 후 |
+| ------- | ------- |
+| 이미지  | 이미지  |
+
+### 💬 리뷰어 참고 사항
+
+- 리뷰어가 중점적으로 봐주었으면 하는 부분
+- 추가 논의가 필요한 부분
+
+---
+
+## 4. 코드 네이밍 컨벤션
+
+| 타입            | 예시                                      |
+| --------------- | ----------------------------------------- |
+| 상수(Constant)  | SCREAMING_SNAKE_CASE (MAX_VALUE, API_URL) |
+| Boolean 변수    | is접두사 사용 (isActive)                  |
+| 일반 변수       | camelCase 사용 (userName, itemList)       |
+| 배열            | 복수형 사용 (users, items)                |
+| 객체            | 단수형 사용 (user, item)                  |
+| 이벤트 핸들러   | handle 접두사 (handleSubmit)              |
+| 비동기 함수     | fetch 접두사 (fetchData)                  |
+| TypeScript 타입 | Interface/Type (interface User {})        |
+
+- 폴더 네이밍: 전부 소문자
+
+---
+
+## 5. 파일 네이밍 컨벤션
+
+| 파일 타입 | 네이밍                                               |
+| --------- | ---------------------------------------------------- |
+| conponent | PascalCase (UserCard.tsx, LoginForm.tsx)             |
+| image     | kebab-case (logo-icon.png, user-avatar.jpg)          |
+| util      | camelCase (fetchUser.ts, calculateSum.ts)            |
+| style     | dot notation (tokens.colors.css, tokens.spacing.css) |
+| type      | camelCase (user.ts, productType.ts)                  |
+| constant  | kebab-case (ui-constants.ts, api-constants.ts)       |
+
+---
+
+## 6. Git 워크플로우
+
+### 브랜치 전략
+
+- 모든 기능 브랜치는 `develop`에서 분기하고 `develop`으로 머지
+- `main` 브랜치는 분기별로 `develop`에서 머지
+
+### 작업 시작 전 체크리스트
+
+1. **이슈 먼저 생성** (브랜치 생성 전 반드시 GitHub 이슈 생성)
+2. **이슈 번호로 브랜치 생성** (예: `feature/123--기능명`)
+
+### commit-push 전 체크리스트
+
+1. **현재 브랜치가 이미 머지되었는지 확인**
+   ```bash
+   git log --oneline origin/develop | grep "현재 브랜치명"
+   ```
+2. **이미 머지된 브랜치라면 `develop`으로 전환 후 새 브랜치 생성**
+   ```bash
+   git checkout develop && git pull
+   git checkout -b 새브랜치명
+   ```
+3. **작업 완료 후 PR은 `develop` 브랜치를 base로 생성**
+4. **PR 생성은 Claude Code가 수행** (`.github/PULL_REQUEST_TEMPLATE.md` 템플릿 사용)
+5. **머지는 사용자가 직접 수행**

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -1,0 +1,109 @@
+# Next.js 마이그레이션 가이드
+
+Vite + React Router 프로젝트를 Next.js App Router로 마이그레이션하는 단계별 가이드입니다.
+
+---
+
+## Phase 1: 프로젝트 초기화
+
+### 1.1 Next.js 초기화
+
+```bash
+npx create-next-app@latest . --typescript --tailwind --eslint --app --src-dir --import-alias "@/*"
+```
+
+### 1.2 Dependencies 설치
+
+```bash
+# 상태 관리 & 데이터 페칭
+npm install zustand @tanstack/react-query axios
+
+# UI & 애니메이션
+npm install framer-motion lucide-react react-icons
+npm install class-variance-authority clsx tailwind-merge
+
+# 폼 & 날짜
+npm install react-hook-form react-datepicker date-fns
+
+# 파일 업로드
+npm install react-dropzone browser-image-compression
+
+# 드래그 앤 드롭
+npm install @dnd-kit/core @dnd-kit/sortable @dnd-kit/utilities
+
+# 실시간 통신
+npm install @stomp/stompjs sockjs-client event-source-polyfill
+
+# 마크다운
+npm install react-markdown rehype-sanitize remark-breaks
+
+# 타입 정의
+npm install -D @types/sockjs-client @types/event-source-polyfill
+```
+
+### 1.3 환경변수 설정
+
+`.env.local`:
+```
+NEXT_PUBLIC_API_BASE_URL=https://cmarket-api.duckdns.org/api
+NEXT_PUBLIC_WS_URL=https://cmarket-api.duckdns.org/ws-stomp
+```
+
+---
+
+## Phase 2: 기존 소스 복사
+
+```bash
+cp -r ~/Desktop/Cuddle-Market-FE/src/components src/
+cp -r ~/Desktop/Cuddle-Market-FE/src/hooks src/
+cp -r ~/Desktop/Cuddle-Market-FE/src/store src/
+cp -r ~/Desktop/Cuddle-Market-FE/src/types src/
+cp -r ~/Desktop/Cuddle-Market-FE/src/constants src/
+mkdir -p src/lib
+cp -r ~/Desktop/Cuddle-Market-FE/src/api src/lib/
+cp -r ~/Desktop/Cuddle-Market-FE/src/utils src/lib/
+cp -r ~/Desktop/Cuddle-Market-FE/public/* public/
+```
+
+---
+
+## Phase 3: 라우팅 변환
+
+| React Router | Next.js App Router |
+|--------------|-------------------|
+| `useNavigate()` | `useRouter()` from `next/navigation` |
+| `navigate('/path')` | `router.push('/path')` |
+| `<Link to="/path">` | `<Link href="/path">` |
+| `useParams()` | `useParams()` from `next/navigation` |
+
+---
+
+## Phase 4: 환경변수 변환
+
+```tsx
+// 기존 (Vite)
+import.meta.env.VITE_API_BASE_URL
+
+// 변경 (Next.js)
+process.env.NEXT_PUBLIC_API_BASE_URL
+```
+
+---
+
+## Phase 5: Client Component 표시
+
+상호작용이 필요한 컴포넌트에 `'use client'` 추가:
+
+```tsx
+'use client';
+
+import { useState } from 'react';
+// ...
+```
+
+---
+
+## 참고
+
+- [Next.js 공식 문서](https://nextjs.org/docs)
+- [App Router 마이그레이션 가이드](https://nextjs.org/docs/app/building-your-application/upgrading/app-router-migration)

--- a/docs/nextjs-learning-context.md
+++ b/docs/nextjs-learning-context.md
@@ -1,0 +1,856 @@
+# Next.js 학습 컨텍스트 (React 개발자용)
+
+이 문서는 React.js를 알고 있는 개발자가 Next.js App Router를 이해하기 위한 가이드입니다.
+Cuddle-Market 프로젝트의 Vite + React Router → Next.js 마이그레이션 과정에서 배운 내용을 정리했습니다.
+
+---
+
+## 1. 핵심 개념: 파일 기반 라우팅
+
+### React Router (기존)
+```tsx
+// App.tsx에서 라우팅을 코드로 정의
+<Route path="/" element={<Home />} />
+<Route path="/community" element={<Community />} />
+<Route path="/chat/:id" element={<Chat />} />
+```
+
+### Next.js App Router (신규)
+```
+src/app/
+  page.tsx              → "/"
+  community/
+    page.tsx            → "/community"
+  chat/
+    [id]/
+      page.tsx          → "/chat/:id" (동적 라우트)
+```
+
+**핵심**: 폴더 구조 = URL 경로. 라우팅 코드를 작성할 필요 없음.
+
+---
+
+## 2. 예약된 파일명
+
+Next.js가 **자동으로 인식**하는 특별한 파일명들:
+
+| 파일명 | 역할 | import 필요? |
+|--------|------|-------------|
+| `page.tsx` | 해당 경로의 페이지 | 자동 |
+| `layout.tsx` | 하위 페이지들을 감싸는 레이아웃 | 자동 |
+| `loading.tsx` | 로딩 UI (Suspense fallback) | 자동 |
+| `error.tsx` | 에러 UI | 자동 |
+| `not-found.tsx` | 404 UI | 자동 |
+
+예시:
+```
+src/app/
+  layout.tsx      ← 모든 페이지에 적용되는 루트 레이아웃
+  page.tsx        ← "/" 페이지
+  community/
+    layout.tsx    ← /community/* 페이지들에만 적용
+    page.tsx      ← "/community" 페이지
+```
+
+---
+
+## 3. Route Group: 괄호 `()` 폴더
+
+**URL에 영향 없이** 페이지들을 그룹화하고 공통 레이아웃 적용.
+
+```
+src/app/
+  (main)/                 ← URL에 포함 안 됨
+    layout.tsx            ← MainLayout 적용 (Header 포함)
+    page.tsx              → "/" (not "/main")
+    community/
+      page.tsx            → "/community" (not "/main/community")
+    auth/
+      login/
+        page.tsx          → "/auth/login" (not "/main/auth/login")
+```
+
+**용도**:
+- `(main)`: 헤더가 있는 모든 페이지들 (인증 페이지 포함)
+- MainLayout에서 경로별로 SearchBar, 메뉴 버튼 등을 조건부 숨김
+
+---
+
+## 4. Server Components vs Client Components
+
+### 기본값: Server Component
+```tsx
+// page.tsx - 기본적으로 서버에서 렌더링
+export default function Page() {
+  return <div>서버에서 렌더링됨</div>
+}
+```
+
+### Client Component: 'use client' 필요
+```tsx
+'use client'  // ← 파일 최상단에 필수
+
+import { useState, useEffect } from 'react'
+
+export default function Counter() {
+  const [count, setCount] = useState(0)  // 브라우저 API 사용
+  return <button onClick={() => setCount(count + 1)}>{count}</button>
+}
+```
+
+### 'use client'가 필요한 경우
+- `useState`, `useEffect`, `useRef` 등 React 훅 사용
+- `onClick`, `onChange` 등 이벤트 핸들러 사용
+- `window`, `document`, `localStorage` 등 브라우저 API 사용
+- `usePathname()`, `useSearchParams()`, `useRouter()` 등 next/navigation 훅 사용
+
+---
+
+## 5. SSR과 Hydration
+
+### SSR (Server-Side Rendering)이란?
+1. 서버에서 HTML을 미리 생성
+2. 브라우저로 HTML 전송 (빠른 초기 로드)
+3. JavaScript 로드 후 이벤트 연결 (Hydration)
+
+### Hydration 에러
+서버 HTML과 클라이언트 초기 렌더링이 다르면 에러 발생.
+
+**문제 예시**:
+```tsx
+// useMediaQuery가 서버에서는 false, 클라이언트에서는 true 반환
+const isXl = useMediaQuery('(min-width: 1280px)')
+// → 서버/클라이언트 className 불일치 → Hydration 에러
+```
+
+**해결책**: 항상 동일한 초기값으로 시작
+```tsx
+export function useMediaQuery(query: string): boolean {
+  // SSR-safe: 항상 false로 시작
+  const [matches, setMatches] = useState(false)
+
+  useEffect(() => {
+    // 클라이언트에서만 실제 값으로 업데이트
+    setMatches(window.matchMedia(query).matches)
+  }, [query])
+
+  return matches
+}
+```
+
+---
+
+## 6. SSR-safe 패턴들
+
+### SSR-safe란?
+
+**SSR-safe** = Server-Side Rendering에서 안전하게 동작하는 코드
+
+Next.js는 컴포넌트를 **서버에서 먼저 렌더링**합니다. 이때 브라우저 전용 API(`window`, `document`, `localStorage` 등)는 서버에 존재하지 않습니다.
+
+```
+[서버]                              [브라우저]
+  │                                    │
+  ├─ window? ❌ 없음                   ├─ window? ✅ 있음
+  ├─ localStorage? ❌ 없음             ├─ localStorage? ✅ 있음
+  └─ document? ❌ 없음                 └─ document? ✅ 있음
+```
+
+**SSR-safe 코드**란:
+1. 서버에서 에러 없이 실행되고
+2. 서버와 클라이언트에서 **동일한 초기 결과**를 반환하는 코드
+
+### 왜 중요한가?
+
+서버와 클라이언트의 렌더링 결과가 다르면 **Hydration 에러** 발생:
+```
+Error: Hydration failed because the server rendered HTML didn't match the client
+```
+
+**예시**: 로그인 상태 확인
+```tsx
+// ❌ SSR-unsafe - Hydration 에러 발생
+const isLoggedIn = localStorage.getItem('token') !== null
+// 서버: localStorage 없음 → 에러 또는 false
+// 클라이언트: localStorage 있음 → true (로그인 시)
+// → 결과 불일치 → Hydration 에러!
+
+// ✅ SSR-safe - useEffect로 클라이언트에서만 확인
+const [isLoggedIn, setIsLoggedIn] = useState(false)  // 서버/클라이언트 동일
+useEffect(() => {
+  setIsLoggedIn(localStorage.getItem('token') !== null)  // 클라이언트에서만 실행
+}, [])
+```
+
+---
+
+### localStorage 접근
+```tsx
+// ❌ 잘못된 방법
+const [value] = useState(localStorage.getItem('key'))  // 서버에서 에러
+
+// ✅ SSR-safe 방법
+const storage: StateStorage = {
+  getItem: (name) => {
+    if (typeof window === 'undefined') return null  // 서버면 null
+    return localStorage.getItem(name)
+  },
+  setItem: (name, value) => {
+    if (typeof window === 'undefined') return
+    localStorage.setItem(name, value)
+  },
+  removeItem: (name) => {
+    if (typeof window === 'undefined') return
+    localStorage.removeItem(name)
+  },
+}
+```
+
+### dynamic import로 SSR 비활성화
+```tsx
+import dynamic from 'next/dynamic'
+
+// 이 컴포넌트는 클라이언트에서만 렌더링
+const LoginModal = dynamic(() => import('@/components/LoginModal'), {
+  ssr: false  // 서버에서 렌더링하지 않음
+})
+```
+
+---
+
+## 7. useSearchParams와 Suspense
+
+`useSearchParams()`를 사용하는 페이지는 반드시:
+
+```tsx
+// page.tsx
+import { Suspense } from 'react'
+import Home from '@/features/home/Home'
+
+export const dynamic = 'force-dynamic'  // 1. 동적 렌더링 강제
+
+export default function HomePage() {
+  return (
+    <Suspense fallback={null}>  {/* 2. Suspense로 감싸기 */}
+      <Home />
+    </Suspense>
+  )
+}
+```
+
+**이유**: `useSearchParams()`는 빌드 시점에 알 수 없는 값이므로 동적 렌더링 필요.
+
+---
+
+## 8. React Router → Next.js 마이그레이션
+
+### 라우팅 관련 변경
+
+| React Router | Next.js |
+|--------------|---------|
+| `react-router-dom` | `next/navigation` |
+| `<Link to="/path">` | `<Link href="/path">` |
+| `useNavigate()` | `useRouter()` |
+| `useLocation().pathname` | `usePathname()` |
+| `useParams()` | `useParams()` |
+| `useSearchParams()` | `useSearchParams()` |
+| `<Outlet />` | `{children}` |
+
+### 예시: useNavigate → useRouter
+```tsx
+// React Router
+import { useNavigate } from 'react-router-dom'
+const navigate = useNavigate()
+navigate('/home')
+navigate(-1)  // 뒤로가기
+
+// Next.js
+import { useRouter } from 'next/navigation'
+const router = useRouter()
+router.push('/home')
+router.back()  // 뒤로가기
+```
+
+### 예시: Layout 변환
+```tsx
+// React Router - MainLayout.tsx
+import { Outlet } from 'react-router-dom'
+export default function MainLayout() {
+  return (
+    <div>
+      <Header />
+      <Outlet />  {/* 자식 라우트 렌더링 */}
+    </div>
+  )
+}
+
+// Next.js - MainLayout.tsx
+export default function MainLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div>
+      <Header />
+      {children}  {/* 자식 페이지 렌더링 */}
+    </div>
+  )
+}
+```
+
+---
+
+## 9. 환경변수
+
+| Vite | Next.js |
+|------|---------|
+| `import.meta.env.VITE_API_URL` | `process.env.NEXT_PUBLIC_API_URL` |
+
+- `NEXT_PUBLIC_` 접두사: 클라이언트에서 접근 가능
+- 접두사 없음: 서버에서만 접근 가능
+
+---
+
+## 10. 정적 에셋 (이미지, SVG) 처리
+
+### Vite vs Next.js 차이점
+
+| Vite | Next.js |
+|------|---------|
+| `import logo from './logo.svg'` → 경로 문자열 | `import logo from './logo.svg'` → 모듈 객체 |
+| `<img src={logo} />` 바로 사용 | `<img src={logo.src} />` 또는 `<Image src={logo} />` |
+
+### SVG 사용 방법
+
+**방법 1: public 폴더 사용 (권장)**
+```tsx
+// SVG 파일을 public/images/에 복사
+// public/images/kakao.svg
+
+// 컴포넌트에서 경로로 직접 참조
+<img src="/images/kakao.svg" alt="카카오" />
+<Button iconSrc="/images/kakao.svg">카카오 로그인</Button>
+```
+
+**방법 2: next/image 사용**
+```tsx
+import Image from 'next/image'
+import logo from '@/assets/images/logo.svg'
+
+// StaticImageData 객체이므로 Image 컴포넌트에서 사용
+<Image src={logo} alt="로고" />
+
+// 일반 img 태그에서는 .src 필요
+<img src={logo.src} alt="로고" />
+```
+
+### 이 프로젝트에서의 처리
+
+소셜 로그인 아이콘 등 기존 `src/assets/images/`의 SVG들을 `public/images/`로 복사하여 사용:
+```
+public/
+  images/
+    kakao.svg
+    google.svg
+```
+
+---
+
+## 11. 프로젝트 폴더 구조
+
+```
+src/
+  app/                    ← Next.js 라우팅 (예약됨)
+    (main)/               ← Route Group (MainLayout 적용, Header 포함)
+      layout.tsx
+      page.tsx            → "/"
+      community/
+        page.tsx          → "/community"
+        [id]/
+          page.tsx        → "/community/:id"
+      auth/               ← 인증 페이지 (헤더 있음, SearchBar/메뉴 조건부 숨김)
+        login/
+          page.tsx        → "/auth/login"
+    layout.tsx            ← 루트 레이아웃
+    providers.tsx         ← QueryClientProvider 등
+
+  features/               ← 실제 페이지 컴포넌트들 (기존 pages/)
+    home/Home.tsx
+    community/Community.tsx
+
+  components/             ← 공통 컴포넌트
+  hooks/                  ← 커스텀 훅
+  store/                  ← Zustand 스토어
+  lib/                    ← 유틸리티, API 등
+    api/
+    utils/
+  layouts/                ← 레이아웃 컴포넌트
+  constants/              ← 상수
+  types/                  ← TypeScript 타입
+```
+
+### 왜 features 폴더를 따로 두나요?
+
+`app/` 폴더는 Next.js 라우팅 규칙에 종속됨:
+- `page.tsx` → 페이지
+- `layout.tsx` → 레이아웃
+- 기타 파일은 라우팅에 영향
+
+실제 UI 로직을 `features/`에 분리하면:
+- 기존 React 코드를 거의 그대로 유지 가능
+- `app/`의 page.tsx는 라우팅 + Next.js 설정만 담당
+
+---
+
+## 12. 자주 발생하는 에러와 해결
+
+### "use client" 누락
+```
+Error: useState only works in Client Components
+```
+→ 파일 최상단에 `'use client'` 추가
+
+### 이벤트 핸들러 에러
+```
+Error: Event handlers cannot be passed to Client Component props.
+  <button onClick={function handleClick} ...>
+```
+→ `onClick`, `onChange` 등 이벤트 핸들러를 사용하는 컴포넌트에 `'use client'` 추가
+
+**실제 사례**: `SocialLoginButtons.tsx`에서 `onClick={handleKakaoLogin}` 사용
+```tsx
+// ❌ 에러 발생 - Server Component에서 이벤트 핸들러 사용
+export function SocialLoginButtons() {
+  const handleKakaoLogin = () => { ... }
+  return <Button onClick={handleKakaoLogin}>로그인</Button>
+}
+
+// ✅ 해결 - 'use client' 추가
+'use client'
+export function SocialLoginButtons() {
+  const handleKakaoLogin = () => { ... }
+  return <Button onClick={handleKakaoLogin}>로그인</Button>
+}
+```
+
+### Hydration 에러
+```
+Error: Hydration failed because the server rendered HTML didn't match the client
+```
+→ 서버/클라이언트 초기값 일치시키기 (섹션 6 참고)
+
+**실제 사례**: `UserControls.tsx`에서 로그인 상태에 따라 다른 UI 렌더링
+```tsx
+// ❌ Hydration 에러 - 서버와 클라이언트 결과 불일치
+const { isLogin } = useUserStore()
+return isLogin() ? <UserMenu /> : <AuthMenu />
+// 서버: isLogin() → false (localStorage 없음)
+// 클라이언트: isLogin() → true (로그인 상태)
+
+// ✅ SSR-safe - 초기값 동일, 마운트 후 업데이트
+const [isLoggedIn, setIsLoggedIn] = useState(false)  // 항상 false로 시작
+useEffect(() => {
+  setIsLoggedIn(isLogin())  // 클라이언트에서만 실제 값으로 업데이트
+}, [isLogin, user])
+return isLoggedIn ? <UserMenu /> : <AuthMenu />
+```
+
+### useSearchParams 에러
+```
+Error: useSearchParams() should be wrapped in a suspense boundary
+```
+→ `export const dynamic = 'force-dynamic'` + `<Suspense>` 래핑
+
+### localStorage 에러
+```
+Error: localStorage is not defined
+```
+→ `typeof window === 'undefined'` 체크 추가
+
+### API 요청 403 Forbidden (CORS)
+```
+// 브라우저 네트워크 탭에서 403 에러
+check?nickname=xxx  403  xhr
+```
+→ **포트 확인**: 서버에서 `localhost:3000`만 CORS 허용하는 경우, 다른 포트(3001, 3002 등)에서는 403 발생
+
+**해결 방법**:
+1. 포트 3000을 사용 중인 프로세스 확인: `lsof -i :3000`
+2. 해당 프로세스 종료: `kill <PID>` 또는 `pkill -f "next dev"`
+3. 개발 서버 재시작: `npm run dev` → `http://localhost:3000`에서 실행 확인
+
+**Turbopack 캐시 에러 발생 시**:
+```
+FATAL: An unexpected Turbopack error occurred
+```
+→ `.next` 폴더 삭제 후 재시작: `rm -rf .next && npm run dev`
+
+### SVG import 에러
+```
+// 이미지가 표시되지 않음 (Vite → Next.js 마이그레이션 시)
+import kakao from '@/assets/images/kakao.svg'
+<img src={kakao} />  // kakao가 문자열이 아닌 객체
+```
+→ SVG를 `public/` 폴더로 이동하고 경로 문자열로 직접 참조
+```tsx
+<img src="/images/kakao.svg" />
+```
+
+---
+
+## 13. 이 프로젝트에서 변경된 파일 목록
+
+### 새로 생성된 파일
+- `src/app/layout.tsx` - 루트 레이아웃
+- `src/app/providers.tsx` - QueryClientProvider
+- `src/app/(main)/layout.tsx` - MainLayout 적용
+- `src/app/(main)/page.tsx` 및 기타 라우트 파일들
+- `src/components/AuthValidator.tsx` - 인증 상태 검증
+- `src/components/ClientComponents.tsx` - 클라이언트 전용 컴포넌트 래퍼
+
+### 수정된 파일
+- `src/store/userStore.ts` - SSR-safe storage 추가
+- `src/hooks/useMediaQuery.ts` - SSR-safe 초기값
+- `src/layouts/MainLayout.tsx` - Outlet → children
+- `src/features/**/*.tsx` - 'use client' 추가, import 경로 수정
+- `src/features/login/components/SocialLoginButtons.tsx` - 'use client' 추가, SVG import를 public 경로로 변경
+- `src/components/header/components/UserControls.tsx` - SSR-safe 로그인 상태 체크 (Hydration 에러 해결)
+- `src/components/header/components/MobileNavigation.tsx` - SSR-safe 로그인 상태 체크 (Hydration 에러 해결)
+- `src/components/commons/InputWithButton.tsx` - 'use client' 추가
+- `src/features/home/Home.tsx` - SSR-safe 로그인 상태 체크 (Hydration 에러 해결)
+
+### 추가된 정적 파일
+- `public/images/kakao.svg` - 카카오 로그인 아이콘
+- `public/images/google.svg` - 구글 로그인 아이콘
+
+---
+
+## 다음 세션에서 이어서 할 작업
+
+1. 브라우저에서 각 페이지 기능 테스트 (로그인, 회원가입, 게시글 작성 등)
+2. 추가 Hydration 에러 발생 시 수정
+3. 프로덕션 빌드 테스트 (`npm run build && npm run start`)
+
+---
+
+## 14. Next.js Image 컴포넌트
+
+### 기본 사용법
+
+`<img>` 태그 대신 `next/image`의 `<Image>` 컴포넌트를 사용하면 자동 이미지 최적화가 적용됩니다.
+
+```tsx
+import Image from 'next/image'
+
+// 기본 사용
+<Image src="/images/logo.png" alt="로고" width={100} height={100} />
+
+// fill 모드 (부모 크기에 맞춤)
+<div className="relative w-32 h-32">
+  <Image src={url} alt="이미지" fill className="object-cover" />
+</div>
+```
+
+### fill 속성 사용 시 주의사항
+
+`fill` 속성을 사용하면 이미지가 **가장 가까운 `position: relative` 부모**를 기준으로 채워집니다.
+
+```tsx
+// ✅ 올바른 사용 - 부모에 relative 필수
+<div className="relative w-32 h-32 overflow-hidden rounded-lg">
+  <Image src={url} alt="이미지" fill className="object-cover" />
+</div>
+
+// ❌ 잘못된 사용 - relative 누락
+<div className="w-32 h-32">
+  <Image src={url} alt="이미지" fill />  {/* 이미지가 페이지 전체를 덮을 수 있음 */}
+</div>
+```
+
+**실제 사례**: `md:static` 클래스 충돌
+```tsx
+// ❌ 문제 - md:static이 relative를 덮어써서 레이아웃 깨짐
+<div className="relative md:static w-32 h-32">
+  <Image src={url} fill />  {/* md 이상에서 이미지가 제대로 표시 안 됨 */}
+</div>
+
+// ✅ 해결 - md:static 제거
+<div className="relative w-32 h-32">
+  <Image src={url} fill />
+</div>
+```
+
+### 이미지 에러 처리 (Fallback 패턴)
+
+외부 이미지 로드 실패 시 대체 이미지를 보여주는 패턴:
+
+```tsx
+const [imgError, setImgError] = useState(false)
+const [usePlaceholder, setUsePlaceholder] = useState(false)
+
+// 2단계 fallback: 최적화 이미지 → 원본 → 플레이스홀더
+const handleImageError = () => {
+  if (!imgError && imageUrl) {
+    setImgError(true)  // 1차: 원본 URL 시도
+  } else {
+    setUsePlaceholder(true)  // 2차: 플레이스홀더 사용
+  }
+}
+
+const getImageSrc = () => {
+  if (usePlaceholder || !imageUrl) return PLACEHOLDER_IMAGE
+  if (imgError) return imageUrl  // 원본 URL
+  return toResizedWebpUrl(imageUrl, 400)  // 최적화 URL
+}
+
+<Image
+  src={getImageSrc()}
+  loader={imgError || usePlaceholder ? undefined : imageLoader}
+  onError={handleImageError}
+  unoptimized={imgError || usePlaceholder}  // 에러 시 최적화 비활성화
+  fill
+/>
+```
+
+### imageLoader 함수
+
+커스텀 이미지 로더로 srcSet에 적절한 크기의 이미지를 제공:
+
+```tsx
+// lib/utils/imageUrl.ts
+export function imageLoader({ src, width }: { src: string; width: number }): string {
+  const size: ImageSize = width <= 150 ? 150 : width <= 400 ? 400 : 800
+  return toResizedWebpUrl(src, size)
+}
+
+// 사용
+<Image
+  src={url}
+  loader={imageLoader}
+  sizes="(max-width: 768px) 100vw, 400px"
+  fill
+/>
+```
+
+### overflow-hidden과 절대 위치 요소
+
+이미지 위에 아이콘을 올릴 때, `overflow-hidden` 안에 두면 잘릴 수 있습니다:
+
+```tsx
+// ❌ 카메라 아이콘이 잘림
+<div className="relative overflow-hidden rounded-full">
+  <Image src={url} fill />
+  <div className="absolute right-0 bottom-2">
+    <Camera />  {/* overflow-hidden 때문에 잘림 */}
+  </div>
+</div>
+
+// ✅ 외부 wrapper 사용
+<div className="relative h-28 w-28">
+  <div className="overflow-hidden rounded-full h-full w-full relative">
+    <Image src={url} fill />
+  </div>
+  <div className="absolute right-0 bottom-2">
+    <Camera />  {/* overflow-hidden 바깥이라 안 잘림 */}
+  </div>
+</div>
+```
+
+---
+
+## 15. React Compiler와 React Hook Form 호환성
+
+### React Compiler란?
+
+React 19에 도입된 컴파일러로, 컴포넌트를 **자동으로 메모이제이션**합니다.
+`useMemo`, `useCallback`을 직접 작성할 필요가 줄어듭니다.
+
+### watch() 함수 경고
+
+React Hook Form의 `watch()` 함수는 React Compiler와 호환되지 않습니다:
+
+```
+Compilation Skipped: Use of incompatible library
+React Hook Form's `useForm()` API returns a `watch()` function which cannot be memoized safely.
+```
+
+**원인**: `watch()`는 매 렌더링마다 새로운 함수 참조를 반환하여 메모이제이션 불가
+
+**해결**: `useWatch` 훅 사용
+
+```tsx
+// ❌ React Compiler 경고 발생
+const { watch } = useForm()
+const nickname = watch('nickname')
+const introduction = watch('introduction')
+
+// ✅ useWatch로 변경
+import { useForm, useWatch } from 'react-hook-form'
+
+const { control } = useForm()
+const nickname = useWatch({ control, name: 'nickname' })
+const introduction = useWatch({ control, name: 'introduction' })
+```
+
+### useEffect 내 setState 경고
+
+React Compiler는 `useEffect` 안에서 동기적으로 `setState`를 호출하면 경고합니다:
+
+```
+Error: Calling setState synchronously within an effect can trigger cascading renders
+```
+
+**해결 방법**: 중복 상태를 제거하고 폼 값을 직접 구독
+
+```tsx
+// ❌ 중복 상태 + useEffect 내 setState
+const [previewUrl, setPreviewUrl] = useState('')
+
+useEffect(() => {
+  if (myData) {
+    setPreviewUrl(myData.profileImageUrl)  // 경고 발생
+    reset({ profileImageUrl: myData.profileImageUrl })
+  }
+}, [myData])
+
+// ✅ 폼 값을 직접 구독 (중복 제거)
+const profileImageUrl = useWatch({ control, name: 'profileImageUrl' })
+
+useEffect(() => {
+  if (myData) {
+    reset({ profileImageUrl: myData.profileImageUrl })  // 폼만 업데이트
+  }
+}, [myData])
+
+// profileImageUrl을 직접 사용
+<Image src={profileImageUrl} ... />
+```
+
+---
+
+## 16. 중복 상태 제거 패턴
+
+### 문제: 같은 값을 여러 곳에 저장
+
+```tsx
+// 폼 상태
+const { setValue, reset } = useForm()
+
+// 별도 상태 (중복!)
+const [previewUrl, setPreviewUrl] = useState('')
+
+// 이미지 업로드 시 두 곳에 저장
+setValue('profileImageUrl', uploadedUrl)  // 폼에 저장
+setPreviewUrl(uploadedUrl)                 // 별도 상태에도 저장
+
+// 데이터 로드 시 두 곳에 저장
+reset({ profileImageUrl: data.url })       // 폼에 저장
+setPreviewUrl(data.url)                    // 별도 상태에도 저장
+```
+
+### 해결: 폼 값 직접 구독
+
+```tsx
+// 폼 값을 구독 (상태 하나로 통일)
+const profileImageUrl = useWatch({ control, name: 'profileImageUrl' })
+
+// 이미지 업로드 시 폼만 업데이트
+setValue('profileImageUrl', uploadedUrl)
+
+// 데이터 로드 시 폼만 업데이트
+reset({ profileImageUrl: data.url })
+
+// 화면에서는 폼 값 직접 사용
+<Image src={profileImageUrl} ... />
+```
+
+**장점**:
+- 코드 간소화 (상태 관리 포인트 감소)
+- 동기화 버그 방지 (값이 불일치할 가능성 제거)
+- React Compiler 경고 해결
+
+---
+
+## 17. URL을 단일 진실 공급원으로 사용
+
+### 문제: URL 파라미터를 상태에 동기화
+
+URL 파라미터 값을 `useState`로 관리하고 `useEffect`로 동기화하면 React Compiler 경고가 발생합니다:
+
+```tsx
+// ❌ 문제: useEffect 내 setState 경고 발생
+const searchParams = useSearchParams()
+const tabParam = searchParams.get('tab')
+
+const [activeTab, setActiveTab] = useState(tabParam || 'tab-question')
+
+// URL 변경 시 상태 동기화
+useEffect(() => {
+  if (tabParam) {
+    setActiveTab(tabParam)  // 경고: setState in useEffect
+  }
+}, [tabParam])
+
+const handleTabChange = (tabId: string) => {
+  setActiveTab(tabId)  // 상태 업데이트
+  router.replace(`?tab=${tabId}`)  // URL도 업데이트
+}
+```
+
+**문제점**:
+- 같은 값(탭 ID)을 두 곳(URL + 상태)에서 관리
+- `useEffect`로 동기화 → React Compiler 경고
+- 동기화 누락 시 불일치 발생 가능
+
+### 해결: URL에서 직접 계산
+
+상태를 제거하고 URL 파라미터에서 직접 값을 계산합니다:
+
+```tsx
+// ✅ 해결: URL을 단일 진실 공급원으로 사용
+const searchParams = useSearchParams()
+const tabParam = searchParams.get('tab')
+
+// URL에서 직접 계산 (상태 불필요)
+const activeTab = tabParam === 'tab-info' ? 'tab-info' : 'tab-question'
+
+const handleTabChange = (tabId: string) => {
+  router.replace(`?tab=${tabId}`)  // URL만 업데이트
+  // 다음 렌더링에서 activeTab이 자동으로 새 값으로 계산됨
+}
+```
+
+### 동작 원리
+
+```
+[사용자 탭 클릭]
+    ↓
+router.replace(`?tab=tab-info`)  // URL 업데이트
+    ↓
+[컴포넌트 리렌더링]
+    ↓
+searchParams.get('tab')  // 'tab-info' 반환
+    ↓
+activeTab = 'tab-info'  // 새 값으로 계산됨
+```
+
+### 장점
+
+1. **코드 간소화**: `useState`, `useEffect` 제거
+2. **동기화 버그 방지**: 값이 한 곳(URL)에만 존재
+3. **React Compiler 호환**: `useEffect` 내 `setState` 없음
+4. **브라우저 뒤로/앞으로 지원**: URL 변경 시 자동 반영
+5. **공유 가능한 URL**: 현재 탭 상태가 URL에 포함됨
+
+### 언제 사용하나요?
+
+- 탭, 필터, 정렬 등 **URL에 저장해야 하는 UI 상태**
+- 브라우저 뒤로/앞으로 버튼으로 **복원되어야 하는 상태**
+- 다른 사람과 **공유 가능해야 하는 상태**
+
+---
+
+## 참고 링크
+
+- [Next.js App Router 공식 문서](https://nextjs.org/docs/app)
+- [Server Components](https://nextjs.org/docs/app/building-your-application/rendering/server-components)
+- [Client Components](https://nextjs.org/docs/app/building-your-application/rendering/client-components)
+- [Next.js Image 최적화](https://nextjs.org/docs/app/building-your-application/optimizing/images)
+- [React Hook Form useWatch](https://react-hook-form.com/docs/usewatch)

--- a/docs/session-context-2024-02-04.md
+++ b/docs/session-context-2024-02-04.md
@@ -1,0 +1,203 @@
+# 세션 컨텍스트 (2024-02-04)
+
+이 문서는 세션 만료에 대비하여 작업 내용을 기록합니다.
+
+---
+
+## 완료된 작업
+
+### 1. Next.js Image 컴포넌트 변환 (이전 세션에서 완료)
+
+모든 `<img>` 태그를 Next.js `<Image />` 컴포넌트로 변환 완료.
+
+**변환된 파일들:**
+- `src/components/commons/button/Button.tsx`
+- `src/components/profile/ProfileAvatar.tsx`
+- `src/components/profile/SellerAvatar.tsx`
+- `src/components/product/ProductThumbnail.tsx`
+- `src/components/product/ProductListItem.tsx`
+- `src/features/product-detail/components/MainImage.tsx`
+- `src/features/product-detail/components/SubImages.tsx`
+- `src/features/chatting-page/components/ChatProductCard.tsx`
+- `src/features/chatting-page/components/ChatLog.tsx`
+- `src/features/my-page/components/MyPagePanel.tsx`
+- `src/features/my-page/components/MyList.tsx`
+- `src/features/product-post/components/imageUploadField/components/SortableImageItem.tsx`
+- `src/features/profile-update/components/ProfileUpdateBaseForm.tsx`
+- `src/components/profile/ProfileData.tsx`
+- `src/components/modal/DeleteConfirmModal.tsx`
+- `src/features/product-detail/components/SellerProfileCard.tsx`
+
+**적용된 패턴:**
+- `imageLoader` 커스텀 로더 함수
+- 2단계 이미지 에러 fallback (최적화 URL → 원본 URL → 플레이스홀더)
+- `fill` 속성 + `relative` 부모 컨테이너
+
+---
+
+### 2. 프로필 수정 페이지 카메라 아이콘 잘림 문제 해결
+
+**파일:** `src/features/profile-update/components/ProfileUpdateBaseForm.tsx`
+
+**문제:** 카메라 아이콘이 `overflow-hidden` 컨테이너 안에 있어서 잘림
+
+**해결:** 구조 변경
+```tsx
+// 변경 전: 카메라 아이콘이 overflow-hidden 안에 있음
+<div className="relative overflow-hidden rounded-full">
+  <Image ... />
+  <div className="absolute ..."><Camera /></div>  // 잘림
+</div>
+
+// 변경 후: 외부 wrapper 사용
+<div className="relative h-28 w-28">
+  <div className="overflow-hidden rounded-full relative ...">
+    <Image ... />
+  </div>
+  <div className="absolute ..."><Camera /></div>  // 안 잘림
+</div>
+```
+
+---
+
+### 3. React Compiler 경고 해결
+
+#### 3-1. `watch()` → `useWatch()` 변경
+
+**파일:** `src/features/profile-update/components/ProfileUpdateBaseForm.tsx`
+
+**문제:** React Hook Form의 `watch()` 함수가 React Compiler와 호환되지 않음
+
+**해결:**
+```tsx
+// 변경 전
+const { watch } = useForm()
+const nickname = watch('nickname')
+const introduction = watch('introduction')
+
+// 변경 후
+import { useForm, useWatch } from 'react-hook-form'
+const { control } = useForm()
+const nickname = useWatch({ control, name: 'nickname' })
+const introduction = useWatch({ control, name: 'introduction' })
+const profileImageUrl = useWatch({ control, name: 'profileImageUrl' })
+```
+
+#### 3-2. 중복 상태 제거 (`previewUrl` 제거)
+
+**파일:** `src/features/profile-update/components/ProfileUpdateBaseForm.tsx`
+
+**문제:**
+- `previewUrl` 상태와 폼의 `profileImageUrl`이 중복
+- `useEffect` 내에서 `setPreviewUrl` 호출 → React Compiler 경고
+
+**해결:**
+- `previewUrl` 상태 제거
+- `profileImageUrl`을 `useWatch`로 직접 구독
+- 이미지 표시에 폼 값 직접 사용
+
+#### 3-3. URL을 단일 진실 공급원으로 사용
+
+**파일:** `src/features/community/CommunityPage.tsx`
+
+**문제:**
+```tsx
+// URL 파라미터를 상태에 동기화 → useEffect 내 setState 경고
+const [activeCommunityTypeTab, setActiveCommunityTypeTab] = useState(initialTab)
+
+useEffect(() => {
+  if (tabParam) {
+    setActiveCommunityTypeTab(tabParam)  // 경고!
+  }
+}, [tabParam])
+```
+
+**해결:**
+```tsx
+// 상태 제거, URL에서 직접 계산
+const activeCommunityTypeTab: CommunityTabId = tabParam === 'tab-info' ? 'tab-info' : 'tab-question'
+
+const handleTabChange = (tabId: string) => {
+  router.replace(`?tab=${tabId}`)  // URL만 업데이트
+}
+```
+
+---
+
+### 4. nextjs-learning-context.md 업데이트
+
+다음 섹션들 추가:
+
+- **섹션 14:** Next.js Image 컴포넌트
+  - 기본 사용법
+  - `fill` 속성 사용 시 주의사항
+  - `md:static` 충돌 문제
+  - 이미지 에러 처리 (Fallback 패턴)
+  - `imageLoader` 함수
+  - `overflow-hidden`과 절대 위치 요소
+
+- **섹션 15:** React Compiler와 React Hook Form 호환성
+  - `watch()` 함수 경고와 `useWatch` 해결책
+  - `useEffect` 내 `setState` 경고
+
+- **섹션 16:** 중복 상태 제거 패턴
+  - 폼 값 직접 구독으로 해결
+
+- **섹션 17:** URL을 단일 진실 공급원으로 사용
+  - URL 파라미터에서 직접 계산
+  - `useState`/`useEffect` 제거
+
+---
+
+## 현재 프로젝트 상태
+
+### 에러/경고 해결됨
+- ✅ 프로필 수정 페이지 카메라 아이콘 잘림
+- ✅ 프로필 이미지 원형 표시 (overflow-hidden + relative 구조)
+- ✅ React Compiler `watch()` 경고
+- ✅ React Compiler `useEffect` 내 `setState` 경고
+- ✅ CommunityPage URL 동기화 경고
+
+### 수정된 주요 파일
+1. `src/features/profile-update/components/ProfileUpdateBaseForm.tsx`
+   - `useWatch` 사용
+   - `previewUrl` 상태 제거
+   - 카메라 아이콘 구조 변경
+
+2. `src/features/community/CommunityPage.tsx`
+   - `activeCommunityTypeTab` 상태 제거
+   - URL에서 직접 계산
+
+3. `docs/nextjs-learning-context.md`
+   - 섹션 14-17 추가
+
+---
+
+## 다음 세션에서 할 작업
+
+1. 브라우저에서 수정된 페이지들 테스트
+   - 프로필 수정 페이지 (이미지 업로드, 카메라 아이콘)
+   - 커뮤니티 페이지 (탭 전환)
+
+2. 추가 React Compiler 경고 확인 및 수정
+
+3. 프로덕션 빌드 테스트 (`npm run build && npm run start`)
+
+---
+
+## 주요 학습 내용 요약
+
+### 1. Next.js Image + fill 속성
+- 부모에 `position: relative` 필수
+- `md:static` 클래스와 충돌 주의
+- `overflow-hidden` 안의 절대 위치 요소 잘림 주의
+
+### 2. React Compiler 호환성
+- `watch()` → `useWatch()` 사용
+- `useEffect` 내 동기적 `setState` 피하기
+- 중복 상태 제거 (단일 진실 공급원)
+
+### 3. URL as Single Source of Truth
+- URL 파라미터를 상태로 복사하지 말고 직접 계산
+- 브라우저 뒤로/앞으로 자동 지원
+- 공유 가능한 URL


### PR DESCRIPTION
## Summary
기존 `docs/62--documentation` 브랜치의 문서를 현재 develop 기준으로 재정리

## Changed Files
- `docs/migration-guide.md` - Vite → Next.js 마이그레이션 단계별 가이드
- `docs/code-convention.md` - 코드 컨벤션 (경로, export, 함수, 타입)
- `docs/conventions.md` - 브랜치/커밋/PR/네이밍/Git 워크플로우 컨벤션
- `docs/nextjs-learning-context.md` - Next.js 학습 컨텍스트 (React 개발자용, auth 라우트 그룹 반영)
- `docs/session-context-2024-02-04.md` - 세션 컨텍스트
- `README.md` - 프로젝트 소개, 기술 스택, 문서 링크 업데이트

## Test plan
- [ ] 각 마크다운 파일 렌더링 확인
- [ ] README.md 문서 링크 정상 작동 확인

Closes #62