### PR TITLE
fix: 필터 전환 시 전체 상품 목록 플리커 수정(#322)

### DIFF
--- a/src/features/home/Home.tsx
+++ b/src/features/home/Home.tsx
@@ -184,11 +184,20 @@ function Home({ initialData }: HomeProps) {
   })
 
   // 모든 페이지의 상품을 하나의 배열로 합치기
-  // SSR 시 useInfiniteQuery가 initialData를 즉시 반영하지 못하므로,
-  // query 데이터가 없을 때 initialData props에서 직접 가져옴
+  // SSR initialData는 최초 마운트 시에만 폴백으로 사용
+  // 필터 전환 중에는 빈 배열을 유지하여 전체 목록 플리커 방지
+  const hasActiveFilters =
+    activePetTypeTab !== 'pet-tab-all' ||
+    activeProductTypeTab !== 'tab-all' ||
+    selectedDetailPet ||
+    selectedCategory ||
+    selectedProductStatus ||
+    selectedProductPrice ||
+    selectedLocation ||
+    keyword
   const allProducts = data?.pages?.length
     ? data.pages.flatMap((page) => page.data.data.content)
-    : (initialData?.data?.data?.content ?? [])
+    : (!hasActiveFilters && initialData?.data?.data?.content) || []
 
   // 무한 스크롤 감지
   const targetRef = useIntersectionObserver({


### PR DESCRIPTION
## 📌 개요

- 필터 전환 시 전체 상품 목록이 잠깐 보였다가 필터링된 결과로 교체되는 플리커 현상을 수정합니다.

## 🔧 작업 내용

- [x] `allProducts` 폴백 로직 수정: 필터 활성화 상태에서는 SSR `initialData` 폴백 비활성화
- [x] 필터 없는 초기 상태에서만 SSR `initialData` 사용

## 📎 관련 이슈

Closes #322

## 💬 리뷰어 참고 사항

- 기존에 `data`가 비어있으면 무조건 `initialData`(전체 상품 목록)로 폴백하여, 필터 전환 중 전체 목록이 잠깐 노출되는 문제가 있었습니다.
- `hasActiveFilters` 플래그로 필터 활성 여부를 판단하여, 필터가 적용된 상태에서는 빈 배열을 반환하도록 변경했습니다.