### PR TITLE
fix: SelectDropdown 접근성 개선 - combobox 역할 수정 및 aria-label 추가(#293)

### DIFF
--- a/src/components/commons/select/SelectDropdown.tsx
+++ b/src/components/commons/select/SelectDropdown.tsx
@@ -19,8 +19,9 @@ function Select({ isOpen, disabled, onClick, id, buttonClassName, selectedLabel,
   return (
     <button
       type="button"
-      role="combobox"
+      aria-haspopup="listbox"
       aria-expanded={isOpen}
+      aria-label={placeholder}
       disabled={disabled}
       onClick={onClick}
       id={id}


### PR DESCRIPTION
## 📌 개요

- 메인페이지 Lighthouse 접근성 분석에서 정렬 버튼에 접근 가능한 이름이 없다는 경고 수정

## 🔧 작업 내용

- [x] `role="combobox"` → `aria-haspopup="listbox"` (커스텀 select에 올바른 ARIA 역할)
- [x] `aria-label={placeholder}` 추가 (접근 가능한 이름 부여)

## 📎 관련 이슈

Closes #293

## 💬 리뷰어 참고 사항

- `combobox`는 텍스트 입력 + 자동완성 위젯용이며, 버튼 클릭 → 옵션 선택 패턴은 `aria-haspopup="listbox"`가 올바름
- 기존 `placeholder`를 `aria-label`로 활용하여 별도 prop 추가 없이 해결