### PR TITLE
chore: SSR 페이지 SEO 메타데이터 추가(#306)

### DIFF
--- a/src/app/(main)/community/[id]/page.tsx
+++ b/src/app/(main)/community/[id]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next'
 import { Suspense } from 'react'
 import { notFound } from 'next/navigation'
 import CommunityDetail from '@/features/community/CommunityDetail'
@@ -6,6 +7,37 @@ import { fetchCommunityDetail, fetchCommunityComments } from '@/lib/api/server/c
 
 interface CommunityDetailPageProps {
   params: Promise<{ id: string }>
+}
+
+export async function generateMetadata({ params }: CommunityDetailPageProps): Promise<Metadata> {
+  const { id } = await params
+  const post = await fetchCommunityDetail(id)
+
+  if (!post) {
+    return { title: '게시글을 찾을 수 없습니다 | 커들마켓' }
+  }
+
+  const title = `${post.title} | 커들마켓 커뮤니티`
+  const description = post.contentPreview?.slice(0, 155) || '커들마켓 커뮤니티에서 확인해보세요'
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      url: `https://cuddle-market.vercel.app/community/${id}`,
+      siteName: '커들마켓',
+      images: post.imageUrls?.[0] ? [{ url: post.imageUrls[0] }] : [{ url: '/og-image.png' }],
+      type: 'article',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: post.imageUrls?.[0] ? [post.imageUrls[0]] : ['/og-image.png'],
+    },
+  }
 }
 
 export default async function CommunityDetailPage({ params }: CommunityDetailPageProps) {

--- a/src/app/(main)/community/page.tsx
+++ b/src/app/(main)/community/page.tsx
@@ -1,7 +1,27 @@
+import type { Metadata } from 'next'
 import { Suspense } from 'react'
 import CommunityPage from '@/features/community/CommunityPage'
 import CommunityListSkeleton from '@/features/community/components/CommunityListSkeleton'
 import { fetchInitialQuestionCommunity, fetchInitialInfoCommunity } from '@/lib/api/server/community'
+
+export const metadata: Metadata = {
+  title: '커뮤니티 | 커들마켓',
+  description: '반려동물 관련 질문과 유용한 정보를 나눠보세요',
+  openGraph: {
+    title: '커뮤니티 | 커들마켓',
+    description: '반려동물 관련 질문과 유용한 정보를 나눠보세요',
+    url: 'https://cuddle-market.vercel.app/community',
+    siteName: '커들마켓',
+    images: [{ url: '/og-image.png', width: 1200, height: 630 }],
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: '커뮤니티 | 커들마켓',
+    description: '반려동물 관련 질문과 유용한 정보를 나눠보세요',
+    images: ['/og-image.png'],
+  },
+}
 
 interface CommunityRouteProps {
   searchParams: Promise<{

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,8 +1,28 @@
+import type { Metadata } from 'next'
 import { Suspense } from 'react'
 import Home from '@/features/home/Home'
 import StaticHomeFallback from '@/features/home/components/StaticHomeFallback'
 import { fetchInitialProducts } from '@/lib/api/server/products'
 import { getImageSrcSet, IMAGE_SIZES } from '@/lib/utils/imageUrl'
+
+export const metadata: Metadata = {
+  title: '커들마켓 | 반려동물 용품 중고거래',
+  description: '반려동물 용품을 사고팔 수 있는 따뜻한 중고거래 플랫폼, 커들마켓',
+  openGraph: {
+    title: '커들마켓 | 반려동물 용품 중고거래',
+    description: '반려동물 용품을 사고팔 수 있는 따뜻한 중고거래 플랫폼, 커들마켓',
+    url: 'https://cuddle-market.vercel.app',
+    siteName: '커들마켓',
+    images: [{ url: '/og-image.png', width: 1200, height: 630 }],
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: '커들마켓 | 반려동물 용품 중고거래',
+    description: '반려동물 용품을 사고팔 수 있는 따뜻한 중고거래 플랫폼, 커들마켓',
+    images: ['/og-image.png'],
+  },
+}
 
 export default async function HomePage() {
   const initialData = await fetchInitialProducts()

--- a/src/app/(main)/products/[id]/page.tsx
+++ b/src/app/(main)/products/[id]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next'
 import { Suspense } from 'react'
 import { notFound } from 'next/navigation'
 import ProductDetail from '@/features/product-detail/ProductDetail'
@@ -5,6 +6,37 @@ import { fetchProductDetail } from '@/lib/api/server/products'
 
 interface ProductDetailPageProps {
   params: Promise<{ id: string }>
+}
+
+export async function generateMetadata({ params }: ProductDetailPageProps): Promise<Metadata> {
+  const { id } = await params
+  const product = await fetchProductDetail(id)
+
+  if (!product) {
+    return { title: '상품을 찾을 수 없습니다 | 커들마켓' }
+  }
+
+  const title = `${product.title} | 커들마켓`
+  const description = product.description?.slice(0, 155) || '커들마켓에서 반려동물 용품을 만나보세요'
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      url: `https://cuddle-market.vercel.app/products/${id}`,
+      siteName: '커들마켓',
+      images: product.mainImageUrl ? [{ url: product.mainImageUrl }] : [{ url: '/og-image.png' }],
+      type: 'article',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: product.mainImageUrl ? [product.mainImageUrl] : ['/og-image.png'],
+    },
+  }
 }
 
 export default async function ProductDetailPage({ params }: ProductDetailPageProps) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import ClientComponents from '@/components/ClientComponents'
 import './globals.css'
 
 export const metadata: Metadata = {
+  metadataBase: new URL('https://cuddle-market.vercel.app'),
   title: '커들마켓',
   description: '반려동물 용품을 사고팔 수 있는 커들마켓',
 }


### PR DESCRIPTION
## 📌 개요

- SSR이 적용된 4개 페이지에 OpenGraph/Twitter Card 메타데이터를 추가하여 SNS 공유 시 제목·설명·이미지가 올바르게 표시되도록 개선

## 🔧 작업 내용

- [x] 루트 `layout.tsx`에 `metadataBase` 설정 (`https://cuddle-market.vercel.app`)
- [x] `/` 홈페이지 - 정적 metadata (OG + Twitter Card)
- [x] `/products/[id]` 상품 상세 - `generateMetadata` (상품 제목/설명/이미지 동적 생성)
- [x] `/community` 커뮤니티 목록 - 정적 metadata (OG + Twitter Card)
- [x] `/community/[id]` 게시글 상세 - `generateMetadata` (게시글 제목/미리보기/이미지 동적 생성)

## 📎 관련 이슈

Closes #306

## 💬 리뷰어 참고 사항

- 정적 페이지(`/`, `/community`)는 `export const metadata`로, 동적 페이지(`/products/[id]`, `/community/[id]`)는 `generateMetadata` 함수로 구현
- Next.js의 Request Deduplication 덕분에 `generateMetadata`와 페이지 컴포넌트에서 같은 fetch를 호출해도 API가 중복 호출되지 않음
- 이미지가 없는 경우 기본 `og-image.png`로 fallback