### PR TITLE
refactor: 커뮤니티 페이지 SSR 전환(#304)

### DIFF
--- a/src/app/(main)/community/[id]/page.tsx
+++ b/src/app/(main)/community/[id]/page.tsx
@@ -1,13 +1,27 @@
 import { Suspense } from 'react'
+import { notFound } from 'next/navigation'
 import CommunityDetail from '@/features/community/CommunityDetail'
 import CommunityDetailSkeleton from '@/features/community/components/CommunityDetailSkeleton'
+import { fetchCommunityDetail, fetchCommunityComments } from '@/lib/api/server/community'
 
-export const dynamic = 'force-dynamic'
+interface CommunityDetailPageProps {
+  params: Promise<{ id: string }>
+}
 
-export default function CommunityDetailPage() {
+export default async function CommunityDetailPage({ params }: CommunityDetailPageProps) {
+  const { id } = await params
+  const [initialPostData, initialCommentData] = await Promise.all([
+    fetchCommunityDetail(id),
+    fetchCommunityComments(id),
+  ])
+
+  if (!initialPostData) {
+    notFound()
+  }
+
   return (
     <Suspense fallback={<CommunityDetailSkeleton />}>
-      <CommunityDetail />
+      <CommunityDetail initialPostData={initialPostData} initialCommentData={initialCommentData} />
     </Suspense>
   )
 }

--- a/src/app/(main)/community/page.tsx
+++ b/src/app/(main)/community/page.tsx
@@ -1,13 +1,33 @@
 import { Suspense } from 'react'
 import CommunityPage from '@/features/community/CommunityPage'
 import CommunityListSkeleton from '@/features/community/components/CommunityListSkeleton'
+import { fetchInitialQuestionCommunity, fetchInitialInfoCommunity } from '@/lib/api/server/community'
 
-export const dynamic = 'force-dynamic'
+interface CommunityRouteProps {
+  searchParams: Promise<{
+    tab?: string
+    searchType?: string
+    communityKeyword?: string
+    sortBy?: string
+  }>
+}
 
-export default function CommunityRoute() {
+export default async function CommunityRoute({ searchParams }: CommunityRouteProps) {
+  const { tab, searchType, communityKeyword, sortBy } = await searchParams
+  const activeTab = tab === 'tab-info' ? 'tab-info' : 'tab-question'
+
+  const [initialQuestionData, initialInfoData] = await Promise.all([
+    activeTab === 'tab-question'
+      ? fetchInitialQuestionCommunity(0, 10, searchType, communityKeyword, sortBy)
+      : Promise.resolve(null),
+    activeTab === 'tab-info'
+      ? fetchInitialInfoCommunity(0, 10, searchType, communityKeyword, sortBy)
+      : Promise.resolve(null),
+  ])
+
   return (
     <Suspense fallback={<CommunityListSkeleton />}>
-      <CommunityPage />
+      <CommunityPage initialQuestionData={initialQuestionData} initialInfoData={initialInfoData} />
     </Suspense>
   )
 }

--- a/src/features/community/CommunityDetail.tsx
+++ b/src/features/community/CommunityDetail.tsx
@@ -11,7 +11,7 @@ import { CommentList, type ReplyRequestFormValues } from './components/CommentLi
 import { CommentForm } from './components/CommentForm'
 import ProfileAvatar from '@/components/commons/ProfileAvatar'
 import { useForm } from 'react-hook-form'
-import type { CommentPostRequestData } from '@/types'
+import type { CommentPostRequestData, CommunityDetailItem, Comment } from '@/types'
 import { useEffect, useRef, useState } from 'react'
 import PostReportModal from '@/components/modal/PostReportModal'
 import DeletePostConfirmModal from '@/components/modal/DeletePostConfirmModal'
@@ -27,7 +27,12 @@ import SimpleHeader from '@/components/header/SimpleHeader'
 import InlineNotification from '@/components/commons/InlineNotification'
 import { useOutsideClick } from '@/hooks/useOutsideClick'
 
-export default function CommunityDetail() {
+interface CommunityDetailProps {
+  initialPostData?: CommunityDetailItem
+  initialCommentData?: { comments: Comment[] } | null
+}
+
+export default function CommunityDetail({ initialPostData, initialCommentData }: CommunityDetailProps) {
   const {
     handleSubmit, // form onSubmit에 들어가는 함수 : 제출 시 실행할 함수를 감싸주는 함수
     register, // onChange 등의 이벤트 객체 생성 : input에 "이 필드는 폼의 어떤 이름이다"라고 연결해주는 함수
@@ -66,12 +71,14 @@ export default function CommunityDetail() {
     queryKey: ['community', id],
     queryFn: () => fetchCommunityId(id!),
     enabled: !!id,
+    initialData: initialPostData,
   })
 
   const { data: commentData, isLoading: isLoadingCommentData } = useQuery({
     queryKey: ['community', id, 'comments'],
     queryFn: () => fetchComments(id!),
     enabled: !!id,
+    initialData: initialCommentData ?? undefined,
   })
 
   const replyMutation = useMutation({

--- a/src/features/community/CommunityPage.tsx
+++ b/src/features/community/CommunityPage.tsx
@@ -20,8 +20,25 @@ import Button from '@/components/commons/button/Button'
 import { cn } from '@/lib/utils/cn'
 import { Z_INDEX } from '@/constants/ui'
 import EmptyState from '@/components/EmptyState'
+import type { CommunityItem } from '@/types'
 
-export default function CommunityPage() {
+interface CommunityListData {
+  page: number
+  size: number
+  total: number
+  content: CommunityItem[]
+  hasNext: boolean
+  hasPrevious: boolean
+  totalElements: number
+  numberOfElements: number
+}
+
+interface CommunityPageProps {
+  initialQuestionData?: CommunityListData | null
+  initialInfoData?: CommunityListData | null
+}
+
+export default function CommunityPage({ initialQuestionData, initialInfoData }: CommunityPageProps) {
   const searchParams = useSearchParams()
   const router = useRouter()
   const tabParam = searchParams.get('tab') as CommunityTabId | null
@@ -81,6 +98,7 @@ export default function CommunityPage() {
     queryFn: ({ pageParam }) => fetchQuestionCommunity(pageParam, 10, searchType, currentKeyword, sortBy),
     getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.page + 1 : undefined),
     initialPageParam: 0,
+    initialData: initialQuestionData ? { pages: [initialQuestionData], pageParams: [0] } : undefined,
     enabled: activeCommunityTypeTab === 'tab-question',
   })
 
@@ -97,6 +115,7 @@ export default function CommunityPage() {
     queryFn: ({ pageParam }) => fetchInfoCommunity(pageParam, 10, searchType, currentKeyword, sortBy),
     getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.page + 1 : undefined),
     initialPageParam: 0,
+    initialData: initialInfoData ? { pages: [initialInfoData], pageParams: [0] } : undefined,
     enabled: activeCommunityTypeTab === 'tab-info',
   })
 

--- a/src/lib/api/server/community.ts
+++ b/src/lib/api/server/community.ts
@@ -1,0 +1,104 @@
+import type { CommunityDetailItem, CommunityItem, Comment } from '@/types'
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL
+
+interface CommunityListData {
+  page: number
+  size: number
+  total: number
+  content: CommunityItem[]
+  hasNext: boolean
+  hasPrevious: boolean
+  totalElements: number
+  numberOfElements: number
+}
+
+export async function fetchInitialQuestionCommunity(
+  page: number = 0,
+  size: number = 10,
+  searchType?: string | null,
+  keyword?: string | null,
+  sortBy?: string | null
+): Promise<CommunityListData | null> {
+  try {
+    const params = new URLSearchParams({
+      page: page.toString(),
+      size: size.toString(),
+      boardType: 'QUESTION',
+    })
+    if (searchType) params.append('searchType', searchType)
+    if (keyword) params.append('keyword', keyword)
+    if (sortBy) params.append('sortBy', sortBy)
+
+    const res = await fetch(`${API_BASE_URL}/community/posts?${params.toString()}`, {
+      cache: 'no-store',
+    })
+
+    if (!res.ok) return null
+
+    const json = await res.json()
+    return json.data
+  } catch {
+    return null
+  }
+}
+
+export async function fetchInitialInfoCommunity(
+  page: number = 0,
+  size: number = 10,
+  searchType?: string | null,
+  keyword?: string | null,
+  sortBy?: string | null
+): Promise<CommunityListData | null> {
+  try {
+    const params = new URLSearchParams({
+      page: page.toString(),
+      size: size.toString(),
+      boardType: 'INFO',
+    })
+    if (searchType) params.append('searchType', searchType)
+    if (keyword) params.append('keyword', keyword)
+    if (sortBy) params.append('sortBy', sortBy)
+
+    const res = await fetch(`${API_BASE_URL}/community/posts?${params.toString()}`, {
+      cache: 'no-store',
+    })
+
+    if (!res.ok) return null
+
+    const json = await res.json()
+    return json.data
+  } catch {
+    return null
+  }
+}
+
+export async function fetchCommunityDetail(postId: string): Promise<CommunityDetailItem | null> {
+  try {
+    const res = await fetch(`${API_BASE_URL}/community/posts/${postId}`, {
+      cache: 'no-store',
+    })
+
+    if (!res.ok) return null
+
+    const json = await res.json()
+    return json.data
+  } catch {
+    return null
+  }
+}
+
+export async function fetchCommunityComments(postId: string): Promise<{ comments: Comment[] } | null> {
+  try {
+    const res = await fetch(`${API_BASE_URL}/community/posts/${postId}/comments`, {
+      cache: 'no-store',
+    })
+
+    if (!res.ok) return null
+
+    const json = await res.json()
+    return json.data
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## 📌 개요

- 커뮤니티 목록/상세 페이지를 CSR에서 SSR로 전환하여 초기 로딩 속도 개선

## 🔧 작업 내용

- [x] `src/lib/api/server/community.ts` 서버용 fetch 함수 4개 생성 (cache: 'no-store')
- [x] `/community` 목록 페이지: async 서버 컴포넌트 전환 + searchParams 기반 초기 데이터 fetch
- [x] `/community/[id]` 상세 페이지: async 서버 컴포넌트 전환 + 게시글/댓글 초기 데이터 fetch
- [x] `CommunityPage`, `CommunityDetail` 클라이언트 컴포넌트에 initialData props 추가

## 📎 관련 이슈

Closes #304

## 💬 리뷰어 참고 사항

- 기존 SSR 패턴(`src/lib/api/server/products.ts` + `products/[id]/page.tsx`)을 동일하게 따름
- ISR/SEO는 추후 별도 작업 예정이므로 `cache: 'no-store'` 사용
- 탭 전환, 검색, 정렬, 더보기 등 기존 클라이언트 기능은 변경 없음