### PR TITLE
refactor: BlockModal 네이티브 dialog 전환(#274)

### DIFF
--- a/src/components/modal/BlockModal.tsx
+++ b/src/components/modal/BlockModal.tsx
@@ -21,10 +21,8 @@ export default function BlockModal({ isOpen, onCancel, userNickname, userId }: B
   const [userBlockError, setUserBlockError] = useState<React.ReactNode | null>(null)
 
   const handleCancel = () => {
-    onCancel()
+    dialogRef.current?.close()
   }
-
-  // useOutsideClick(isOpen, [modalRef], onCancel)
 
   const onUserBlock = async () => {
     try {
@@ -42,9 +40,9 @@ export default function BlockModal({ isOpen, onCancel, userNickname, userId }: B
   }
   useEffect(() => {
     const dialog = dialogRef.current
-    if (isOpen) {
+    if (isOpen && !dialog?.open) {
       dialog?.showModal()
-    } else {
+    } else if (!isOpen && dialog?.open) {
       dialog?.close()
     }
   }, [isOpen])
@@ -54,7 +52,7 @@ export default function BlockModal({ isOpen, onCancel, userNickname, userId }: B
       ref={dialogRef}
       className="w-11/12 open:flex flex-col gap-4 rounded-lg bg-white p-5 backdrop:bg-gray-900/70 md:w-[16vw] md:min-w-max"
       onClick={(e) => {
-        if (e.target === dialogRef.current) onCancel()
+        if (e.target === dialogRef.current) dialogRef.current.close()
       }}
       onClose={onCancel}
     >


### PR DESCRIPTION
## 📌 개요

- BlockModal 컴포넌트를 div 기반에서 네이티브 dialog 요소로 전환하여 웹 접근성을 개선합니다.

## 🔧 작업 내용

- [x] div+fixed overlay → 네이티브 dialog 요소 전환
- [x] showModal()/close() API 적용
- [x] useOutsideClick 제거 (네이티브 backdrop click 처리)
- [x] ::backdrop 스타일링 적용 (backdrop:bg-gray-900/70)

## 📎 관련 이슈

Closes #274

## 💬 리뷰어 참고 사항

- dialog 요소는 showModal()로 열면 네이티브 포커스 트래핑, ESC 키 닫기, 뷰포트 정중앙 배치를 브라우저가 자동 처리합니다.
- 나머지 모달 컴포넌트(DeleteConfirmModal, WithdrawModal 등)의 dialog 전환은 BlockModal 동작 확인 후 후속 작업으로 진행 예정입니다.