### PR TITLE
refactor: 나머지 모달 컴포넌트 네이티브 dialog 전환(#280)

### DIFF
--- a/src/components/modal/DeleteConfirmModal.tsx
+++ b/src/components/modal/DeleteConfirmModal.tsx
@@ -4,10 +4,7 @@ import Button from '../commons/button/Button'
 import AlertBox from './AlertBox'
 import { PRODUCT_DELETE_ALERT_LIST } from '@/constants/constants'
 import ModalTitle from './ModalTitle'
-import { useRef } from 'react'
-import { useOutsideClick } from '@/hooks/useOutsideClick'
-import { Z_INDEX } from '@/constants/ui'
-import { cn } from '@/lib/utils/cn'
+import { useEffect, useRef } from 'react'
 import { AnimatePresence } from 'framer-motion'
 import InlineNotification from '../commons/InlineNotification'
 
@@ -21,63 +18,78 @@ interface DeleteConfirmModalProps {
 }
 
 export default function DeleteConfirmModal({ isOpen, product, onConfirm, onCancel, error, onClearError }: DeleteConfirmModalProps) {
-  const modalRef = useRef<HTMLDivElement>(null)
-  useOutsideClick(isOpen, [modalRef], onCancel)
+  const dialogRef = useRef<HTMLDialogElement>(null)
 
-  if (!isOpen || !product) return null
+  useEffect(() => {
+    const dialog = dialogRef.current
+    if (isOpen && product && !dialog?.open) {
+      dialog?.showModal()
+    } else if (!isOpen && dialog?.open) {
+      dialog?.close()
+    }
+  }, [isOpen, product])
 
   return (
-    <div className={cn('fixed inset-0 flex items-center justify-center bg-gray-900/70', Z_INDEX.MODAL)}>
-      <div className="flex w-11/12 flex-col gap-4 rounded-lg bg-white p-5 md:w-[16vw] md:min-w-96" ref={modalRef}>
-        <ModalTitle heading="상품 삭제" description="정말로 이 상품을 삭제하시겠습니까?" />
-        <AnimatePresence>
-          {error && (
-            <InlineNotification type="error" onClose={() => onClearError?.()}>
-              {error}
-            </InlineNotification>
-          )}
-        </AnimatePresence>
-        <AlertBox alertList={PRODUCT_DELETE_ALERT_LIST} />
-        <ul>
-          <li className="flex gap-2.5 rounded-lg border border-gray-300 bg-gray-100/30 p-2.5">
-            <div className="aspect-square w-16 shrink-0 overflow-hidden rounded-lg">
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                src={product.mainImageUrl ? toResizedWebpUrl(product.mainImageUrl, 150) : PLACEHOLDER_IMAGES[150]}
-                srcSet={product.mainImageUrl ? getImageSrcSet(product.mainImageUrl) : PLACEHOLDER_SRCSET}
-                sizes={IMAGE_SIZES.tinyThumbnail}
-                alt={product.title}
-                onError={(e) => {
-                  const img = e.currentTarget
-                  if (product.mainImageUrl && img.src !== product.mainImageUrl) {
-                    img.srcset = ''
-                    img.src = product.mainImageUrl
-                  } else {
-                    img.srcset = PLACEHOLDER_SRCSET
-                    img.src = PLACEHOLDER_IMAGES[150]
-                  }
-                }}
-                className="h-full w-full object-cover"
-              />
-            </div>
-            <div className="flex flex-col gap-1">
-              <p className="line-clamp-2 w-full font-medium md:line-clamp-none md:w-72 md:truncate">{product.title}</p>
-              <p className="font-medium">
-                <span>{formatPrice(Number(product.price))}</span>원
-              </p>
-            </div>
-          </li>
-        </ul>
+    <dialog
+      ref={dialogRef}
+      className="m-auto w-11/12 open:flex flex-col gap-4 rounded-lg bg-white p-5 backdrop:bg-gray-900/70 md:w-[16vw] md:min-w-96"
+      onClick={(e) => {
+        if (e.target === dialogRef.current) dialogRef.current.close()
+      }}
+      onClose={onCancel}
+    >
+      {product && (
+        <>
+          <ModalTitle heading="상품 삭제" description="정말로 이 상품을 삭제하시겠습니까?" />
+          <AnimatePresence>
+            {error && (
+              <InlineNotification type="error" onClose={() => onClearError?.()}>
+                {error}
+              </InlineNotification>
+            )}
+          </AnimatePresence>
+          <AlertBox alertList={PRODUCT_DELETE_ALERT_LIST} />
+          <ul>
+            <li className="flex gap-2.5 rounded-lg border border-gray-300 bg-gray-100/30 p-2.5">
+              <div className="aspect-square w-16 shrink-0 overflow-hidden rounded-lg">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={product.mainImageUrl ? toResizedWebpUrl(product.mainImageUrl, 150) : PLACEHOLDER_IMAGES[150]}
+                  srcSet={product.mainImageUrl ? getImageSrcSet(product.mainImageUrl) : PLACEHOLDER_SRCSET}
+                  sizes={IMAGE_SIZES.tinyThumbnail}
+                  alt={product.title}
+                  onError={(e) => {
+                    const img = e.currentTarget
+                    if (product.mainImageUrl && img.src !== product.mainImageUrl) {
+                      img.srcset = ''
+                      img.src = product.mainImageUrl
+                    } else {
+                      img.srcset = PLACEHOLDER_SRCSET
+                      img.src = PLACEHOLDER_IMAGES[150]
+                    }
+                  }}
+                  className="h-full w-full object-cover"
+                />
+              </div>
+              <div className="flex flex-col gap-1">
+                <p className="line-clamp-2 w-full font-medium md:line-clamp-none md:w-72 md:truncate">{product.title}</p>
+                <p className="font-medium">
+                  <span>{formatPrice(Number(product.price))}</span>원
+                </p>
+              </div>
+            </li>
+          </ul>
 
-        <div className="flex justify-end gap-3">
-          <Button onClick={onCancel} size="sm" className="cursor-pointer rounded-lg border border-gray-300 bg-white">
-            취소
-          </Button>
-          <Button onClick={() => onConfirm(product.id)} size="sm" className="bg-danger-600 cursor-pointer rounded-lg text-white">
-            삭제하기
-          </Button>
-        </div>
-      </div>
-    </div>
+          <div className="flex justify-end gap-3">
+            <Button onClick={() => dialogRef.current?.close()} size="sm" className="cursor-pointer rounded-lg border border-gray-300 bg-white">
+              취소
+            </Button>
+            <Button onClick={() => onConfirm(product.id)} size="sm" className="bg-danger-600 cursor-pointer rounded-lg text-white">
+              삭제하기
+            </Button>
+          </div>
+        </>
+      )}
+    </dialog>
   )
 }

--- a/src/components/modal/DeleteReplyModal.tsx
+++ b/src/components/modal/DeleteReplyModal.tsx
@@ -1,8 +1,6 @@
 import Button from '../commons/button/Button'
 import ModalTitle from './ModalTitle'
-import { useRef, useState } from 'react'
-import { useOutsideClick } from '@/hooks/useOutsideClick'
-import { Z_INDEX } from '@/constants/ui'
+import { useEffect, useRef, useState } from 'react'
 import { AnimatePresence } from 'framer-motion'
 import InlineNotification from '../commons/InlineNotification'
 
@@ -14,14 +12,22 @@ interface DeleteReplyModalProps {
 }
 
 export default function DeleteReplyModal({ isOpen, onCancel, replyId, onConfirm }: DeleteReplyModalProps) {
-  const modalRef = useRef<HTMLDivElement>(null)
+  const dialogRef = useRef<HTMLDialogElement>(null)
   const [replyDeleteError, setReplyDeleteError] = useState<React.ReactNode | null>(null)
-  useOutsideClick(isOpen, [modalRef], onCancel)
+
+  useEffect(() => {
+    const dialog = dialogRef.current
+    if (isOpen && replyId && !dialog?.open) {
+      dialog?.showModal()
+    } else if (!isOpen && dialog?.open) {
+      dialog?.close()
+    }
+  }, [isOpen, replyId])
 
   const handleConfirm = async () => {
     try {
       await onConfirm(replyId)
-      onCancel()
+      dialogRef.current?.close()
     } catch {
       setReplyDeleteError(
         <div className="flex flex-col gap-0.5">
@@ -32,33 +38,36 @@ export default function DeleteReplyModal({ isOpen, onCancel, replyId, onConfirm 
     }
   }
 
-  if (!isOpen || !replyId) return null
-
   return (
-    <div className={`fixed inset-0 flex items-center justify-center bg-gray-900/70 ${Z_INDEX.MODAL}`}>
-      <div ref={modalRef} className="flex w-11/12 flex-col gap-4 rounded-lg bg-white p-5 md:w-[16vw] md:min-w-max">
-        <ModalTitle heading="댓글 삭제하기" description="정말로 이 댓글을 삭제하시겠습니까?" />
-        <AnimatePresence>
-          {replyDeleteError && (
-            <InlineNotification type="error" onClose={() => setReplyDeleteError(null)}>
-              {replyDeleteError}
-            </InlineNotification>
-          )}
-        </AnimatePresence>
-        <div className="flex justify-end gap-3">
-          <Button type="button" onClick={onCancel} size="sm" className="cursor-pointer rounded-lg border border-gray-300 bg-white">
-            취소
-          </Button>
-          <Button
-            type="button"
-            size="sm"
-            onClick={handleConfirm}
-            className="bg-danger-600 cursor-pointer rounded-lg text-white disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            삭제하기
-          </Button>
-        </div>
+    <dialog
+      ref={dialogRef}
+      className="m-auto w-11/12 open:flex flex-col gap-4 rounded-lg bg-white p-5 backdrop:bg-gray-900/70 md:w-[16vw] md:min-w-max"
+      onClick={(e) => {
+        if (e.target === dialogRef.current) dialogRef.current.close()
+      }}
+      onClose={onCancel}
+    >
+      <ModalTitle heading="댓글 삭제하기" description="정말로 이 댓글을 삭제하시겠습니까?" />
+      <AnimatePresence>
+        {replyDeleteError && (
+          <InlineNotification type="error" onClose={() => setReplyDeleteError(null)}>
+            {replyDeleteError}
+          </InlineNotification>
+        )}
+      </AnimatePresence>
+      <div className="flex justify-end gap-3">
+        <Button type="button" onClick={() => dialogRef.current?.close()} size="sm" className="cursor-pointer rounded-lg border border-gray-300 bg-white">
+          취소
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          onClick={handleConfirm}
+          className="bg-danger-600 cursor-pointer rounded-lg text-white disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          삭제하기
+        </Button>
       </div>
-    </div>
+    </dialog>
   )
 }

--- a/src/components/modal/LoginModal.tsx
+++ b/src/components/modal/LoginModal.tsx
@@ -6,18 +6,23 @@ import Button from '@/components/commons/button/Button'
 import { ROUTES } from '@/constants/routes'
 import { useLoginModalStore } from '@/store/modalStore'
 import { useUserStore } from '@/store/userStore'
-import { useRef } from 'react'
-import { useOutsideClick } from '@/hooks/useOutsideClick'
-import { Z_INDEX } from '@/constants/ui'
+import { useEffect, useRef } from 'react'
 
 export default function LoginModal() {
   const { isOpen, modalType, onConfirm, closeModal } = useLoginModalStore()
   const setRedirectUrl = useUserStore((state) => state.setRedirectUrl)
   const pathname = usePathname()
   const searchParams = useSearchParams()
-  const modalRef = useRef<HTMLDivElement>(null)
-  useOutsideClick(isOpen, [modalRef], closeModal)
-  if (!isOpen) return null
+  const dialogRef = useRef<HTMLDialogElement>(null)
+
+  useEffect(() => {
+    const dialog = dialogRef.current
+    if (isOpen && !dialog?.open) {
+      dialog?.showModal()
+    } else if (!isOpen && dialog?.open) {
+      dialog?.close()
+    }
+  }, [isOpen])
 
   // 모달 타입에 따른 텍스트 설정
   const isLogin = modalType === 'login'
@@ -30,39 +35,44 @@ export default function LoginModal() {
     if (onConfirm) {
       onConfirm()
     }
-    closeModal()
+    dialogRef.current?.close()
   }
 
   return (
-    <div className={`fixed inset-0 flex items-center justify-center bg-gray-900/70 ${Z_INDEX.MODAL}`}>
-      <div ref={modalRef} className="flex w-11/12 flex-col items-center gap-6 rounded-lg bg-white p-5 md:w-[16vw] md:min-w-80">
-        <div className="flex w-full flex-col items-center gap-2">
-          <h2 className="heading-h4">{heading}</h2>
-          <p>{description}</p>
-        </div>
-        <div className="flex w-full gap-3">
-          <Button size="md" className="flex-1 cursor-pointer border border-gray-300" onClick={closeModal} type="button">
-            취소
-          </Button>
-          {isLogin ? (
-            <Link
-              href={ROUTES.LOGIN}
-              className="bg-primary-300 flex flex-1 items-center justify-center rounded-lg px-4 py-2.5 text-white"
-              onClick={() => {
-                const search = searchParams.toString()
-                setRedirectUrl(search ? `${pathname}?${search}` : pathname)
-                closeModal()
-              }}
-            >
-              {confirmText}
-            </Link>
-          ) : (
-            <Button size="md" className="bg-primary-300 flex-1 cursor-pointer text-white" onClick={handleConfirm}>
-              {confirmText}
-            </Button>
-          )}
-        </div>
+    <dialog
+      ref={dialogRef}
+      className="m-auto w-11/12 open:flex flex-col items-center gap-6 rounded-lg bg-white p-5 backdrop:bg-gray-900/70 md:w-[16vw] md:min-w-80"
+      onClick={(e) => {
+        if (e.target === dialogRef.current) dialogRef.current.close()
+      }}
+      onClose={closeModal}
+    >
+      <div className="flex w-full flex-col items-center gap-2">
+        <h2 className="heading-h4">{heading}</h2>
+        <p>{description}</p>
       </div>
-    </div>
+      <div className="flex w-full gap-3">
+        <Button size="md" className="flex-1 cursor-pointer border border-gray-300" onClick={() => dialogRef.current?.close()} type="button">
+          취소
+        </Button>
+        {isLogin ? (
+          <Link
+            href={ROUTES.LOGIN}
+            className="bg-primary-300 flex flex-1 items-center justify-center rounded-lg px-4 py-2.5 text-white"
+            onClick={() => {
+              const search = searchParams.toString()
+              setRedirectUrl(search ? `${pathname}?${search}` : pathname)
+              dialogRef.current?.close()
+            }}
+          >
+            {confirmText}
+          </Link>
+        ) : (
+          <Button size="md" className="bg-primary-300 flex-1 cursor-pointer text-white" onClick={handleConfirm}>
+            {confirmText}
+          </Button>
+        )}
+      </div>
+    </dialog>
   )
 }

--- a/src/components/modal/ReportModalBase.tsx
+++ b/src/components/modal/ReportModalBase.tsx
@@ -5,9 +5,7 @@ import { useForm, useWatch } from 'react-hook-form'
 import { ReportApiErrors } from '@/constants/validationRules'
 // TODO: ImageUploadField 마이그레이션 후 활성화 (#42-#43)
 // import ImageUploadField from '@/components/product/imageUploadField/ImageUploadField'
-import { useRef, type ReactNode } from 'react'
-import { useOutsideClick } from '@/hooks/useOutsideClick'
-import { Z_INDEX } from '@/constants/ui'
+import { useEffect, useRef, type ReactNode } from 'react'
 import { AnimatePresence } from 'framer-motion'
 import InlineNotification from '../commons/InlineNotification'
 
@@ -48,106 +46,114 @@ export default function ReportModalBase({ isOpen, heading, description, reasons,
       imageFiles: [],
     },
   })
-  const modalRef = useRef<HTMLDivElement>(null)
-  useOutsideClick(isOpen, [modalRef], onCancel)
+  const dialogRef = useRef<HTMLDialogElement>(null)
+
+  useEffect(() => {
+    const dialog = dialogRef.current
+    if (isOpen && !dialog?.open) {
+      dialog?.showModal()
+    } else if (!isOpen && dialog?.open) {
+      dialog?.close()
+    }
+  }, [isOpen])
 
   const detailReason = useWatch({ control, name: 'detailReason' })
   const titleLength = detailReason?.length ?? 0
 
-  const handleCancel = () => {
-    reset()
-    onCancel()
-  }
-
   const handleFormSubmit = async (data: ReportFormValues) => {
     await onSubmit(data)
-    reset()
   }
 
-  if (!isOpen) return null
-
   return (
-    <div className={`fixed inset-0 flex items-center justify-center bg-gray-900/70 p-4 ${Z_INDEX.MODAL}`}>
-      <div ref={modalRef} className="flex max-h-[90vh] w-11/12 flex-col gap-4 overflow-y-auto rounded-lg bg-white p-5 md:w-1/5 md:min-w-96">
-        <ModalTitle heading={heading} description={description} />
-        <AnimatePresence>
-          {error && (
-            <InlineNotification type="error" onClose={() => onClearError?.()}>
-              {error}
-            </InlineNotification>
-          )}
-        </AnimatePresence>
-        <form onSubmit={handleSubmit(handleFormSubmit)} className="flex flex-col gap-4">
-          <div className="flex flex-col gap-6 pt-2">
-            <div className="flex flex-col gap-1">
-              <RequiredLabel htmlFor="reportReason" labelClass="font-semibold">
-                신고 사유
-              </RequiredLabel>
-              <div className="flex flex-col gap-1 rounded-lg border border-gray-300 px-3 py-2.5">
-                {reasons.map((reason) => (
-                  <div key={reason.id} className="flex items-center gap-3">
-                    <input
-                      type="radio"
-                      id={`reportReason-${reason.id}`}
-                      value={reason.id}
-                      className="h-3 w-3 border-gray-500"
-                      {...register('reasonCode', { required: true })}
-                    />
-                    <label htmlFor={`reportReason-${reason.id}`}>{reason.label}</label>
-                  </div>
-                ))}
-              </div>
+    <dialog
+      ref={dialogRef}
+      className="m-auto w-11/12 max-h-[90vh] open:flex flex-col gap-4 overflow-y-auto rounded-lg bg-white p-5 backdrop:bg-gray-900/70 md:w-1/5 md:min-w-96"
+      onClick={(e) => {
+        if (e.target === dialogRef.current) dialogRef.current.close()
+      }}
+      onClose={() => {
+        reset()
+        onCancel()
+      }}
+    >
+      <ModalTitle heading={heading} description={description} />
+      <AnimatePresence>
+        {error && (
+          <InlineNotification type="error" onClose={() => onClearError?.()}>
+            {error}
+          </InlineNotification>
+        )}
+      </AnimatePresence>
+      <form onSubmit={handleSubmit(handleFormSubmit)} className="flex flex-col gap-4">
+        <div className="flex flex-col gap-6 pt-2">
+          <div className="flex flex-col gap-1">
+            <RequiredLabel htmlFor="reportReason" labelClass="font-semibold">
+              신고 사유
+            </RequiredLabel>
+            <div className="flex flex-col gap-1 rounded-lg border border-gray-300 px-3 py-2.5">
+              {reasons.map((reason) => (
+                <div key={reason.id} className="flex items-center gap-3">
+                  <input
+                    type="radio"
+                    id={`reportReason-${reason.id}`}
+                    value={reason.id}
+                    className="h-3 w-3 border-gray-500"
+                    {...register('reasonCode', { required: true })}
+                  />
+                  <label htmlFor={`reportReason-${reason.id}`}>{reason.label}</label>
+                </div>
+              ))}
             </div>
-            <div className="flex flex-col gap-1">
-              <RequiredLabel htmlFor="reportReasonDetail" labelClass="font-semibold" required={false}>
-                신고 상세 사유 (선택항목)
-              </RequiredLabel>
-              <div className="flex flex-col gap-0.5">
-                <textarea
-                  placeholder="신고 상세 사유를 입력해주세요."
-                  className="bg-primary-50 focus:border-primary-500 min-h-32 w-full resize-none rounded-lg px-3 py-3 text-sm placeholder:text-gray-400 focus:outline-none md:min-h-20"
-                  id="reportReasonDetail"
-                  {...register('detailReason', {
-                    maxLength: ReportApiErrors.detailReason.maxLength,
-                  })}
-                />
-                <p className="text-sm font-semibold text-gray-400">{titleLength}/300자</p>
-                {errors.detailReason && <p className="text-danger-500 text-xs font-semibold"> {errors.detailReason.message}</p>}
-              </div>
-            </div>
-
-            {/* TODO: ImageUploadField 마이그레이션 후 활성화 (#42-#43) */}
-            {/* <div className="flex w-full flex-col gap-3">
-              <ImageUploadField
-                setValue={setValue}
-                errors={errors}
-                setError={setError}
-                clearErrors={clearErrors}
-                mainImageField="imageFiles"
-                heading="신고 이미지 첨부 (선택항목/최대 3장)"
-                showSection={false}
-                maxFiles={3}
-                className="gap-1"
-                headingClassName="text-gray-900 font-semibold"
+          </div>
+          <div className="flex flex-col gap-1">
+            <RequiredLabel htmlFor="reportReasonDetail" labelClass="font-semibold" required={false}>
+              신고 상세 사유 (선택항목)
+            </RequiredLabel>
+            <div className="flex flex-col gap-0.5">
+              <textarea
+                placeholder="신고 상세 사유를 입력해주세요."
+                className="bg-primary-50 focus:border-primary-500 min-h-32 w-full resize-none rounded-lg px-3 py-3 text-sm placeholder:text-gray-400 focus:outline-none md:min-h-20"
+                id="reportReasonDetail"
+                {...register('detailReason', {
+                  maxLength: ReportApiErrors.detailReason.maxLength,
+                })}
               />
-            </div> */}
+              <p className="text-sm font-semibold text-gray-400">{titleLength}/300자</p>
+              {errors.detailReason && <p className="text-danger-500 text-xs font-semibold"> {errors.detailReason.message}</p>}
+            </div>
           </div>
 
-          <div className="flex justify-end gap-3">
-            <Button type="button" onClick={handleCancel} size="sm" className="cursor-pointer rounded-lg border border-gray-300 bg-white">
-              취소
-            </Button>
-            <Button
-              type="submit"
-              disabled={!isValid}
-              size="sm"
-              className="bg-danger-600 cursor-pointer rounded-lg text-white disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              신고하기
-            </Button>
-          </div>
-        </form>
-      </div>
-    </div>
+          {/* TODO: ImageUploadField 마이그레이션 후 활성화 (#42-#43) */}
+          {/* <div className="flex w-full flex-col gap-3">
+            <ImageUploadField
+              setValue={setValue}
+              errors={errors}
+              setError={setError}
+              clearErrors={clearErrors}
+              mainImageField="imageFiles"
+              heading="신고 이미지 첨부 (선택항목/최대 3장)"
+              showSection={false}
+              maxFiles={3}
+              className="gap-1"
+              headingClassName="text-gray-900 font-semibold"
+            />
+          </div> */}
+        </div>
+
+        <div className="flex justify-end gap-3">
+          <Button type="button" onClick={() => dialogRef.current?.close()} size="sm" className="cursor-pointer rounded-lg border border-gray-300 bg-white">
+            취소
+          </Button>
+          <Button
+            type="submit"
+            disabled={!isValid}
+            size="sm"
+            className="bg-danger-600 cursor-pointer rounded-lg text-white disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            신고하기
+          </Button>
+        </div>
+      </form>
+    </dialog>
   )
 }

--- a/src/components/modal/WithdrawModal.tsx
+++ b/src/components/modal/WithdrawModal.tsx
@@ -6,10 +6,7 @@ import RequiredLabel from '../commons/RequiredLabel'
 import { WithDrawApiErrors } from '@/constants/validationRules'
 import AlertBox from './AlertBox'
 import ModalTitle from './ModalTitle'
-import { useRef } from 'react'
-import { useOutsideClick } from '@/hooks/useOutsideClick'
-import { Z_INDEX } from '@/constants/ui'
-import { cn } from '@/lib/utils/cn'
+import { useEffect, useRef } from 'react'
 import { AnimatePresence } from 'framer-motion'
 import InlineNotification from '../commons/InlineNotification'
 
@@ -44,102 +41,109 @@ export default function WithdrawModal({ isOpen, onConfirm, onCancel, error, onCl
   })
   const detailReason = useWatch({ control, name: 'detailReason' })
   const titleLength = detailReason?.length ?? 0
-  const modalRef = useRef<HTMLDivElement>(null)
+  const dialogRef = useRef<HTMLDialogElement>(null)
 
-  useOutsideClick(isOpen, [modalRef], onCancel)
-
-  const handleCancel = () => {
-    reset()
-    onCancel()
-  }
+  useEffect(() => {
+    const dialog = dialogRef.current
+    if (isOpen && !dialog?.open) {
+      dialog?.showModal()
+    } else if (!isOpen && dialog?.open) {
+      dialog?.close()
+    }
+  }, [isOpen])
 
   const onSubmit = (data: WithDrawFormValues) => {
     const koToEn = WiTH_DRAW_REASON.find((status) => status.label === data.reason)?.id ?? data.reason
     onConfirm({ ...data, reason: koToEn })
-    reset()
   }
 
-  if (!isOpen) return null
-
   return (
-    <div className={cn('fixed inset-0 flex items-center justify-center bg-gray-900/70', Z_INDEX.MODAL)}>
-      <div ref={modalRef} className="flex w-11/12 flex-col gap-4 rounded-lg bg-white p-5 md:w-[16vw] md:min-w-96">
-        <ModalTitle heading="회원탈퇴" description="정말로 탈퇴하시겠습니까?" />
-        <AnimatePresence>
-          {error && (
-            <InlineNotification type="error" onClose={() => onClearError?.()}>
-              {error}
-            </InlineNotification>
-          )}
-        </AnimatePresence>
-        <AlertBox alertList={WITH_DRAW_ALERT_LIST} />
+    <dialog
+      ref={dialogRef}
+      className="m-auto w-11/12 open:flex flex-col gap-4 rounded-lg bg-white p-5 backdrop:bg-gray-900/70 md:w-[16vw] md:min-w-96"
+      onClick={(e) => {
+        if (e.target === dialogRef.current) dialogRef.current.close()
+      }}
+      onClose={() => {
+        reset()
+        onCancel()
+      }}
+    >
+      <ModalTitle heading="회원탈퇴" description="정말로 탈퇴하시겠습니까?" />
+      <AnimatePresence>
+        {error && (
+          <InlineNotification type="error" onClose={() => onClearError?.()}>
+            {error}
+          </InlineNotification>
+        )}
+      </AnimatePresence>
+      <AlertBox alertList={WITH_DRAW_ALERT_LIST} />
 
-        <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-4">
-          <div className="flex flex-col gap-6 pt-2">
-            <div className="flex flex-col gap-1">
-              <RequiredLabel htmlFor="withdrawReason" labelClass="font-semibold">
-                탈퇴 사유
-              </RequiredLabel>
-              <Controller
-                name="reason"
-                control={control}
-                rules={{ required: true }}
-                render={({ field }) => (
-                  <SelectDropdown
-                    value={field.value}
-                    onChange={field.onChange}
-                    options={WiTH_DRAW_REASON.map((sort) => ({
-                      value: sort.label,
-                      label: sort.label,
-                    }))}
-                    buttonClassName="border-0 bg-primary-50 text-gray-900 px-3 py-3"
-                  />
-                )}
-              />
-            </div>
-            <div className="flex flex-col gap-1">
-              <RequiredLabel htmlFor="withdrawReasonDetail" labelClass="font-semibold">
-                탈퇴 상세 사유
-              </RequiredLabel>
-              <div className="flex flex-col gap-0.5">
-                <textarea
-                  placeholder="탈퇴 사유를 입력해주세요."
-                  className="bg-primary-50 focus:border-primary-500 w-full resize-none rounded-lg px-3 py-3 text-sm placeholder:text-gray-400 focus:outline-none"
-                  id="withdrawReasonDetail"
-                  {...register('detailReason', {
-                    required: WithDrawApiErrors.detailReason.required,
-                    minLength: WithDrawApiErrors.detailReason.minLength,
-                    maxLength: WithDrawApiErrors.detailReason.maxLength,
-                  })}
+      <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-4">
+        <div className="flex flex-col gap-6 pt-2">
+          <div className="flex flex-col gap-1">
+            <RequiredLabel htmlFor="withdrawReason" labelClass="font-semibold">
+              탈퇴 사유
+            </RequiredLabel>
+            <Controller
+              name="reason"
+              control={control}
+              rules={{ required: true }}
+              render={({ field }) => (
+                <SelectDropdown
+                  value={field.value}
+                  onChange={field.onChange}
+                  options={WiTH_DRAW_REASON.map((sort) => ({
+                    value: sort.label,
+                    label: sort.label,
+                  }))}
+                  buttonClassName="border-0 bg-primary-50 text-gray-900 px-3 py-3"
                 />
-                <p className="text-sm font-semibold text-gray-400">{titleLength}/500자</p>
-                {errors.detailReason && <p className="text-danger-500 text-xs font-semibold"> {errors.detailReason.message}</p>}
-              </div>
-            </div>
-
-            <div className="flex items-center gap-3">
-              <input id="withdrawAgree" type="checkbox" className="h-4 w-4" {...register('agree', { required: true })} />
-              <RequiredLabel htmlFor="withdrawAgree" labelClass="text-sm font-semibold">
-                회원 탈퇴에 동의합니다.
-              </RequiredLabel>
+              )}
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <RequiredLabel htmlFor="withdrawReasonDetail" labelClass="font-semibold">
+              탈퇴 상세 사유
+            </RequiredLabel>
+            <div className="flex flex-col gap-0.5">
+              <textarea
+                placeholder="탈퇴 사유를 입력해주세요."
+                className="bg-primary-50 focus:border-primary-500 w-full resize-none rounded-lg px-3 py-3 text-sm placeholder:text-gray-400 focus:outline-none"
+                id="withdrawReasonDetail"
+                {...register('detailReason', {
+                  required: WithDrawApiErrors.detailReason.required,
+                  minLength: WithDrawApiErrors.detailReason.minLength,
+                  maxLength: WithDrawApiErrors.detailReason.maxLength,
+                })}
+              />
+              <p className="text-sm font-semibold text-gray-400">{titleLength}/500자</p>
+              {errors.detailReason && <p className="text-danger-500 text-xs font-semibold"> {errors.detailReason.message}</p>}
             </div>
           </div>
 
-          <div className="flex justify-end gap-3">
-            <Button type="button" onClick={handleCancel} size="sm" className="cursor-pointer rounded-lg border border-gray-300 bg-white">
-              취소
-            </Button>
-            <Button
-              type="submit"
-              disabled={!isValid}
-              size="sm"
-              className="bg-danger-600 cursor-pointer rounded-lg text-white disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              탈퇴하기
-            </Button>
+          <div className="flex items-center gap-3">
+            <input id="withdrawAgree" type="checkbox" className="h-4 w-4" {...register('agree', { required: true })} />
+            <RequiredLabel htmlFor="withdrawAgree" labelClass="text-sm font-semibold">
+              회원 탈퇴에 동의합니다.
+            </RequiredLabel>
           </div>
-        </form>
-      </div>
-    </div>
+        </div>
+
+        <div className="flex justify-end gap-3">
+          <Button type="button" onClick={() => dialogRef.current?.close()} size="sm" className="cursor-pointer rounded-lg border border-gray-300 bg-white">
+            취소
+          </Button>
+          <Button
+            type="submit"
+            disabled={!isValid}
+            size="sm"
+            className="bg-danger-600 cursor-pointer rounded-lg text-white disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            탈퇴하기
+          </Button>
+        </div>
+      </form>
+    </dialog>
   )
 }


### PR DESCRIPTION
## 📌 개요

- BlockModal에서 검증된 네이티브 dialog 패턴을 나머지 6개 모달에 적용합니다.

## 🔧 작업 내용

- [x] LoginModal.tsx → dialog 전환
- [x] DeleteConfirmModal.tsx → dialog 전환
- [x] WithdrawModal.tsx → dialog 전환
- [x] DeleteReplyModal.tsx → dialog 전환
- [x] ReportModalBase.tsx → dialog 전환 (PostReportModal, UserReportModal 포함)

## 📎 관련 이슈

Closes #280

## 💬 리뷰어 참고 사항

- BlockModal과 동일한 패턴 적용: `m-auto`, `open:flex`, `backdrop:`, `dialog.open` 가드, `dialog.close()` 통일
- 폼이 있는 모달(WithdrawModal, ReportModalBase)은 `onClose`에서 `reset()` 처리하여 ESC/백드롭 닫기 시에도 폼이 초기화됩니다.
- DeleteConfirmModal, DeleteReplyModal은 조건부 데이터(product, replyId)가 있어야 `showModal()` 호출