### PR TITLE
fix: 채팅방 클릭 시 WebSocket 미연결 에러 방지(#295)

### DIFF
--- a/src/features/chatting-page/ChattingPage.tsx
+++ b/src/features/chatting-page/ChattingPage.tsx
@@ -95,7 +95,9 @@ export default function ChattingPage() {
   const isChatOpen = !!chatRoomId
 
   const handleSelectRoom = (room: fetchChatRoom) => {
-    subscribeToRoom(room.chatRoomId)
+    if (isConnected) {
+      subscribeToRoom(room.chatRoomId)
+    }
     const roomUnreadCount = chatSocketStore.getState().chatRoomUpdates[room.chatRoomId]?.unreadCount ?? room.unreadCount ?? 0
     if (roomUnreadCount > 0) {
       queryClient.setQueryData<{ unreadCount: number }>(['notifications', 'unreadCount'], (prev) => ({


### PR DESCRIPTION
## 📌 개요

- `_hasHydrated` 변경으로 인해 WebSocket 연결 완료 전에 채팅방 클릭이 가능해지면서 발생한 에러를 수정합니다.

## 🔧 작업 내용

- [x] `handleSelectRoom`에서 `isConnected` 체크 추가하여 미연결 상태에서 `subscribeToRoom` 호출 방지

## 📎 관련 이슈

Closes #295

## 💬 리뷰어 참고 사항

- 기존에는 hydration 전 로그인 페이지로 즉시 리다이렉트되어 이 코드에 도달할 수 없었습니다.
- `_hasHydrated` 변경 후 페이지가 유지되면서 WebSocket 연결 완료 전에 채팅방 클릭이 가능해졌습니다.
- 연결 완료 후에는 기존 useEffect(`isConnected && chatRoomId`)가 자동으로 구독을 처리합니다.
- main 브랜치에는 긴급 수정으로 이미 반영되어 있습니다.