### PR TITLE
refactor: SEO 친화적 URL 패턴 적용(#314)

### DIFF
--- a/src/app/(main)/community/[id]/[name]/page.tsx
+++ b/src/app/(main)/community/[id]/[name]/page.tsx
@@ -1,0 +1,95 @@
+import type { Metadata } from 'next'
+import { Suspense } from 'react'
+import { notFound, redirect } from 'next/navigation'
+import CommunityDetail from '@/features/community/CommunityDetail'
+import CommunityDetailSkeleton from '@/features/community/components/CommunityDetailSkeleton'
+import { fetchCommunityDetail, fetchCommunityComments } from '@/lib/api/server/community'
+import { toUrlName } from '@/lib/utils/toUrlName'
+
+interface CommunityDetailPageProps {
+  params: Promise<{ id: string; name: string }>
+}
+
+export async function generateMetadata({ params }: CommunityDetailPageProps): Promise<Metadata> {
+  const { id } = await params
+  const post = await fetchCommunityDetail(id)
+
+  if (!post) {
+    return { title: '게시글을 찾을 수 없습니다 | 커들마켓' }
+  }
+
+  const name = toUrlName(post.title)
+  const title = `${post.title} | 커들마켓 커뮤니티`
+  const description = post.contentPreview?.slice(0, 155) || '커들마켓 커뮤니티에서 확인해보세요'
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: `/community/${id}/${name}`,
+    },
+    openGraph: {
+      title,
+      description,
+      url: `https://cuddle-market.vercel.app/community/${id}/${name}`,
+      siteName: '커들마켓',
+      images: post.imageUrls?.[0] ? [{ url: post.imageUrls[0] }] : [{ url: '/og-image.png' }],
+      type: 'article',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: post.imageUrls?.[0] ? [post.imageUrls[0]] : ['/og-image.png'],
+    },
+  }
+}
+
+export default async function CommunityDetailPage({ params }: CommunityDetailPageProps) {
+  const { id, name } = await params
+  const [initialPostData, initialCommentData] = await Promise.all([
+    fetchCommunityDetail(id),
+    fetchCommunityComments(id),
+  ])
+
+  if (!initialPostData) {
+    notFound()
+  }
+
+  const correctName = toUrlName(initialPostData.title)
+  if (decodeURIComponent(name) !== correctName) {
+    redirect(`/community/${id}/${correctName}`)
+  }
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: initialPostData.title,
+    description: initialPostData.contentPreview || '',
+    image: initialPostData.imageUrls,
+    author: {
+      '@type': 'Person',
+      name: initialPostData.authorNickname,
+    },
+    datePublished: initialPostData.createdAt,
+    dateModified: initialPostData.updatedAt,
+    articleSection: initialPostData.boardType === 'QUESTION' ? '질문' : '정보',
+    publisher: {
+      '@type': 'Organization',
+      name: '커들마켓',
+      url: 'https://cuddle-market.vercel.app',
+    },
+  }
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <Suspense fallback={<CommunityDetailSkeleton />}>
+        <CommunityDetail initialPostData={initialPostData} initialCommentData={initialCommentData} />
+      </Suspense>
+    </>
+  )
+}

--- a/src/app/(main)/community/[id]/page.tsx
+++ b/src/app/(main)/community/[id]/page.tsx
@@ -1,88 +1,18 @@
-import type { Metadata } from 'next'
-import { Suspense } from 'react'
-import { notFound } from 'next/navigation'
-import CommunityDetail from '@/features/community/CommunityDetail'
-import CommunityDetailSkeleton from '@/features/community/components/CommunityDetailSkeleton'
-import { fetchCommunityDetail, fetchCommunityComments } from '@/lib/api/server/community'
+import { notFound, redirect } from 'next/navigation'
+import { fetchCommunityDetail } from '@/lib/api/server/community'
+import { toUrlName } from '@/lib/utils/toUrlName'
 
