### PR TITLE
fix: dialog 모달 뷰포트 중앙 배치 수정(#278)

### DIFF
--- a/src/components/modal/BlockModal.tsx
+++ b/src/components/modal/BlockModal.tsx
@@ -50,7 +50,7 @@ export default function BlockModal({ isOpen, onCancel, userNickname, userId }: B
   return (
     <dialog
       ref={dialogRef}
-      className="w-11/12 open:flex flex-col gap-4 rounded-lg bg-white p-5 backdrop:bg-gray-900/70 md:w-[16vw] md:min-w-max"
+      className="m-auto w-11/12 open:flex flex-col gap-4 rounded-lg bg-white p-5 backdrop:bg-gray-900/70 md:w-[16vw] md:min-w-max"
       onClick={(e) => {
         if (e.target === dialogRef.current) dialogRef.current.close()
       }}


### PR DESCRIPTION
## 📌 개요

- BlockModal dialog가 뷰포트 좌상단에 표시되는 버그를 수정합니다.

## 🔧 작업 내용

- [x] dialog 요소에 `m-auto` 추가 (Tailwind preflight의 margin 리셋 대응)

## 📎 관련 이슈

Closes #278

## 💬 리뷰어 참고 사항

- `showModal()`의 중앙 배치는 브라우저 UA 스타일시트의 `margin: auto`에 의존하지만, Tailwind preflight가 `margin: 0`으로 리셋하여 깨지는 문제였습니다.