### PR TITLE
refactor: 홈페이지 HydrationBoundary SSR 리팩터링(#326)

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,8 +1,10 @@
 import type { Metadata } from 'next'
 import { Suspense } from 'react'
+import { QueryClient, dehydrate, HydrationBoundary } from '@tanstack/react-query'
 import Home from '@/features/home/Home'
 import StaticHomeFallback from '@/features/home/components/StaticHomeFallback'
-import { fetchInitialProducts } from '@/lib/api/server/products'
+import { fetchProducts } from '@/lib/api/server/products'
+import { productListQueryKey, extractProductSearchParams } from '@/lib/queries/productQueryKeys'
 import { getImageSrcSet, IMAGE_SIZES } from '@/lib/utils/imageUrl'
 
 export const metadata: Metadata = {
@@ -27,8 +29,25 @@ export const metadata: Metadata = {
   },
 }
 
-export default async function HomePage() {
-  const initialData = await fetchInitialProducts()
+interface HomePageProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>>
+}
+
+export default async function HomePage({ searchParams }: HomePageProps) {
+  const resolvedParams = await searchParams
+  const filterParams = extractProductSearchParams(resolvedParams)
+  const queryKey = productListQueryKey(filterParams)
+
+  const queryClient = new QueryClient()
+
+  const initialData = await fetchProducts(filterParams)
+  if (initialData) {
+    queryClient.setQueryData(queryKey, {
+      pages: [initialData],
+      pageParams: [0],
+    })
+  }
+
   const products = initialData?.data?.data?.content ?? []
   const totalElements = initialData?.data?.data?.totalElements ?? 0
   const firstImageUrl = products[0]?.mainImageUrl
@@ -44,9 +63,11 @@ export default async function HomePage() {
           fetchPriority="high"
         />
       )}
-      <Suspense fallback={<StaticHomeFallback products={products} totalElements={totalElements} />}>
-        <Home initialData={initialData} />
-      </Suspense>
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <Suspense fallback={<StaticHomeFallback products={products} totalElements={totalElements} />}>
+          <Home />
+        </Suspense>
+      </HydrationBoundary>
     </>
   )
 }

--- a/src/features/home/Home.tsx
+++ b/src/features/home/Home.tsx
@@ -17,13 +17,9 @@ import { useUserStore } from '@/store/userStore'
 import { useMediaQuery } from '@/hooks/useMediaQuery'
 import { Z_INDEX } from '@/constants/ui'
 import HomeSkeleton from './components/product-section/HomeSkeleton'
-import { ProductResponse } from '@/types'
+import { productListQueryKey, extractProductSearchParams } from '@/lib/queries/productQueryKeys'
 
