### PR TITLE
refactor: Canonical URL 및 JSON-LD 구조화 데이터 추가(#310)

### DIFF
--- a/src/app/(main)/community/[id]/page.tsx
+++ b/src/app/(main)/community/[id]/page.tsx
@@ -23,6 +23,9 @@ export async function generateMetadata({ params }: CommunityDetailPageProps): Pr
   return {
     title,
     description,
+    alternates: {
+      canonical: `/community/${id}`,
+    },
     openGraph: {
       title,
       description,
@@ -51,9 +54,35 @@ export default async function CommunityDetailPage({ params }: CommunityDetailPag
     notFound()
   }
 
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: initialPostData.title,
+    description: initialPostData.contentPreview || '',
+    image: initialPostData.imageUrls,
+    author: {
+      '@type': 'Person',
+      name: initialPostData.authorNickname,
+    },
+    datePublished: initialPostData.createdAt,
+    dateModified: initialPostData.updatedAt,
+    articleSection: initialPostData.boardType === 'QUESTION' ? '질문' : '정보',
+    publisher: {
+      '@type': 'Organization',
+      name: '커들마켓',
+      url: 'https://cuddle-market.vercel.app',
+    },
+  }
+
   return (
-    <Suspense fallback={<CommunityDetailSkeleton />}>
-      <CommunityDetail initialPostData={initialPostData} initialCommentData={initialCommentData} />
-    </Suspense>
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <Suspense fallback={<CommunityDetailSkeleton />}>
+        <CommunityDetail initialPostData={initialPostData} initialCommentData={initialCommentData} />
+      </Suspense>
+    </>
   )
 }

--- a/src/app/(main)/community/page.tsx
+++ b/src/app/(main)/community/page.tsx
@@ -7,6 +7,9 @@ import { fetchInitialQuestionCommunity, fetchInitialInfoCommunity } from '@/lib/
 export const metadata: Metadata = {
   title: '커뮤니티 | 커들마켓',
   description: '반려동물 관련 질문과 유용한 정보를 나눠보세요',
+  alternates: {
+    canonical: '/community',
+  },
   openGraph: {
     title: '커뮤니티 | 커들마켓',
     description: '반려동물 관련 질문과 유용한 정보를 나눠보세요',

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -8,6 +8,9 @@ import { getImageSrcSet, IMAGE_SIZES } from '@/lib/utils/imageUrl'
 export const metadata: Metadata = {
   title: '커들마켓 | 반려동물 용품 중고거래',
   description: '반려동물 용품을 사고팔 수 있는 따뜻한 중고거래 플랫폼, 커들마켓',
+  alternates: {
+    canonical: '/',
+  },
   openGraph: {
     title: '커들마켓 | 반려동물 용품 중고거래',
     description: '반려동물 용품을 사고팔 수 있는 따뜻한 중고거래 플랫폼, 커들마켓',

--- a/src/app/(main)/products/[id]/page.tsx
+++ b/src/app/(main)/products/[id]/page.tsx
@@ -22,6 +22,9 @@ export async function generateMetadata({ params }: ProductDetailPageProps): Prom
   return {
     title,
     description,
+    alternates: {
+      canonical: `/products/${id}`,
+    },
     openGraph: {
       title,
       description,
@@ -47,9 +50,43 @@ export default async function ProductDetailPage({ params }: ProductDetailPagePro
     notFound()
   }
 
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Product',
+    name: initialData.title,
+    description: initialData.description,
+    image: [initialData.mainImageUrl, ...(initialData.subImageUrls ?? [])],
+    offers: {
+      '@type': 'Offer',
+      price: initialData.price,
+      priceCurrency: 'KRW',
+      availability:
+        initialData.tradeStatus === 'SELLING'
+          ? 'https://schema.org/InStock'
+          : initialData.tradeStatus === 'RESERVED'
+            ? 'https://schema.org/LimitedAvailability'
+            : 'https://schema.org/SoldOut',
+      itemCondition:
+        initialData.productStatus === 'NEW'
+          ? 'https://schema.org/NewCondition'
+          : 'https://schema.org/UsedCondition',
+      url: `https://cuddle-market.vercel.app/products/${id}`,
+      seller: {
+        '@type': 'Person',
+        name: initialData.sellerInfo.sellerNickname,
+      },
+    },
+  }
+
   return (
-    <Suspense fallback={null}>
-      <ProductDetail initialData={initialData} />
-    </Suspense>
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <Suspense fallback={null}>
+        <ProductDetail initialData={initialData} />
+      </Suspense>
+    </>
   )
 }


### PR DESCRIPTION
## 📌 개요

- SEO 개선을 위해 4개 SSR 페이지에 Canonical URL을 추가하고, 상세 페이지에 JSON-LD 구조화 데이터를 적용합니다.

## 🔧 작업 내용

- [x] 4개 페이지에 `alternates.canonical` 추가 (홈, 커뮤니티 목록, 상품 상세, 커뮤니티 상세)
- [x] 상품 상세 페이지에 Product 스키마 JSON-LD 추가 (가격, 판매 상태, 상품 상태, 판매자 정보)
- [x] 커뮤니티 상세 페이지에 Article 스키마 JSON-LD 추가 (작성자, 작성일, 카테고리)
- [x] 시맨틱 HTML(h1) 확인 — 이미 올바르게 구현되어 있어 변경 불필요

## 📎 관련 이슈

Closes #310

## 💬 리뷰어 참고 사항

- Canonical URL은 `metadataBase`가 root layout에 설정되어 있으므로 상대 경로(`/`, `/community` 등)로 작성했습니다.
- JSON-LD는 서버 컴포넌트에서 `<script type="application/ld+json">`으로 렌더링되어 크롤러가 즉시 파싱 가능합니다.
- Google Rich Results Test(https://search.google.com/test/rich-results)로 유효성 검증 가능합니다.