### PR TITLE
fix: 웹 접근성 개선 - 중복 ARIA ID 수정 및 aria-label 추가(#296)

### DIFF
--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -73,13 +73,13 @@ export const PETS = [
 ] as const
 
 export const PET_TYPE_TABS = [
-  { id: 'tab-all', label: '전체', code: 'ALL' },
-  { id: 'tab-mammal', label: '포유류', code: 'MAMMAL' },
-  { id: 'tab-bird', label: '조류', code: 'BIRD' },
-  { id: 'tab-reptile', label: '파충류', code: 'REPTILE' },
-  { id: 'tab-fish', label: '수생동물', code: 'FISH' },
-  { id: 'tab-amphibian', label: '곤충/절지동물', code: 'AMPHIBIAN' },
-  { id: 'tab-etc', label: '기타', code: 'ETC' },
+  { id: 'pet-tab-all', label: '전체', code: 'ALL' },
+  { id: 'pet-tab-mammal', label: '포유류', code: 'MAMMAL' },
+  { id: 'pet-tab-bird', label: '조류', code: 'BIRD' },
+  { id: 'pet-tab-reptile', label: '파충류', code: 'REPTILE' },
+  { id: 'pet-tab-fish', label: '수생동물', code: 'FISH' },
+  { id: 'pet-tab-amphibian', label: '곤충/절지동물', code: 'AMPHIBIAN' },
+  { id: 'pet-tab-etc', label: '기타', code: 'ETC' },
 ] as const
 export type PetTypeTabId = (typeof PET_TYPE_TABS)[number]['id']
 

--- a/src/features/community/CommunityDetail.tsx
+++ b/src/features/community/CommunityDetail.tsx
@@ -161,6 +161,7 @@ export default function CommunityDetail() {
 
   return (
     <>
+      {/* 모바일 영역 */}
       {!isMd ? (
         <div
           className={cn('bg-primary-200 sticky top-0 mx-auto flex w-full max-w-7xl justify-between px-3.5 py-4', Z_INDEX.HEADER)}
@@ -173,6 +174,7 @@ export default function CommunityDetail() {
           </span>
         </div>
       ) : (
+        //  데스크탑
         <SimpleHeader
           title={headerTitle}
           description={isMd ? headerDescription : undefined}
@@ -188,7 +190,7 @@ export default function CommunityDetail() {
                 <Badge className="bg-primary-400 w-fit rounded-full text-white">
                   {getBoardType(data.boardType as 'QUESTION' | 'INFO')}
                 </Badge>
-                <IconButton className="" size="sm" onClick={handleMoreToggle}>
+                <IconButton aria-label="더보기" className="" size="sm" onClick={handleMoreToggle}>
                   <EllipsisVertical size={16} className="text-gray-500" />
                 </IconButton>
                 {isMoreMenuOpen && (
@@ -253,7 +255,10 @@ export default function CommunityDetail() {
               <MdPreview value={data.content} className="p-0" />
             </div>
 
-            <section aria-label="댓글" className="flex flex-col gap-3.5 rounded-lg border border-gray-400 bg-white px-6 py-5 shadow-xl">
+            <section
+              aria-label="댓글"
+              className="flex flex-col gap-3.5 rounded-lg border border-gray-400 bg-white px-6 py-5 shadow-xl"
+            >
               <div className="flex items-center gap-1">
                 <span>댓글</span>
                 <span>{data.commentCount}</span>

--- a/src/features/community/CommunityPage.tsx
+++ b/src/features/community/CommunityPage.tsx
@@ -272,75 +272,81 @@ export default function CommunityPage() {
               </div>
             </div>
           )}
-          {communityPosts.length === 0 ? (
-            <div className={cn('px-3.5 md:px-0', !isMd && (isFilterCollapsed ? 'mt-20' : 'mt-4'))}>
-              <EmptyState icon={MessageSquareText} title="아직 게시글이 없어요" description="첫 번째 이야기를 나눠보세요!" />
-            </div>
-          ) : (
-            <ul className={cn('flex flex-col gap-2.5 px-3.5 md:p-0', !isMd && (isFilterCollapsed ? 'mt-20' : 'mt-4'))}>
-              {communityPosts.map((post) =>
-                isMd ? (
-                  <li
-                    key={post.id}
-                    className="flex flex-col justify-center gap-2.5 rounded-lg border border-gray-400 bg-white px-3.5 pt-3.5 pb-3.5 shadow-xl"
-                  >
-                    <Link href={ROUTES.COMMUNITY_DETAIL_ID(post.id)} className="flex flex-col gap-1">
-                      <p className="font-semibold">{post.title}</p>
-                      <div className="flex items-center gap-2.5">
-                        <div className="flex items-center gap-1 text-gray-500">
-                          <UserRound size={16} className="text-gray-500" strokeWidth={2.3} />
-                          <p>{post.authorNickname}</p>
-                        </div>
-                        <div className="flex items-center gap-1 text-gray-500">
-                          <Clock size={16} className="text-gray-500" strokeWidth={2.3} />
-                          <p>{getTimeAgo(post.createdAt)}</p>
-                        </div>
-                        <div className="flex items-center gap-1 text-gray-500">
-                          <MessageSquare size={16} className="text-gray-500" strokeWidth={2.3} />
-                          <p>{post.commentCount}</p>
-                        </div>
-                        <div className="flex items-center gap-1 text-gray-500">
-                          <Eye size={16} className="text-gray-500" strokeWidth={2.3} />
-                          <span>조회</span>
-                          <span>{post.viewCount}</span>
-                        </div>
-                      </div>
-                    </Link>
-                  </li>
-                ) : (
-                  <li
-                    key={post.id}
-                    className="flex flex-col justify-center gap-2.5 rounded-lg border border-gray-400 bg-white px-3.5 pt-3.5 pb-5 shadow-xl"
-                  >
-                    <Link href={ROUTES.COMMUNITY_DETAIL_ID(post.id)} className="flex flex-col gap-4">
-                      <div className="flex flex-col gap-2">
-                        <p className="text-lg font-semibold">{post.title}</p>
-
-                        <p className="line-clamp-1">{post.contentPreview}</p>
-                      </div>
-                      <div className="flex items-center justify-between gap-2.5">
-                        <div className="flex items-center text-gray-500">
-                          <p>{post.authorNickname}</p>
-                          <Dot size={12} />
-                          <p>{getTimeAgo(post.createdAt)}</p>
-                        </div>
+          <div
+            id={`panel-${COMMUNITY_TABS.find((tab) => tab.id === activeCommunityTypeTab)?.code}`}
+            role="tabpanel"
+            aria-labelledby={activeCommunityTypeTab}
+          >
+            {communityPosts.length === 0 ? (
+              <div className={cn('px-3.5 md:px-0', !isMd && (isFilterCollapsed ? 'mt-20' : 'mt-4'))}>
+                <EmptyState icon={MessageSquareText} title="아직 게시글이 없어요" description="첫 번째 이야기를 나눠보세요!" />
+              </div>
+            ) : (
+              <ul className={cn('flex flex-col gap-2.5 px-3.5 md:p-0', !isMd && (isFilterCollapsed ? 'mt-20' : 'mt-4'))}>
+                {communityPosts.map((post) =>
+                  isMd ? (
+                    <li
+                      key={post.id}
+                      className="flex flex-col justify-center gap-2.5 rounded-lg border border-gray-400 bg-white px-3.5 pt-3.5 pb-3.5 shadow-xl"
+                    >
+                      <Link href={ROUTES.COMMUNITY_DETAIL_ID(post.id)} className="flex flex-col gap-1">
+                        <p className="font-semibold">{post.title}</p>
                         <div className="flex items-center gap-2.5">
+                          <div className="flex items-center gap-1 text-gray-500">
+                            <UserRound size={16} className="text-gray-500" strokeWidth={2.3} />
+                            <p>{post.authorNickname}</p>
+                          </div>
+                          <div className="flex items-center gap-1 text-gray-500">
+                            <Clock size={16} className="text-gray-500" strokeWidth={2.3} />
+                            <p>{getTimeAgo(post.createdAt)}</p>
+                          </div>
                           <div className="flex items-center gap-1 text-gray-500">
                             <MessageSquare size={16} className="text-gray-500" strokeWidth={2.3} />
                             <p>{post.commentCount}</p>
                           </div>
                           <div className="flex items-center gap-1 text-gray-500">
                             <Eye size={16} className="text-gray-500" strokeWidth={2.3} />
+                            <span>조회</span>
                             <span>{post.viewCount}</span>
                           </div>
                         </div>
-                      </div>
-                    </Link>
-                  </li>
-                )
-              )}
-            </ul>
-          )}
+                      </Link>
+                    </li>
+                  ) : (
+                    <li
+                      key={post.id}
+                      className="flex flex-col justify-center gap-2.5 rounded-lg border border-gray-400 bg-white px-3.5 pt-3.5 pb-5 shadow-xl"
+                    >
+                      <Link href={ROUTES.COMMUNITY_DETAIL_ID(post.id)} className="flex flex-col gap-4">
+                        <div className="flex flex-col gap-2">
+                          <p className="text-lg font-semibold">{post.title}</p>
+
+                          <p className="line-clamp-1">{post.contentPreview}</p>
+                        </div>
+                        <div className="flex items-center justify-between gap-2.5">
+                          <div className="flex items-center text-gray-500">
+                            <p>{post.authorNickname}</p>
+                            <Dot size={12} />
+                            <p>{getTimeAgo(post.createdAt)}</p>
+                          </div>
+                          <div className="flex items-center gap-2.5">
+                            <div className="flex items-center gap-1 text-gray-500">
+                              <MessageSquare size={16} className="text-gray-500" strokeWidth={2.3} />
+                              <p>{post.commentCount}</p>
+                            </div>
+                            <div className="flex items-center gap-1 text-gray-500">
+                              <Eye size={16} className="text-gray-500" strokeWidth={2.3} />
+                              <span>{post.viewCount}</span>
+                            </div>
+                          </div>
+                        </div>
+                      </Link>
+                    </li>
+                  )
+                )}
+              </ul>
+            )}
+          </div>
           {hasNextPage &&
             (isMd ? (
               <LoadMoreButton onClick={() => fetchNextPage()} isLoading={isFetchingNextPage} className="border-0" />

--- a/src/features/community/components/CommentItem.tsx
+++ b/src/features/community/components/CommentItem.tsx
@@ -91,7 +91,7 @@ export function CommentItem({
 
         {isMyComment && (
           <div className="relative ml-auto">
-            <IconButton className="" size="sm" onClick={handleMoreToggle}>
+            <IconButton aria-label="더보기" className="" size="sm" onClick={handleMoreToggle}>
               <EllipsisVertical size={16} className="text-gray-500" />
             </IconButton>
             {isMoreMenuOpen && (

--- a/src/features/community/components/markdown/MdToolbar.tsx
+++ b/src/features/community/components/markdown/MdToolbar.tsx
@@ -37,28 +37,28 @@ export default function MdToolbar({ tab, setTab, onBold, onItalic, onCode, onLin
 
       {/* 우측 툴바 */}
       <div className="ml-0 flex items-center gap-1 md:ml-auto">
-        <IconButton onClick={onBold}>
+        <IconButton aria-label="굵게" onClick={onBold}>
           <Bold size={16} />
         </IconButton>
-        <IconButton onClick={onItalic}>
+        <IconButton aria-label="기울임" onClick={onItalic}>
           <Italic size={16} />
         </IconButton>
-        <IconButton onClick={onCode}>
+        <IconButton aria-label="코드" onClick={onCode}>
           <Code2 size={16} />
         </IconButton>
-        <IconButton onClick={onLink}>
+        <IconButton aria-label="링크" onClick={onLink}>
           <LinkIcon size={16} />
         </IconButton>
-        <IconButton onClick={onH1}>
+        <IconButton aria-label="제목" onClick={onH1}>
           <span>
             <span>H</span>
             <span className="text-xs">1</span>
           </span>
         </IconButton>
-        <IconButton onClick={(e) => (e.shiftKey ? onNumber() : onBullet())}>
+        <IconButton aria-label="목록" onClick={(e) => (e.shiftKey ? onNumber() : onBullet())}>
           <List size={16} />
         </IconButton>
-        <IconButton onClick={onImage}>
+        <IconButton aria-label="이미지" onClick={onImage}>
           <Image size={16} />
         </IconButton>
       </div>

--- a/src/features/home/Home.tsx
+++ b/src/features/home/Home.tsx
@@ -32,7 +32,7 @@ function Home({ initialData }: HomeProps) {
   const pathname = usePathname()
 
   // 탭 상태 (새로고침 시 초기화)
-  const [activePetTypeTab, setActivePetTypeTab] = useState<PetTypeTabId>('tab-all')
+  const [activePetTypeTab, setActivePetTypeTab] = useState<PetTypeTabId>('pet-tab-all')
   const [activeProductTypeTab, setActiveProductTypeTab] = useState<ProductTypeTabId>('tab-all')
 
   // URL에서 필터 값 직접 파싱 (Single Source of Truth)
@@ -154,7 +154,7 @@ function Home({ initialData }: HomeProps) {
   const filterReset = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation()
-      setActivePetTypeTab('tab-all')
+      setActivePetTypeTab('pet-tab-all')
       setActiveProductTypeTab('tab-all')
       router.push(pathname)
     },


### PR DESCRIPTION
## 📌 개요

- Google Lighthouse 접근성 분석에서 발견된 문제들을 수정합니다.

## 🔧 작업 내용

- [x] `constants.ts` PET_TYPE_TABS ID를 `pet-tab-*`로 변경하여 PRODUCT_TYPE_TABS와의 중복 ARIA ID 해결
- [x] `Home.tsx` 변경된 ID 참조 업데이트
- [x] `CommunityDetail.tsx`, `CommentItem.tsx` IconButton에 aria-label="더보기" 추가
- [x] `MdToolbar.tsx` 마크다운 툴바 버튼들에 aria-label 추가 (굵게, 기울임, 코드, 링크, 제목, 목록, 이미지)
- [x] `CommunityPage.tsx` 게시글 목록에 tabpanel role/aria 추가

## 📎 관련 이슈

Closes #296

## 💬 리뷰어 참고 사항

- Lighthouse "중복되는 ARIA ID가 없음" 항목 해결을 위해 PET_TYPE_TABS의 ID에 `pet-` 접두사를 추가했습니다.
- "버튼에 접근 가능한 이름이 없습니다" 항목 해결을 위해 IconButton에 aria-label을 추가했습니다.