### PR TITLE
fix: 상품 상세페이지 LCP 이미지 fetchpriority=high 적용(#291)

### DIFF
--- a/src/features/product-detail/components/MainImage.tsx
+++ b/src/features/product-detail/components/MainImage.tsx
@@ -1,8 +1,6 @@
 'use client'
 
-import { useState } from 'react'
-import Image from 'next/image'
-import { IMAGE_SIZES, imageLoader, toResizedWebpUrl, PLACEHOLDER_IMAGES } from '@/lib/utils/imageUrl'
+import { getImageSrcSet, IMAGE_SIZES, toResizedWebpUrl, PLACEHOLDER_IMAGES, PLACEHOLDER_SRCSET } from '@/lib/utils/imageUrl'
 
 interface MainImageProps {
   mainImageUrl: string | null
@@ -10,35 +8,26 @@ interface MainImageProps {
 }
 
 export default function MainImage({ mainImageUrl, title }: MainImageProps) {
-  const [imgError, setImgError] = useState(false)
-  const [usePlaceholder, setUsePlaceholder] = useState(false)
-
-  const handleImageError = () => {
-    if (!imgError && mainImageUrl) {
-      setImgError(true)
-    } else {
-      setUsePlaceholder(true)
-    }
-  }
-
-  const getImageSrc = () => {
-    if (usePlaceholder || !mainImageUrl) return PLACEHOLDER_IMAGES[800]
-    if (imgError) return mainImageUrl
-    return toResizedWebpUrl(mainImageUrl, 800)
-  }
-
   return (
     <div className="relative overflow-hidden rounded-xl pb-[100%]">
-      <Image
-        src={getImageSrc()}
-        loader={imgError || usePlaceholder || !mainImageUrl ? undefined : imageLoader}
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={mainImageUrl ? toResizedWebpUrl(mainImageUrl, 800) : PLACEHOLDER_IMAGES[800]}
+        srcSet={mainImageUrl ? getImageSrcSet(mainImageUrl) : PLACEHOLDER_SRCSET}
         sizes={IMAGE_SIZES.mainImage}
         alt={title}
-        fill
-        priority
-        className="object-cover"
-        onError={handleImageError}
-        unoptimized={imgError || usePlaceholder || !mainImageUrl}
+        fetchPriority="high"
+        className="absolute inset-0 h-full w-full object-cover"
+        onError={(e) => {
+          const img = e.currentTarget
+          if (mainImageUrl && img.src !== mainImageUrl) {
+            img.srcset = ''
+            img.src = mainImageUrl
+          } else {
+            img.srcset = PLACEHOLDER_SRCSET
+            img.src = PLACEHOLDER_IMAGES[800]
+          }
+        }}
       />
     </div>
   )


### PR DESCRIPTION
## 📌 개요

- 상품 상세페이지 Lighthouse LCP 이미지 `fetchpriority=high` 미적용 경고 수정
- 메인페이지 Lighthouse 접근성 경고 수정 (정렬 버튼에 접근 가능한 이름 없음)

## 🔧 작업 내용

- [x] MainImage: `next/image` → `<img>` 변환 (CDN 이미지 컨벤션 통일)
- [x] `fetchPriority="high"` 명시 적용, `srcSet` 추가
- [x] SelectDropdown: `role="combobox"` → `aria-haspopup="listbox"` (올바른 ARIA 역할)
- [x] SelectDropdown: `aria-label={placeholder}` 추가 (접근 가능한 이름 부여)

## 📎 관련 이슈

Closes #291

## 💬 리뷰어 참고 사항

- MainImage: ProductThumbnail과 동일한 `<img>` + `onError` 패턴으로 통일
- SelectDropdown: 커스텀 select는 `combobox`가 아닌 `aria-haspopup="listbox"` 패턴이 올바름