-interface HomeProps {
-  initialData: { data: ProductResponse; total: number } | null
-}
-
-function Home({ initialData }: HomeProps) {
+function Home() {
   const { isLogin } = useUserStore()
   const isLoggedIn = isLogin()
   const isMd = useMediaQuery('(min-width: 768px)')
@@ -31,7 +27,7 @@ function Home({ initialData }: HomeProps) {
   const router = useRouter()
   const pathname = usePathname()
 
-  // URL에서 탭 초기값 결정
+  // URL에서 탭 초기값 결정 (시각적 표시용)
   const urlPetType = searchParams.get('petType')
   const urlProductType = searchParams.get('productType')
   const initialPetTab = (urlPetType && PET_TYPE_TABS.find((tab) => tab.code === urlPetType)?.id) || 'pet-tab-all'
@@ -72,7 +68,6 @@ function Home({ initialData }: HomeProps) {
   )
 
   // URL에서 필터 값 직접 파싱 (Single Source of Truth)
-  const keyword = searchParams.get('keyword') || ''
   const sortBy = searchParams.get('sortBy')
   const sortOrder = searchParams.get('sortOrder')
   const selectedDetailPet = searchParams.get('petDetailType') || null
@@ -81,9 +76,6 @@ function Home({ initialData }: HomeProps) {
   const minPrice = searchParams.get('minPrice')
   const maxPrice = searchParams.get('maxPrice')
   const selectedProductPrice = minPrice ? { min: Number(minPrice), max: maxPrice ? Number(maxPrice) : null } : null
-  const addressSido = searchParams.get('addressSido') || ''
-  const addressGugun = searchParams.get('addressGugun') || ''
-  const selectedLocation = addressSido ? { sido: addressSido, gugun: addressGugun || null } : null
 
   const selectedSort = useMemo(() => {
     if (!sortBy) return '최신순'
@@ -123,47 +115,31 @@ function Home({ initialData }: HomeProps) {
     setIsDetailFilterOpen(isOpen)
   }, [])
 
+  // URL 파라미터 기반 쿼리 키 (서버 HydrationBoundary와 동일한 키)
+  const filterParams = useMemo(() => extractProductSearchParams(searchParams), [searchParams])
+  const queryKey = useMemo(() => productListQueryKey(filterParams), [filterParams])
+
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, error, refetch } = useInfiniteQuery({
-    queryKey: [
-      'products',
-      activeProductTypeTab,
-      selectedDetailPet,
-      selectedProductStatus,
-      selectedProductPrice,
-      selectedLocation,
-      selectedCategory,
-      activePetTypeTab,
-      keyword,
-      sortBy,
-      sortOrder,
-    ],
+    queryKey,
 
     queryFn: ({ pageParam = 0 }) => {
-      const productTypeCode = PRODUCT_TYPE_TABS.find((tab) => tab.id === activeProductTypeTab)?.code
-      const petTypeCode = PET_TYPE_TABS.find((tab) => tab.id === activePetTypeTab)?.code
-
-      // 'ALL'은 undefined로 변환 (API에 파라미터 전달하지 않음)
-      const productType = productTypeCode === 'ALL' ? undefined : productTypeCode
-      const petType = petTypeCode === 'ALL' ? undefined : petTypeCode
-
       return fetchAllProducts(
         pageParam,
         20,
-        productType,
-        selectedProductStatus,
-        selectedProductPrice?.min ?? null,
-        selectedProductPrice?.max ?? null,
-        selectedLocation?.sido ?? null,
-        selectedLocation?.gugun ?? null,
-        selectedCategory,
-        petType,
-        selectedDetailPet,
-        keyword,
-        sortBy,
-        sortOrder
+        filterParams.productType || undefined,
+        filterParams.productStatuses,
+        filterParams.minPrice ? Number(filterParams.minPrice) : null,
+        filterParams.maxPrice ? Number(filterParams.maxPrice) : null,
+        filterParams.addressSido,
+        filterParams.addressGugun,
+        filterParams.categories,
+        filterParams.petType || undefined,
+        filterParams.petDetailType,
+        filterParams.keyword,
+        filterParams.sortBy,
+        filterParams.sortOrder,
       )
     },
-    initialData: initialData ? { pages: [initialData], pageParams: [0] } : undefined,
 
     getNextPageParam: (lastPage) => {
       const currentPage = lastPage.data.data.page
@@ -179,25 +155,10 @@ function Home({ initialData }: HomeProps) {
 
     initialPageParam: 0,
 
-    placeholderData: (previousData) => previousData,
-    refetchOnMount: 'always',
+    staleTime: 60 * 1000,
   })
 
-  // 모든 페이지의 상품을 하나의 배열로 합치기
-  // SSR initialData는 최초 마운트 시에만 폴백으로 사용
-  // 필터 전환 중에는 빈 배열을 유지하여 전체 목록 플리커 방지
-  const hasActiveFilters =
-    activePetTypeTab !== 'pet-tab-all' ||
-    activeProductTypeTab !== 'tab-all' ||
-    selectedDetailPet ||
-    selectedCategory ||
-    selectedProductStatus ||
-    selectedProductPrice ||
-    selectedLocation ||
-    keyword
-  const allProducts = data?.pages?.length
-    ? data.pages.flatMap((page) => page.data.data.content)
-    : (!hasActiveFilters && initialData?.data?.data?.content) || []
+  const allProducts = data?.pages?.flatMap((page) => page.data.data.content) ?? []
 
   // 무한 스크롤 감지
   const targetRef = useIntersectionObserver({

--- a/src/lib/api/server/products.ts
+++ b/src/lib/api/server/products.ts
@@ -1,10 +1,29 @@
 import type { ProductDetailItem } from '@/types/product'
+import type { ProductSearchParams } from '@/lib/queries/productQueryKeys'
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL
 
-export async function fetchInitialProducts() {
+export async function fetchProducts(params: ProductSearchParams, page: number = 0, size: number = 20) {
   try {
-    const res = await fetch(`${API_BASE_URL}/products/search?page=0&size=20`, {
+    const urlParams = new URLSearchParams({
+      page: page.toString(),
+      size: size.toString(),
+    })
+
+    if (params.keyword) urlParams.append('keyword', params.keyword)
+    if (params.petType) urlParams.append('petType', params.petType)
+    if (params.petDetailType) urlParams.append('petDetailType', params.petDetailType)
+    if (params.productType) urlParams.append('productType', params.productType)
+    if (params.productStatuses) urlParams.append('productStatuses', params.productStatuses)
+    if (params.minPrice) urlParams.append('minPrice', params.minPrice)
+    if (params.maxPrice) urlParams.append('maxPrice', params.maxPrice)
+    if (params.addressSido) urlParams.append('addressSido', params.addressSido)
+    if (params.addressGugun) urlParams.append('addressGugun', params.addressGugun)
+    if (params.categories) urlParams.append('categories', params.categories)
+    if (params.sortBy) urlParams.append('sortBy', params.sortBy)
+    if (params.sortOrder) urlParams.append('sortOrder', params.sortOrder)
+
+    const res = await fetch(`${API_BASE_URL}/products/search?${urlParams.toString()}`, {
       next: { revalidate: 60 },
     })
 
@@ -18,6 +37,11 @@ export async function fetchInitialProducts() {
   } catch {
     return null
   }
+}
+
+/** @deprecated Use fetchProducts instead */
+export async function fetchInitialProducts() {
+  return fetchProducts({})
 }
 
 export async function fetchProductDetail(id: string): Promise<ProductDetailItem | null> {

--- a/src/lib/queries/productQueryKeys.ts
+++ b/src/lib/queries/productQueryKeys.ts
@@ -1,0 +1,68 @@
+export interface ProductSearchParams {
+  petType?: string | null
+  productType?: string | null
+  petDetailType?: string | null
+  categories?: string | null
+  productStatuses?: string | null
+  minPrice?: string | null
+  maxPrice?: string | null
+  addressSido?: string | null
+  addressGugun?: string | null
+  keyword?: string | null
+  sortBy?: string | null
+  sortOrder?: string | null
+}
+
+/**
+ * 서버(page.tsx)와 클라이언트(Home.tsx)에서 동일한 쿼리 키를 생성하는 공유 함수.
+ * 모든 값은 primitive (string | null) — 객체 없음, 탭 ID 없음.
+ * 배열 첫 요소 'products'로 기존 invalidateQueries 호환 유지.
+ */
+export function productListQueryKey(params: ProductSearchParams) {
+  return [
+    'products',
+    params.petType || null,
+    params.productType || null,
+    params.petDetailType || null,
+    params.categories || null,
+    params.productStatuses || null,
+    params.minPrice || null,
+    params.maxPrice || null,
+    params.addressSido || null,
+    params.addressGugun || null,
+    params.keyword || null,
+    params.sortBy || null,
+    params.sortOrder || null,
+  ] as const
+}
+
+/**
+ * URLSearchParams (클라이언트) 또는 plain object (서버 searchParams)에서
+ * ProductSearchParams를 추출하는 유틸리티.
+ */
+export function extractProductSearchParams(
+  searchParams: URLSearchParams | Record<string, string | string[] | undefined>
+): ProductSearchParams {
+  const get = (key: string): string | null => {
+    if (searchParams instanceof URLSearchParams) {
+      return searchParams.get(key)
+    }
+    const val = searchParams[key]
+    return typeof val === 'string' ? val : null
+  }
+
+  return {
+    petType: get('petType'),
+    productType: get('productType'),
+    petDetailType: get('petDetailType'),
+    categories: get('categories'),
+    productStatuses: get('productStatuses'),
+    minPrice: get('minPrice'),
+    maxPrice: get('maxPrice'),
+    addressSido: get('addressSido'),
+    addressGugun: get('addressGugun'),
+    keyword: get('keyword'),
+    sortBy: get('sortBy'),
+    sortOrder: get('sortOrder'),
+  }
+}


### PR DESCRIPTION
## 📌 개요

- 홈페이지 필터 전환 시 이전 데이터가 깜박이는(플리커) 문제 해결
- 서버에서 `searchParams` 기반으로 필터된 데이터를 prefetch하여 SSR의 이점을 제대로 활용
- SEO 개선: 각 필터 URL이 올바른 상품 데이터를 서버 HTML에 포함

## 🔧 작업 내용

- [x] `src/lib/queries/productQueryKeys.ts` 생성: 서버/클라이언트 공유 쿼리 키 빌더
- [x] `src/lib/api/server/products.ts` 수정: `fetchProducts(params)` - 모든 필터 파라미터 지원
- [x] `src/app/(main)/page.tsx` 수정: `searchParams` 읽기 + `HydrationBoundary` + `dehydrate`
- [x] `src/features/home/Home.tsx` 수정: URL 기반 쿼리 키, `initialData`/`placeholderData`/`refetchOnMount` 제거, `staleTime: 60s`

## 📎 관련 이슈

Closes #326

## 💬 리뷰어 참고 사항

- 쿼리 키가 기존 React state 기반(탭 ID, 객체)에서 URL 파라미터 기반(primitive string/null)으로 변경됨
- 탭 시각적 상태(`activePetTypeTab`, `activeProductTypeTab`)는 React state로 유지하되 쿼리 키에서는 제외 → 버튼 즉시 반응, 데이터는 서버 응답 시 전환
- `staleTime: 60s`는 서버의 `next: { revalidate: 60 }` ISR과 매칭