### PR TITLE
feat: 홈 페이지 URL 필터 동기화(#319)

### DIFF
--- a/src/features/home/Home.tsx
+++ b/src/features/home/Home.tsx
@@ -51,7 +51,7 @@ function Home({ initialData }: HomeProps) {
       } else {
         params.delete('petType')
       }
-      router.push(`${pathname}?${params.toString()}`)
+      router.push(`${pathname}?${params.toString()}`, { scroll: false })
     },
     [searchParams, router, pathname]
   )
@@ -66,7 +66,7 @@ function Home({ initialData }: HomeProps) {
       } else {
         params.delete('productType')
       }
-      router.push(`${pathname}?${params.toString()}`)
+      router.push(`${pathname}?${params.toString()}`, { scroll: false })
     },
     [searchParams, router, pathname]
   )


### PR DESCRIPTION
## 📌 개요

- HTML 사이트맵 등 외부 링크에서 `?petType=MAMMAL&productType=SELL` 형태로 접근 시, 홈 페이지 탭이 해당 필터에 맞게 초기화되도록 수정합니다.

## 🔧 작업 내용

- [x] `petType` URL 파라미터를 읽어 반려동물 종류 탭 초기값 설정
- [x] `productType` URL 파라미터를 읽어 거래 유형 탭 초기값 설정
- [x] 파라미터가 없을 경우 기존 기본값(전체) 유지

## 📎 관련 이슈

Closes #319

## 💬 리뷰어 참고 사항

- `petDetailType`, `categories` 등 기존 URL 파라미터는 이미 `searchParams`에서 읽고 있었으나, `petType`과 `productType`만 탭 state로만 관리되어 URL 동기화가 누락되어 있었습니다.