### PR TITLE
fix: placeholderData로 인한 필터 전환 플리커 수정(#324)

### DIFF
--- a/src/features/home/Home.tsx
+++ b/src/features/home/Home.tsx
@@ -179,7 +179,6 @@ function Home({ initialData }: HomeProps) {
 
     initialPageParam: 0,
 
-    placeholderData: (previousData) => previousData,
     refetchOnMount: 'always',
   })
 


### PR DESCRIPTION
## 📌 개요

- 필터 전환 시 이전 쿼리의 전체 상품 목록이 잠깐 보이는 플리커 현상을 수정합니다.

## 🔧 작업 내용

- [x] `useInfiniteQuery`의 `placeholderData: (previousData) => previousData` 옵션 제거
- [x] 필터 전환 시 스켈레톤 → 결과 순서로 깔끔하게 표시

## 📎 관련 이슈

Closes #324

## 💬 리뷰어 참고 사항

- `placeholderData`는 queryKey 변경 시 이전 쿼리의 데이터를 placeholder로 표시하는 옵션입니다.
- 필터 전환 시 이전 필터의 결과(전체 목록)가 잠깐 보이는 원인이었습니다.
- 제거 후 필터 전환 시 `isLoading=true` → `HomeSkeleton` 표시 → API 응답 후 결과 표시로 변경됩니다.
- 무한스크롤에는 영향 없습니다 (다음 페이지 로딩 시 `isLoading`은 false).