### PR TITLE
refactor: force-dynamic 제거 및 LCP preload 전략으로 변경(#260)

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,11 +1,27 @@
+import { Suspense } from 'react'
 import Home from '@/features/home/Home'
+import HomeSkeleton from '@/features/home/components/product-section/HomeSkeleton'
 import { fetchInitialProducts } from '@/lib/api/server/products'
-
-export const dynamic = 'force-dynamic'
+import { getImageSrcSet, IMAGE_SIZES } from '@/lib/utils/imageUrl'
 
 export default async function HomePage() {
   const initialData = await fetchInitialProducts()
+  const firstImageUrl = initialData?.data?.data?.content?.[0]?.mainImageUrl
+
   return (
-    <Home initialData={initialData} />
+    <>
+      {firstImageUrl && (
+        <link
+          rel="preload"
+          as="image"
+          imageSrcSet={getImageSrcSet(firstImageUrl)}
+          imageSizes={IMAGE_SIZES.productThumbnail}
+          fetchPriority="high"
+        />
+      )}
+      <Suspense fallback={<HomeSkeleton />}>
+        <Home initialData={initialData} />
+      </Suspense>
+    </>
   )
 }

--- a/src/features/home/Home.tsx
+++ b/src/features/home/Home.tsx
@@ -136,9 +136,11 @@ function Home({ initialData }: HomeProps) {
   })
 
   // 모든 페이지의 상품을 하나의 배열로 합치기
-  const allProducts = useMemo(() => {
-    return data?.pages?.flatMap((page) => page.data.data.content) ?? []
-  }, [data?.pages])
+  // SSR 시 useInfiniteQuery가 initialData를 즉시 반영하지 못하므로,
+  // query 데이터가 없을 때 initialData props에서 직접 가져옴
+  const allProducts = data?.pages?.length
+    ? data.pages.flatMap((page) => page.data.data.content)
+    : initialData?.data?.data?.content ?? []
 
   // 무한 스크롤 감지
   const targetRef = useIntersectionObserver({
@@ -208,7 +210,7 @@ function Home({ initialData }: HomeProps) {
                 onTabChange={(tabId) => setActiveProductTypeTab(tabId as ProductTypeTabId)}
                 ariaLabel="상품 타입 분류"
               />
-              {isLoading ? (
+              {isLoading && allProducts.length === 0 ? (
                 <HomeSkeleton />
               ) : (
                 <ProductsSection


### PR DESCRIPTION
## 📌 개요

- PR #262에서 적용한 `force-dynamic`이 DebugBear 점수 하락(94→83)을 유발하여, 대안 전략으로 변경합니다.
- `force-dynamic` 제거 → Suspense + ISR 캐싱 복원 + `<link rel="preload">` 이미지 프리로드

## 🔧 작업 내용

- [x] `page.tsx`: `export const dynamic = 'force-dynamic'` 제거
- [x] `page.tsx`: `<Suspense>` 복원하여 빌드 에러 방지 및 HTML 캐싱 유지
- [x] `page.tsx`: `<link rel="preload" as="image">` 추가로 첫 번째 상품 이미지를 초기 HTML에 포함
- [x] `Home.tsx`: `allProducts`에서 `initialData` fallback 추가 (skeleton 깜빡임 방지)
- [x] `Home.tsx`: skeleton 표시 조건을 `isLoading && allProducts.length === 0`으로 변경

## 📎 관련 이슈

- Close #260

## 💬 리뷰어 참고 사항

### force-dynamic 제거 이유
`force-dynamic`은 HTML 캐싱을 비활성화하여 TTFB가 증가하고, Suspense 없이 `useSearchParams()`를 사용하면서 이미지도 여전히 초기 HTML에 포함되지 않아 모든 지표가 악화됨.

### 새로운 접근법
| | force-dynamic (이전) | preload 전략 (현재) |
|---|---|---|
| HTML 캐싱 | ❌ 없음 | ✅ ISR (60초) |
| Suspense | ❌ 없음 | ✅ 있음 |
| 이미지 발견 시점 | JS 실행 후 | HTML 즉시 (`<link rel="preload">`) |
| 빌드 | ○ Static → ƒ Dynamic | ○ Static (ISR) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)