### PR TITLE
fix: Zustand hydration 타이밍 수정으로 인증 페이지 새로고침 깜빡임 해결(#295)

### DIFF
--- a/src/features/chatting-page/ChattingPage.tsx
+++ b/src/features/chatting-page/ChattingPage.tsx
@@ -27,7 +27,7 @@ export default function ChattingPage() {
   const [imageUploadError, setImageUploadError] = useState<React.ReactNode | null>(null)
 
   const router = useRouter()
-  const { user, accessToken } = useUserStore()
+  const { user, _hasHydrated, accessToken } = useUserStore()
   const params = useParams()
   const chatRoomId = params.id as string | undefined
   const {
@@ -178,10 +178,10 @@ export default function ChattingPage() {
   }, [isConnected, chatRoomId, subscribeToRoom, clearRoomMessages])
 
   useEffect(() => {
-    if (!user) {
+    if (_hasHydrated && !user) {
       router.push('/auth/login')
     }
-  }, [router, user])
+  }, [_hasHydrated, router, user])
 
   if (isLoadingRooms && !rooms) {
     return (
@@ -257,7 +257,7 @@ export default function ChattingPage() {
                   <Paperclip size={20} />
                 </label>
                 <ChatInput value={inputMessage} onChange={setInputMessage} onSubmit={handleSend} />
-                <IconButton size="lg" className="bg-primary-100 aspect-square h-full" onClick={handleSend}>
+                <IconButton aria-label="전송" size="lg" className="bg-primary-100 aspect-square h-full" onClick={handleSend}>
                   <Send className="text-white" />
                 </IconButton>
               </div>

--- a/src/features/community/components/CommunityPostForm.tsx
+++ b/src/features/community/components/CommunityPostForm.tsx
@@ -56,21 +56,13 @@ export default function CommunityPostForm() {
   const params = useParams()
   const id = params.id as string | undefined
   const isEditMode = !!id
-  const { user, setRedirectUrl } = useUserStore()
+  const { user, _hasHydrated, setRedirectUrl } = useUserStore()
   const searchParams = useSearchParams()
   const initialBoardType = searchParams.get('tab') === 'tab-question' ? 'QUESTION' : 'INFO'
   const [showDraftModal, setShowDraftModal] = useState(false)
   const [isDraftChecked, setIsDraftChecked] = useState(isEditMode)
 
   const pathname = usePathname()
-
-  // 비로그인 시 로그인 페이지로 리다이렉트
-  useEffect(() => {
-    if (!user?.id) {
-      setRedirectUrl(pathname)
-      router.push('/auth/login')
-    }
-  }, [user, router, setRedirectUrl, pathname])
 
   const {
     control,
@@ -164,6 +156,14 @@ export default function CommunityPostForm() {
     }
     checkDraft()
   }, [initialBoardType, isEditMode])
+
+  // 비로그인 시 로그인 페이지로 리다이렉트
+  useEffect(() => {
+    if (_hasHydrated && !user?.id) {
+      setRedirectUrl(pathname)
+      router.push('/auth/login')
+    }
+  }, [_hasHydrated, user, router, setRedirectUrl, pathname])
 
   if (postLoadError) {
     return (

--- a/src/features/my-page/MyPage.tsx
+++ b/src/features/my-page/MyPage.tsx
@@ -25,7 +25,7 @@ import InlineNotification from '@/components/commons/InlineNotification'
 function MyPage() {
   const [deleteError, setDeleteError] = useState<React.ReactNode | null>(null)
 
-  const { user, clearAll, updateUserProfile, setRedirectUrl } = useUserStore()
+  const { user, _hasHydrated, clearAll, updateUserProfile, setRedirectUrl } = useUserStore()
   const searchParams = useSearchParams()
   const queryClient = useQueryClient()
   const router = useRouter()
@@ -209,11 +209,11 @@ function MyPage() {
   }, [myData, updateUserProfile])
 
   useEffect(() => {
-    if (!user?.id) {
+    if (_hasHydrated && !user?.id) {
       setRedirectUrl(pathname)
       router.push('/auth/login')
     }
-  }, [user?.id, pathname, router, setRedirectUrl])
+  }, [_hasHydrated, user?.id, pathname, router, setRedirectUrl])
 
   if ((isLoadingMyData && !myData) || (isLoadingMyProductData && !myProductsData)) {
     return (
@@ -236,7 +236,7 @@ function MyPage() {
     )
   }
 
-  if (!user?.id) {
+  if (!_hasHydrated || !user?.id) {
     return null
   }
 

--- a/src/features/product-post/ProductPost.tsx
+++ b/src/features/product-post/ProductPost.tsx
@@ -21,7 +21,7 @@ function ProductPost() {
   const [productData, setProductData] = useState<ProductDetailItem | null>(null)
   const params = useParams()
   const id = params.id as string | undefined
-  const { user, setRedirectUrl } = useUserStore()
+  const { user, _hasHydrated, setRedirectUrl } = useUserStore()
 
   const isEditMode = !!id
 
@@ -48,11 +48,11 @@ function ProductPost() {
 
   // 비로그인 시 로그인 페이지로 리다이렉트
   useEffect(() => {
-    if (!user?.id) {
+    if (_hasHydrated && !user?.id) {
       setRedirectUrl(window.location.pathname)
       router.push('/auth/login')
     }
-  }, [user, router, setRedirectUrl])
+  }, [_hasHydrated, user, router, setRedirectUrl])
 
   useEffect(() => {
     const loadProduct = async () => {

--- a/src/features/profile-update/ProfileUpdate.tsx
+++ b/src/features/profile-update/ProfileUpdate.tsx
@@ -18,18 +18,11 @@ function ProfileUpdate() {
   const pathname = usePathname()
   const [isWithdrawModalOpen, setIsWithdrawModalOpen] = useState(false)
   const [withdrawError, setWithdrawError] = useState<React.ReactNode | null>(null)
-  const { user, clearAll, updateUserProfile, setRedirectUrl } = useUserStore()
+  const { user, _hasHydrated, clearAll, updateUserProfile, setRedirectUrl } = useUserStore()
 
   const socialDomains = ['gmail', 'kakao']
   const isSocialLogin = socialDomains.some((domain) => user?.email?.includes(domain))
 
-  // 비로그인 시 로그인 페이지로 리다이렉트
-  useEffect(() => {
-    if (!user?.id) {
-      setRedirectUrl(pathname)
-      router.push(ROUTES.LOGIN)
-    }
-  }, [user, router, setRedirectUrl, pathname])
   const isMd = useMediaQuery('(min-width: 768px)')
   const {
     data: myData,
@@ -71,6 +64,14 @@ function ProfileUpdate() {
       })
     }
   }, [myData, updateUserProfile])
+
+  // 비로그인 시 로그인 페이지로 리다이렉트
+  useEffect(() => {
+    if (_hasHydrated && !user?.id) {
+      setRedirectUrl(pathname)
+      router.push(ROUTES.LOGIN)
+    }
+  }, [_hasHydrated, user, router, setRedirectUrl, pathname])
 
   if (isLoadingMyData) {
     return (

--- a/src/store/userStore.ts
+++ b/src/store/userStore.ts
@@ -7,6 +7,7 @@ interface UserState {
   accessToken: string | null
   refreshToken: string | null
   redirectUrl: string | null
+  _hasHydrated: boolean
 
   setUser: (user: User | null) => void
   setAccessToken: (token: string | null) => void
@@ -29,6 +30,7 @@ export const useUserStore = create<UserState>()(
       accessToken: null,
       redirectUrl: null,
       refreshToken: null,
+      _hasHydrated: false,
 
       setUser: (user) => set({ user }),
       setAccessToken: (token) => set({ accessToken: token }),
@@ -87,6 +89,11 @@ export const useUserStore = create<UserState>()(
         accessToken: state.accessToken,
         refreshToken: state.refreshToken,
       }),
+      onRehydrateStorage: () => {
+        return () => {
+          useUserStore.setState({ _hasHydrated: true })
+        }
+      },
     }
   )
 )


### PR DESCRIPTION
## 📌 개요

- Zustand persist 스토어의 hydration 완료 전에 인증 리다이렉트가 실행되어, 로그인된 유저도 새로고침 시 로그인 페이지가 깜빡이는 문제를 수정합니다.

## 🔧 작업 내용

- [x] `userStore.ts`에 `_hasHydrated` 플래그 및 `onRehydrateStorage` 콜백 추가
- [x] `MyPage`, `ChattingPage`, `ProductPost`, `CommunityPostForm`, `ProfileUpdate`의 인증 리다이렉트에 `_hasHydrated` 체크 추가
- [x] `MyPage`의 렌더링 가드에 `!_hasHydrated` 조건 추가

## 📎 관련 이슈

Closes #295

## 💬 리뷰어 참고 사항

- `_hasHydrated`는 `partialize`에서 제외되어 localStorage에 저장되지 않습니다 (인메모리 전용).
- hydration 완료 전(`_hasHydrated === false`)에는 리다이렉트하지 않고 대기하여, 로그인 상태 복원 후 정상 렌더링됩니다.
- Lighthouse Navigation 모드에서 "저장용량 비우기" 해제 시 인증 페이지 분석이 가능해집니다.