### PR TITLE
refactor: Google Search Console 인증 메타 태그 추가(#312)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,9 @@ export const metadata: Metadata = {
   metadataBase: new URL('https://cuddle-market.vercel.app'),
   title: '커들마켓',
   description: '반려동물 용품을 사고팔 수 있는 커들마켓',
+  verification: {
+    google: 'QwSeEYXUKCcLgTD8CtBEEpERKpp34sHBD_6r8dvKM2Q',
+  },
 }
 
 export default function RootLayout({


### PR DESCRIPTION
## 📌 개요

- Google Search Console 소유권 인증을 위해 `verification.google` 메타 태그를 추가합니다.

## 🔧 작업 내용

- [x] `src/app/layout.tsx`에 `verification.google` 메타 태그 추가

## 📎 관련 이슈

Closes #312

## 💬 리뷰어 참고 사항

- Next.js Metadata API의 `verification.google`을 사용하여 `<meta name="google-site-verification">` 태그가 자동 생성됩니다.
- Search Console 등록 후 sitemap 제출 및 검색 데이터 모니터링이 가능합니다.