### PR TITLE
fix: Lighthouse 접근성 aria-label 누락 수정(#284)

### DIFF
--- a/src/components/header/components/UserControls.tsx
+++ b/src/components/header/components/UserControls.tsx
@@ -38,7 +38,7 @@ export default function UserControls({ isSideOpen, setIsSideOpen, hideMenuButton
     <div className="flex items-center gap-2 xl:gap-4">
       {isLogin() ? (
         <div className="flex items-center gap-1">
-          <Link href={ROUTES.CHAT} className="ml-1">
+          <Link href={ROUTES.CHAT} className="ml-1" aria-label="채팅">
             <MessageCircleMore className="text-white" strokeWidth={1.5} />
           </Link>
           <div className="relative mr-2.5" onClick={handleBellToggle}>

--- a/src/features/product-detail/components/ProductActions.tsx
+++ b/src/features/product-detail/components/ProductActions.tsx
@@ -52,6 +52,7 @@ export default function ProductActions({ id, isFavorite: initialIsFavorite, sell
         }}
         size="md"
         className="cursor-pointer border border-gray-300 bg-white"
+        aria-label="찜하기"
         onClick={handleToggleFavorite}
       />
       <Button size="md" className="bg-primary-400 flex-1 cursor-pointer text-white" onClick={isMyProduct ? () => handleEdit(id) : handleChat}>


### PR DESCRIPTION
## 📌 개요

- Google Lighthouse 접근성 분석에서 발견된 aria-label 누락 이슈 2건 수정

## 🔧 작업 내용

- [x] `UserControls.tsx` - 채팅 아이콘 Link에 `aria-label="채팅"` 추가
- [x] `ProductActions.tsx` - 찜하기(Heart) 아이콘 Button에 `aria-label="찜하기"` 추가

## 📎 관련 이슈

Closes #284

## 💬 리뷰어 참고 사항

- 아이콘만 있고 텍스트가 없는 인터랙티브 요소에 `aria-label`을 추가하여 스크린리더 접근성을 개선했습니다