-interface CommunityDetailPageProps {
+interface CommunityRedirectPageProps {
   params: Promise<{ id: string }>
 }
 
-export async function generateMetadata({ params }: CommunityDetailPageProps): Promise<Metadata> {
+export default async function CommunityRedirectPage({ params }: CommunityRedirectPageProps) {
   const { id } = await params
   const post = await fetchCommunityDetail(id)
 
   if (!post) {
-    return { title: '게시글을 찾을 수 없습니다 | 커들마켓' }
-  }
-
-  const title = `${post.title} | 커들마켓 커뮤니티`
-  const description = post.contentPreview?.slice(0, 155) || '커들마켓 커뮤니티에서 확인해보세요'
-
-  return {
-    title,
-    description,
-    alternates: {
-      canonical: `/community/${id}`,
-    },
-    openGraph: {
-      title,
-      description,
-      url: `https://cuddle-market.vercel.app/community/${id}`,
-      siteName: '커들마켓',
-      images: post.imageUrls?.[0] ? [{ url: post.imageUrls[0] }] : [{ url: '/og-image.png' }],
-      type: 'article',
-    },
-    twitter: {
-      card: 'summary_large_image',
-      title,
-      description,
-      images: post.imageUrls?.[0] ? [post.imageUrls[0]] : ['/og-image.png'],
-    },
-  }
-}
-
-export default async function CommunityDetailPage({ params }: CommunityDetailPageProps) {
-  const { id } = await params
-  const [initialPostData, initialCommentData] = await Promise.all([
-    fetchCommunityDetail(id),
-    fetchCommunityComments(id),
-  ])
-
-  if (!initialPostData) {
     notFound()
   }
 
-  const jsonLd = {
-    '@context': 'https://schema.org',
-    '@type': 'Article',
-    headline: initialPostData.title,
-    description: initialPostData.contentPreview || '',
-    image: initialPostData.imageUrls,
-    author: {
-      '@type': 'Person',
-      name: initialPostData.authorNickname,
-    },
-    datePublished: initialPostData.createdAt,
-    dateModified: initialPostData.updatedAt,
-    articleSection: initialPostData.boardType === 'QUESTION' ? '질문' : '정보',
-    publisher: {
-      '@type': 'Organization',
-      name: '커들마켓',
-      url: 'https://cuddle-market.vercel.app',
-    },
-  }
-
-  return (
-    <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-      />
-      <Suspense fallback={<CommunityDetailSkeleton />}>
-        <CommunityDetail initialPostData={initialPostData} initialCommentData={initialCommentData} />
-      </Suspense>
-    </>
-  )
+  redirect(`/community/${id}/${toUrlName(post.title)}`)
 }

--- a/src/app/(main)/products/[id]/[name]/page.tsx
+++ b/src/app/(main)/products/[id]/[name]/page.tsx
@@ -1,0 +1,99 @@
+import type { Metadata } from 'next'
+import { Suspense } from 'react'
+import { notFound, redirect } from 'next/navigation'
+import ProductDetail from '@/features/product-detail/ProductDetail'
+import { fetchProductDetail } from '@/lib/api/server/products'
+import { toUrlName } from '@/lib/utils/toUrlName'
+
+interface ProductDetailPageProps {
+  params: Promise<{ id: string; name: string }>
+}
+
+export async function generateMetadata({ params }: ProductDetailPageProps): Promise<Metadata> {
+  const { id } = await params
+  const product = await fetchProductDetail(id)
+
+  if (!product) {
+    return { title: '상품을 찾을 수 없습니다 | 커들마켓' }
+  }
+
+  const name = toUrlName(product.title)
+  const title = `${product.title} | 커들마켓`
+  const description = product.description?.slice(0, 155) || '커들마켓에서 반려동물 용품을 만나보세요'
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: `/products/${id}/${name}`,
+    },
+    openGraph: {
+      title,
+      description,
+      url: `https://cuddle-market.vercel.app/products/${id}/${name}`,
+      siteName: '커들마켓',
+      images: product.mainImageUrl ? [{ url: product.mainImageUrl }] : [{ url: '/og-image.png' }],
+      type: 'article',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: product.mainImageUrl ? [product.mainImageUrl] : ['/og-image.png'],
+    },
+  }
+}
+
+export default async function ProductDetailPage({ params }: ProductDetailPageProps) {
+  const { id, name } = await params
+  const initialData = await fetchProductDetail(id)
+
+  if (!initialData) {
+    notFound()
+  }
+
+  const correctName = toUrlName(initialData.title)
+  if (decodeURIComponent(name) !== correctName) {
+    redirect(`/products/${id}/${correctName}`)
+  }
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Product',
+    name: initialData.title,
+    description: initialData.description,
+    image: [initialData.mainImageUrl, ...(initialData.subImageUrls ?? [])],
+    offers: {
+      '@type': 'Offer',
+      price: initialData.price,
+      priceCurrency: 'KRW',
+      availability:
+        initialData.tradeStatus === 'SELLING'
+          ? 'https://schema.org/InStock'
+          : initialData.tradeStatus === 'RESERVED'
+            ? 'https://schema.org/LimitedAvailability'
+            : 'https://schema.org/SoldOut',
+      itemCondition:
+        initialData.productStatus === 'NEW'
+          ? 'https://schema.org/NewCondition'
+          : 'https://schema.org/UsedCondition',
+      url: `https://cuddle-market.vercel.app/products/${id}/${correctName}`,
+      seller: {
+        '@type': 'Person',
+        name: initialData.sellerInfo.sellerNickname,
+      },
+    },
+  }
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <Suspense fallback={null}>
+        <ProductDetail initialData={initialData} />
+      </Suspense>
+    </>
+  )
+}

