### PR TITLE
refactor: 상품 상세 페이지 SSR 전환(#286)

### DIFF
--- a/src/app/(main)/products/[id]/page.tsx
+++ b/src/app/(main)/products/[id]/page.tsx
@@ -1,12 +1,23 @@
 import { Suspense } from 'react'
+import { notFound } from 'next/navigation'
 import ProductDetail from '@/features/product-detail/ProductDetail'
+import { fetchProductDetail } from '@/lib/api/server/products'
 
-export const dynamic = 'force-dynamic'
+interface ProductDetailPageProps {
+  params: Promise<{ id: string }>
+}
 
-export default function ProductDetailPage() {
+export default async function ProductDetailPage({ params }: ProductDetailPageProps) {
+  const { id } = await params
+  const initialData = await fetchProductDetail(id)
+
+  if (!initialData) {
+    notFound()
+  }
+
   return (
     <Suspense fallback={null}>
-      <ProductDetail />
+      <ProductDetail initialData={initialData} />
     </Suspense>
   )
 }

--- a/src/features/product-detail/ProductDetail.tsx
+++ b/src/features/product-detail/ProductDetail.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useRouter, useParams } from 'next/navigation'
+import { useParams } from 'next/navigation'
 import { fetchProductById } from '@/lib/api/products'
 import { useQuery } from '@tanstack/react-query'
 import Footer from '@/components/footer/Footer'
@@ -13,42 +13,26 @@ import ProductDescription from './components/ProductDescription'
 import ProductActions from './components/ProductActions'
 import SellerOtherProducts from './components/SellerOtherProducts'
 import { useEffect } from 'react'
+import type { ProductDetailItem } from '@/types/product'
 
-function ProductDetail() {
-  const router = useRouter()
+interface ProductDetailProps {
+  initialData: ProductDetailItem
+}
+
+function ProductDetail({ initialData }: ProductDetailProps) {
   const params = useParams<{ id: string }>()
   const id = params.id
 
-  const { data, isLoading, error } = useQuery({
+  const { data } = useQuery({
     queryKey: ['product', id],
     queryFn: () => fetchProductById(id!),
     enabled: !!id,
+    initialData,
   })
 
   useEffect(() => {
     window.scrollTo(0, 0)
   }, [])
-
-  if (isLoading) {
-    return (
-      <div className="flex min-h-screen items-center justify-center">
-        <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-blue-600"></div>
-      </div>
-    )
-  }
-
-  if (error || !data) {
-    return (
-      <div className="flex min-h-screen items-center justify-center">
-        <div className="flex flex-col items-center gap-4">
-          <p>상품 정보를 불러올 수 없습니다</p>
-          <button onClick={() => router.push('/')} className="text-blue-600 hover:text-blue-800">
-            목록으로 돌아가기
-          </button>
-        </div>
-      </div>
-    )
-  }
 
   return (
     <>

--- a/src/lib/api/server/products.ts
+++ b/src/lib/api/server/products.ts
@@ -1,3 +1,5 @@
+import type { ProductDetailItem } from '@/types/product'
+
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL
 
 export async function fetchInitialProducts() {
@@ -13,6 +15,21 @@ export async function fetchInitialProducts() {
       data: json,
       total: json.data.totalElements,
     }
+  } catch {
+    return null
+  }
+}
+
+export async function fetchProductDetail(id: string): Promise<ProductDetailItem | null> {
+  try {
+    const res = await fetch(`${API_BASE_URL}/products/${id}`, {
+      next: { revalidate: 60 },
+    })
+
+    if (!res.ok) return null
+
+    const json = await res.json()
+    return json.data
   } catch {
     return null
   }


### PR DESCRIPTION
## 📌 개요

- 상품 상세 페이지를 CSR(useQuery)에서 SSR로 전환하여 Lighthouse CLS 0.279 해결
- 메인 페이지와 동일한 SSR 패턴 적용 (서버 fetch → initialData → useQuery hydration)

## 🔧 작업 내용

- [x] `src/lib/api/server/products.ts` - `fetchProductDetail(id)` 서버 사이드 fetch 함수 추가 (60초 revalidate)
- [x] `src/app/(main)/products/[id]/page.tsx` - async 서버 컴포넌트로 전환, 데이터 없으면 `notFound()`
- [x] `src/features/product-detail/ProductDetail.tsx` - `initialData` prop 추가, `useQuery({ initialData })`로 hydration, 로딩 스피너/에러 상태 제거

## 📎 관련 이슈

Closes #286

## 💬 리뷰어 참고 사항

- 서버에서 HTML이 완성된 상태로 전달되므로 로딩 스피너 → 콘텐츠 전환이 사라져 CLS가 해결됩니다
- `useQuery({ initialData })`를 사용하여 서버 데이터로 캐시를 미리 채우고, 이후 찜하기 등 클라이언트 인터랙션 시 refetch가 동작합니다
- 상품이 존재하지 않으면 Next.js `notFound()`로 404 페이지를 표시합니다