### PR TITLE
chore: SEO 설정 도메인 URL 업데이트(#270)

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -19,4 +19,4 @@ Disallow: /chat
 Disallow: /oauth-redirect
 
 # 사이트맵 위치
-Sitemap: https://cuddle-market-fe.vercel.app/sitemap.xml
+Sitemap: https://cuddle-market.vercel.app/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://cuddle-market-fe.vercel.app/</loc>
+    <loc>https://cuddle-market.vercel.app/</loc>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://cuddle-market-fe.vercel.app/community</loc>
+    <loc>https://cuddle-market.vercel.app/community</loc>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>


### PR DESCRIPTION
## 📌 개요

프로젝트 도메인이 `cuddle-market-fe.vercel.app`에서 `cuddle-market.vercel.app`로 변경됨에 따라 SEO 관련 설정 파일의 URL을 업데이트합니다.

## 🔧 작업 내용

- [x] robots.txt의 Sitemap URL 업데이트
- [x] sitemap.xml의 모든 페이지 URL 업데이트

## 📎 관련 이슈

Closes #270

## 💬 리뷰어 참고 사항

- 도메인 URL이 올바르게 변경되었는지 확인 부탁드립니다