### PR TITLE
fix: 채팅방 선택 시 lastMessage 플레이스홀더 flash 현상 수정(#302)

### DIFF
--- a/src/features/chatting-page/ChattingPage.tsx
+++ b/src/features/chatting-page/ChattingPage.tsx
@@ -95,9 +95,6 @@ export default function ChattingPage() {
   const isChatOpen = !!chatRoomId
 
   const handleSelectRoom = (room: fetchChatRoom) => {
-    if (isConnected) {
-      subscribeToRoom(room.chatRoomId)
-    }
     const roomUnreadCount = chatSocketStore.getState().chatRoomUpdates[room.chatRoomId]?.unreadCount ?? room.unreadCount ?? 0
     if (roomUnreadCount > 0) {
       queryClient.setQueryData<{ unreadCount: number }>(['notifications', 'unreadCount'], (prev) => ({


### PR DESCRIPTION
## 📌 개요

- 채팅방 클릭 시 "채팅방에 입장해주세요" 플레이스홀더가 잠깐 노출되는 현상 수정

## 🔧 작업 내용

- [x] `handleSelectRoom`에서 중복 `subscribeToRoom` 호출 제거
- [x] 구독은 기존 useEffect(`[isConnected, chatRoomId]`)가 네비게이션 완료 후 처리

## 📎 관련 이슈

Closes #302

## 💬 리뷰어 참고 사항

- `handleSelectRoom`에서 구독 후 서버 응답이 `chatRoomUpdates`를 업데이트하면서 `lastMessage`가 빈 값으로 덮어써짐
- useEffect가 동일한 구독을 수행하므로 `handleSelectRoom`의 구독은 중복이었음