--- a/src/app/(main)/products/[id]/page.tsx
+++ b/src/app/(main)/products/[id]/page.tsx
@@ -1,92 +1,18 @@
-import type { Metadata } from 'next'
-import { Suspense } from 'react'
-import { notFound } from 'next/navigation'
-import ProductDetail from '@/features/product-detail/ProductDetail'
+import { notFound, redirect } from 'next/navigation'
 import { fetchProductDetail } from '@/lib/api/server/products'
+import { toUrlName } from '@/lib/utils/toUrlName'
 
-interface ProductDetailPageProps {
+interface ProductRedirectPageProps {
   params: Promise<{ id: string }>
 }
 
-export async function generateMetadata({ params }: ProductDetailPageProps): Promise<Metadata> {
+export default async function ProductRedirectPage({ params }: ProductRedirectPageProps) {
   const { id } = await params
   const product = await fetchProductDetail(id)
 
   if (!product) {
-    return { title: '상품을 찾을 수 없습니다 | 커들마켓' }
-  }
-
-  const title = `${product.title} | 커들마켓`
-  const description = product.description?.slice(0, 155) || '커들마켓에서 반려동물 용품을 만나보세요'
-
-  return {
-    title,
-    description,
-    alternates: {
-      canonical: `/products/${id}`,
-    },
-    openGraph: {
-      title,
-      description,
-      url: `https://cuddle-market.vercel.app/products/${id}`,
-      siteName: '커들마켓',
-      images: product.mainImageUrl ? [{ url: product.mainImageUrl }] : [{ url: '/og-image.png' }],
-      type: 'article',
-    },
-    twitter: {
-      card: 'summary_large_image',
-      title,
-      description,
-      images: product.mainImageUrl ? [product.mainImageUrl] : ['/og-image.png'],
-    },
-  }
-}
-
-export default async function ProductDetailPage({ params }: ProductDetailPageProps) {
-  const { id } = await params
-  const initialData = await fetchProductDetail(id)
-
-  if (!initialData) {
     notFound()
   }
 
-  const jsonLd = {
-    '@context': 'https://schema.org',
-    '@type': 'Product',
-    name: initialData.title,
-    description: initialData.description,
-    image: [initialData.mainImageUrl, ...(initialData.subImageUrls ?? [])],
-    offers: {
-      '@type': 'Offer',
-      price: initialData.price,
-      priceCurrency: 'KRW',
-      availability:
-        initialData.tradeStatus === 'SELLING'
-          ? 'https://schema.org/InStock'
-          : initialData.tradeStatus === 'RESERVED'
-            ? 'https://schema.org/LimitedAvailability'
-            : 'https://schema.org/SoldOut',
-      itemCondition:
-        initialData.productStatus === 'NEW'
-          ? 'https://schema.org/NewCondition'
-          : 'https://schema.org/UsedCondition',
-      url: `https://cuddle-market.vercel.app/products/${id}`,
-      seller: {
-        '@type': 'Person',
-        name: initialData.sellerInfo.sellerNickname,
-      },
-    },
-  }
-
-  return (
-    <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-      />
-      <Suspense fallback={null}>
-        <ProductDetail initialData={initialData} />
-      </Suspense>
-    </>
-  )
+  redirect(`/products/${id}/${toUrlName(product.title)}`)
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,4 +1,5 @@
 import type { MetadataRoute } from 'next'
+import { toUrlName } from '@/lib/utils/toUrlName'
 
 const SITE_URL = 'https://cuddle-market.vercel.app'
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL
@@ -18,20 +19,20 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   ]
 
   const [products, questionPosts, infoPosts] = await Promise.all([
-    fetchAllProducts(),
-    fetchAllCommunityPosts('QUESTION'),
-    fetchAllCommunityPosts('INFO'),
+    fetchProductSitemapEntries(),
+    fetchCommunitySitemapEntries('QUESTION'),
+    fetchCommunitySitemapEntries('INFO'),
   ])
 
   const productPages: MetadataRoute.Sitemap = products.map((product) => ({
-    url: `${SITE_URL}/products/${product.id}`,
+    url: `${SITE_URL}/products/${product.id}/${toUrlName(product.title)}`,
     lastModified: product.createdAt,
     changeFrequency: 'weekly',
     priority: 0.7,
   }))
 
   const communityPages: MetadataRoute.Sitemap = [...questionPosts, ...infoPosts].map((post) => ({
-    url: `${SITE_URL}/community/${post.id}`,
+    url: `${SITE_URL}/community/${post.id}/${toUrlName(post.title)}`,
     lastModified: post.updatedAt || post.createdAt,
     changeFrequency: 'weekly',
     priority: 0.6,
@@ -40,7 +41,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   return [...staticPages, ...productPages, ...communityPages]
 }
 
-async function fetchAllProducts(): Promise<{ id: number; createdAt: string }[]> {
+async function fetchProductSitemapEntries(): Promise<{ id: number; title: string; createdAt: string }[]> {
   try {
     const res = await fetch(`${API_BASE_URL}/products/search?page=0&size=1000`, {
       next: { revalidate: 3600 },
@@ -53,9 +54,9 @@ async function fetchAllProducts(): Promise<{ id: number; createdAt: string }[]> 
   }
 }
 
-async function fetchAllCommunityPosts(
+async function fetchCommunitySitemapEntries(
   boardType: string
-): Promise<{ id: number; createdAt: string; updatedAt: string }[]> {
+): Promise<{ id: number; title: string; createdAt: string; updatedAt: string }[]> {
   try {
     const res = await fetch(`${API_BASE_URL}/community/posts?boardType=${boardType}&page=0&size=1000`, {
       next: { revalidate: 3600 },

--- a/src/components/product/ProductCard.tsx
+++ b/src/components/product/ProductCard.tsx
@@ -42,7 +42,7 @@ function ProductCard({ data, 'data-index': dataIndex }: ProductCardProps) {
       data-index={dataIndex}
     >
       <Link
-        href={ROUTES.DETAIL_ID(id)}
+        href={ROUTES.DETAIL_ID(id, title)}
         className="absolute inset-0 z-0"
         aria-label={`${title}, ${price}원, ${productStatusName}, ${petTypeName}, ${productTradeName}`}
         onClick={handleCardClick}

--- a/src/components/product/ProductListItem.tsx
+++ b/src/components/product/ProductListItem.tsx
@@ -25,7 +25,7 @@ export function ProductListItem({ product, children }: ProductListItemProps) {
   const isMd = useMediaQuery('(min-width: 768px)')
   return (
     <li id={id.toString()} className="w-full">
-      <Link href={ROUTES.DETAIL_ID(id)} className="flex w-full items-center justify-center gap-6 rounded-lg border border-gray-300 p-3.5">
+      <Link href={ROUTES.DETAIL_ID(id, title)} className="flex w-full items-center justify-center gap-6 rounded-lg border border-gray-300 p-3.5">
         <div className="relative aspect-square w-32 shrink-0 overflow-hidden rounded-lg md:static md:w-[10%]">
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -1,15 +1,19 @@
+import { toUrlName } from '@/lib/utils/toUrlName'
+
 export const ROUTES = {
   HOME: '/',
   MYPAGE: '/mypage',
   DETAIL: `/products/:id`,
-  DETAIL_ID: (id: string | number) => `/products/${id}`,
+  DETAIL_ID: (id: string | number, name?: string) =>
+    name ? `/products/${id}/${toUrlName(name)}` : `/products/${id}`,
 
   // Community
   COMMUNITY: '/community',
   COMMUNITY_POST: '/community-post',
   COMMUNITY_EDIT: '/community/:id/edit',
   COMMUNITY_DETAIL: '/community/:id',
-  COMMUNITY_DETAIL_ID: (id: string | number) => `/community/${id}`,
+  COMMUNITY_DETAIL_ID: (id: string | number, name?: string) =>
+    name ? `/community/${id}/${toUrlName(name)}` : `/community/${id}`,
 
   // Product
   PRODUCT_POST: '/product-post',

--- a/src/features/chatting-page/components/ChatRoomInfo.tsx
+++ b/src/features/chatting-page/components/ChatRoomInfo.tsx
@@ -49,7 +49,7 @@ export function ChatRoomInfo({ data, onLeaveRoom, onBack }: ChatRoomInfoProps) {
         </Button>
       </div>
       <Link
-        href={ROUTES.DETAIL_ID(Number(data?.productId))}
+        href={ROUTES.DETAIL_ID(Number(data?.productId), data?.productTitle)}
         className="flex items-center gap-2 rounded-lg border border-gray-200 px-2.5 py-3 hover:bg-gray-50"
       >
         <ChatProductCard productImageUrl={data?.productImageUrl} productTitle={data?.productTitle} productPrice={data?.productPrice} size="md" />

--- a/src/features/community/CommunityPage.tsx
+++ b/src/features/community/CommunityPage.tsx
@@ -308,7 +308,7 @@ export default function CommunityPage({ initialQuestionData, initialInfoData }: 
                       key={post.id}
                       className="flex flex-col justify-center gap-2.5 rounded-lg border border-gray-400 bg-white px-3.5 pt-3.5 pb-3.5 shadow-xl"
                     >
-                      <Link href={ROUTES.COMMUNITY_DETAIL_ID(post.id)} className="flex flex-col gap-1">
+                      <Link href={ROUTES.COMMUNITY_DETAIL_ID(post.id, post.title)} className="flex flex-col gap-1">
                         <p className="font-semibold">{post.title}</p>
                         <div className="flex items-center gap-2.5">
                           <div className="flex items-center gap-1 text-gray-500">
@@ -336,7 +336,7 @@ export default function CommunityPage({ initialQuestionData, initialInfoData }: 
                       key={post.id}
                       className="flex flex-col justify-center gap-2.5 rounded-lg border border-gray-400 bg-white px-3.5 pt-3.5 pb-5 shadow-xl"
                     >
-                      <Link href={ROUTES.COMMUNITY_DETAIL_ID(post.id)} className="flex flex-col gap-4">
+                      <Link href={ROUTES.COMMUNITY_DETAIL_ID(post.id, post.title)} className="flex flex-col gap-4">
                         <div className="flex flex-col gap-2">
                           <p className="text-lg font-semibold">{post.title}</p>
 

--- a/src/features/home/components/StaticHomeFallback.tsx
+++ b/src/features/home/components/StaticHomeFallback.tsx
@@ -135,7 +135,7 @@ function StaticProductCard({ product, index }: { product: Product; index: number
     <Link
       className="border-border text-text-primary flex cursor-pointer flex-row-reverse overflow-hidden rounded-xl border bg-white shadow-md transition-shadow duration-200 hover:shadow-xl md:flex-col-reverse"
       aria-label={`${title}, ${price}원, ${productStatusName}, ${petTypeName}, ${productTradeName}`}
-      href={ROUTES.DETAIL_ID(id)}
+      href={ROUTES.DETAIL_ID(id, title)}
     >
       {/* ProductInfo */}
       <div className="flex h-full flex-1 flex-col justify-between gap-5 p-3 md:flex-none">

--- a/src/features/my-page/components/MyList.tsx
+++ b/src/features/my-page/components/MyList.tsx
@@ -132,7 +132,7 @@ export default function MyList({ id, title, price, mainImageUrl, tradeStatus, vi
   return (
     <li id={id.toString()} className="w-full pt-5 pb-5 md:p-0">
       <Link
-        href={ROUTES.DETAIL_ID(id)}
+        href={ROUTES.DETAIL_ID(id, title)}
         className="flex w-full items-start justify-center gap-3 rounded-lg border-gray-300 md:items-center md:justify-between md:gap-6 md:border md:p-3.5"
       >
         <div className="relative aspect-square w-32 shrink-0 overflow-hidden rounded-lg">

--- a/src/lib/utils/toUrlName.ts
+++ b/src/lib/utils/toUrlName.ts
@@ -1,0 +1,9 @@
+/**
+ * 제목에서 URL용 문자열을 생성한다.
+ * 예: "강아지 첫 용품 추천?" → "강아지첫용품추천"
+ */
+export function toUrlName(str: string): string {
+  return (str ?? '')
+    .replace(/[^\p{L}\p{N}]/gu, '') // 문자(한글/영문)와 숫자만 유지
+    .toLowerCase()
+}


### PR DESCRIPTION
## 📌 개요

- 상품/커뮤니티 상세 페이지 URL에 제목을 포함하여 SEO 향상
- `/products/123` → `/products/123/맥북프로16인치`
- `/community/456` → `/community/456/강아지첫용품추천`

## 🔧 작업 내용

- [x] `toUrlName` 유틸리티 함수 생성 (제목 → URL용 문자열 변환)
- [x] `products/[id]/[name]/page.tsx` 신규 생성 (Metadata, JSON-LD, name 자동 교정)
- [x] `community/[id]/[name]/page.tsx` 신규 생성 (동일 패턴)
- [x] 기존 `[id]/page.tsx`를 redirect 전용 페이지로 변경 (하위 호환)
- [x] `routes.ts`에 optional name 파라미터 추가
- [x] 링크 사용처 6곳 수정 (ProductCard, ProductListItem, StaticHomeFallback, MyList, CommunityPage, ChatRoomInfo)
- [x] Sitemap URL에 제목 반영 및 함수 네이밍 개선

## 📎 관련 이슈

Closes #314

## 💬 리뷰어 참고 사항

- `[id]`로 API 호출, `[name]`은 SEO 전용 (백엔드 변경 없음)
- 기존 URL(`/products/123`) 접속 시 자동 redirect로 하위 호환 보장
- URL의 `[name]`이 실제 제목과 다르면 올바른 URL로 자동 교정(redirect)
- `/products/[id]/edit`, `/community/[id]/edit` 등 정적 세그먼트는 동적 `[name]`보다 우선하므로 충돌 없음