### PR TITLE
fix: Zustand persist hydration mismatch 수정(#282)

### DIFF
--- a/src/components/ClientComponents.tsx
+++ b/src/components/ClientComponents.tsx
@@ -1,6 +1,8 @@
 'use client'
 
+import { useEffect } from 'react'
 import dynamic from 'next/dynamic'
+import { useUserStore } from '@/store/userStore'
 
 // SSR 비활성화로 클라이언트에서만 렌더링
 const AuthValidator = dynamic(() => import('@/components/AuthValidator'), { ssr: false })
@@ -9,11 +11,16 @@ const ToastContainer = dynamic(() => import('@/components/commons/ToastContainer
 
 /**
  * 클라이언트에서만 렌더링되는 전역 컴포넌트들
+ * - StoreHydration: Zustand persist 스토어를 클라이언트에서 rehydrate
  * - AuthValidator: 앱 시작 시 인증 상태 검증
  * - LoginModal: 전역 로그인/로그아웃 모달
  * - ToastContainer: 전역 토스트 알림
  */
 export default function ClientComponents() {
+  useEffect(() => {
+    useUserStore.persist.rehydrate()
+  }, [])
+
   return (
     <>
       <AuthValidator />

--- a/src/store/userStore.ts
+++ b/src/store/userStore.ts
@@ -81,6 +81,7 @@ export const useUserStore = create<UserState>()(
     {
       name: 'user-storage',
       storage: createJSONStorage(() => localStorage),
+      skipHydration: true,
       partialize: (state) => ({
         user: state.user,
         accessToken: state.accessToken,


### PR DESCRIPTION
## 📌 개요

- 배포 환경에서 React error #418 (Hydration mismatch) 수정
- Zustand persist 스토어가 서버/클라이언트에서 다른 초기 상태를 가져 hydration 불일치 발생

## 🔧 작업 내용

- [x] `userStore.ts`에 `skipHydration: true` 추가하여 자동 rehydrate 비활성화
- [x] `ClientComponents.tsx`에서 useEffect로 수동 rehydrate 호출

## 📎 관련 이슈

Closes #282

## 💬 리뷰어 참고 사항

- 서버 렌더링 시 `user: null` 상태로 렌더링하고, 클라이언트 hydration 이후 localStorage에서 상태를 복원하는 방식입니다
- 로그인된 사용자의 경우 hydration 후 잠깐 비로그인 UI가 보일 수 있으나, hydration error로 인한 전체 앱 깨짐보다 훨씬 안정적입니다