### PR TITLE
refactor: 홈페이지 필터 전환 클라이언트 네비게이션 최적화(#328)

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -6,6 +6,7 @@ import StaticHomeFallback from '@/features/home/components/StaticHomeFallback'
 import { fetchProducts } from '@/lib/api/server/products'
 import { productListQueryKey, extractProductSearchParams } from '@/lib/queries/productQueryKeys'
 import { getImageSrcSet, IMAGE_SIZES } from '@/lib/utils/imageUrl'
+import { FilterNavigationProvider } from '@/hooks/useFilterNavigation'
 
 export const metadata: Metadata = {
   title: '커들마켓 | 반려동물 용품 중고거래',
@@ -65,7 +66,9 @@ export default async function HomePage({ searchParams }: HomePageProps) {
       )}
       <HydrationBoundary state={dehydrate(queryClient)}>
         <Suspense fallback={<StaticHomeFallback products={products} totalElements={totalElements} />}>
-          <Home />
+          <FilterNavigationProvider>
+            <Home />
+          </FilterNavigationProvider>
         </Suspense>
       </HydrationBoundary>
     </>

--- a/src/components/product/ProductStateFilter.tsx
+++ b/src/components/product/ProductStateFilter.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react'
 import { CONDITION_ITEMS } from '@/constants/constants'
 import { cn } from '@/lib/utils/cn'
-import { useSearchParams, useRouter, usePathname } from 'next/navigation'
+import { useFilterNavigation } from '@/hooks/useFilterNavigation'
 import RequiredLabel from '@/components/commons/RequiredLabel'
 
 interface ProductStateFilterProps {
@@ -25,9 +25,7 @@ export function ProductStateFilter({
   onProductStatusChange,
   useUrlSync = false,
 }: ProductStateFilterProps) {
-  const searchParams = useSearchParams()
-  const router = useRouter()
-  const pathname = usePathname()
+  const { searchParams, pathname, push } = useFilterNavigation()
   const [internalSelectedStatus, setInternalSelectedStatus] = useState<string | null>(null)
 
   // 외부에서 전달된 값이 있으면 사용, 없으면 내부 state 사용
@@ -40,7 +38,7 @@ export function ProductStateFilter({
     if (useUrlSync) {
       const params = new URLSearchParams(searchParams.toString())
       params.set('productStatuses', value)
-      router.push(`${pathname}?${params.toString()}`)
+      push(`${pathname}?${params.toString()}`)
     }
 
     // 외부 콜백이 있으면 호출, 없으면 내부 state 업데이트

--- a/src/features/home/Home.tsx
+++ b/src/features/home/Home.tsx
@@ -10,7 +10,8 @@ import { useIntersectionObserver } from '@/hooks/useIntersectionObserver'
 import { PRODUCT_TYPE_TABS, PET_TYPE_TABS, type ProductTypeTabId, SORT_TYPE, type PetTypeTabId } from '@/constants/constants'
 import { PetTypeFilter } from './components/filter/PetTypeFilter'
 import { CategoryFilter } from './components/filter/CategoryFilter'
-import { useSearchParams, useRouter, usePathname } from 'next/navigation'
+import { useRouter } from 'next/navigation'
+import { useFilterNavigation } from '@/hooks/useFilterNavigation'
 import { Plus } from 'lucide-react'
 import Button from '@/components/commons/button/Button'
 import { useUserStore } from '@/store/userStore'
@@ -23,9 +24,8 @@ function Home() {
   const { isLogin } = useUserStore()
   const isLoggedIn = isLogin()
   const isMd = useMediaQuery('(min-width: 768px)')
-  const searchParams = useSearchParams()
+  const { searchParams, pathname, push } = useFilterNavigation()
   const router = useRouter()
-  const pathname = usePathname()
 
   // URL에서 탭 초기값 결정 (시각적 표시용)
   const urlPetType = searchParams.get('petType')
@@ -47,9 +47,9 @@ function Home() {
       } else {
         params.delete('petType')
       }
-      router.push(`${pathname}?${params.toString()}`, { scroll: false })
+      push(`${pathname}?${params.toString()}`)
     },
-    [searchParams, router, pathname]
+    [searchParams, push, pathname]
   )
 
   const handleProductTypeTabChange = useCallback(
@@ -62,9 +62,9 @@ function Home() {
       } else {
         params.delete('productType')
       }
-      router.push(`${pathname}?${params.toString()}`, { scroll: false })
+      push(`${pathname}?${params.toString()}`)
     },
-    [searchParams, router, pathname]
+    [searchParams, push, pathname]
   )
 
   // URL에서 필터 값 직접 파싱 (Single Source of Truth)
@@ -174,9 +174,9 @@ function Home() {
       e.stopPropagation()
       setActivePetTypeTab('pet-tab-all')
       setActiveProductTypeTab('tab-all')
-      router.push(pathname)
+      push(pathname)
     },
-    [router, pathname]
+    [push, pathname]
   )
 
   const toGoProductPostPage = (e: React.MouseEvent) => {

--- a/src/features/home/components/filter/CategoryFilter.tsx
+++ b/src/features/home/components/filter/CategoryFilter.tsx
@@ -3,7 +3,7 @@
 import Button from '@/components/commons/button/Button'
 import { PRODUCT_CATEGORIES } from '@/constants/constants'
 import { cn } from '@/lib/utils/cn'
-import { useSearchParams, useRouter, usePathname } from 'next/navigation'
+import { useFilterNavigation } from '@/hooks/useFilterNavigation'
 
 interface CategoryFilterProps {
   headingClassName?: string
@@ -11,9 +11,7 @@ interface CategoryFilterProps {
 }
 
 export function CategoryFilter({ headingClassName, selectedCategory }: CategoryFilterProps) {
-  const searchParams = useSearchParams()
-  const router = useRouter()
-  const pathname = usePathname()
+  const { searchParams, pathname, push } = useFilterNavigation()
 
   const handleProductCategory = (e: React.MouseEvent, category: string) => {
     e.stopPropagation() // 이벤트 버블링 방지
@@ -27,7 +25,7 @@ export function CategoryFilter({ headingClassName, selectedCategory }: CategoryF
     } else {
       params.set('categories', category) // 선택 시 URL에 추가
     }
-    router.push(`${pathname}?${params.toString()}`)
+    push(`${pathname}?${params.toString()}`)
   }
   return (
     <div className="flex flex-col gap-2.5">

--- a/src/features/home/components/filter/LocationFilter.tsx
+++ b/src/features/home/components/filter/LocationFilter.tsx
@@ -4,16 +4,14 @@ import { useState, useEffect } from 'react'
 import SelectDropdown from '@/components/commons/select/SelectDropdown'
 import { CITIES, PROVINCES, type Province } from '@/constants/cities'
 import { cn } from '@/lib/utils/cn'
-import { useSearchParams, useRouter, usePathname } from 'next/navigation'
+import { useFilterNavigation } from '@/hooks/useFilterNavigation'
 
 interface LocationFilterProps {
   headingClassName?: string
 }
 
 export function LocationFilter({ headingClassName }: LocationFilterProps) {
-  const searchParams = useSearchParams()
-  const router = useRouter()
-  const pathname = usePathname()
+  const { searchParams, pathname, push } = useFilterNavigation()
 
   const isValidProvince = (value: string): value is Province => {
     return PROVINCES.includes(value as Province)
@@ -51,7 +49,7 @@ export function LocationFilter({ headingClassName }: LocationFilterProps) {
       params.delete('addressSido')
       params.delete('addressGugun')
     }
-    router.push(`${pathname}?${params.toString()}`)
+    push(`${pathname}?${params.toString()}`)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedSido, selectedGugun])
 

--- a/src/features/home/components/filter/PetTypeFilter.tsx
+++ b/src/features/home/components/filter/PetTypeFilter.tsx
@@ -4,7 +4,7 @@ import Button from '@/components/commons/button/Button'
 import { PET_DETAILS, PET_TYPE_TABS, PETS, type PetTypeTabId } from '@/constants/constants'
 import { cn } from '@/lib/utils/cn'
 import { ProductPetTypeTabs } from '../tab/ProductPetTypeTabs'
-import { useSearchParams, useRouter, usePathname } from 'next/navigation'
+import { useFilterNavigation } from '@/hooks/useFilterNavigation'
 import { useState } from 'react'
 import { useMediaQuery } from '@/hooks/useMediaQuery'
 
@@ -18,9 +18,7 @@ interface PetTypeFilterProps {
 }
 
 export function PetTypeFilter({ activeTab, headingClassName, selectedDetailPet, onTabChange }: PetTypeFilterProps) {
-  const searchParams = useSearchParams()
-  const router = useRouter()
-  const pathname = usePathname()
+  const { searchParams, pathname, push } = useFilterNavigation()
   const [showAll, setShowAll] = useState(false)
   const isMobile = useMediaQuery('(max-width: 767px)')
 
@@ -36,7 +34,7 @@ export function PetTypeFilter({ activeTab, headingClassName, selectedDetailPet, 
     } else {
       params.set('petDetailType', pet) // 선택 시 URL에 추가
     }
-    router.push(`${pathname}?${params.toString()}`)
+    push(`${pathname}?${params.toString()}`)
   }
   const selectedPetTypeCode = PET_TYPE_TABS.find((tab) => tab.id === activeTab)?.code
 

--- a/src/features/home/components/filter/PriceFilter.tsx
+++ b/src/features/home/components/filter/PriceFilter.tsx
@@ -3,7 +3,7 @@
 import Button from '@/components/commons/button/Button'
 import { PRICE_TYPE, type PriceRange } from '@/constants/constants'
 import { cn } from '@/lib/utils/cn'
-import { useSearchParams, useRouter, usePathname } from 'next/navigation'
+import { useFilterNavigation } from '@/hooks/useFilterNavigation'
 
 interface PriceFilterProps {
   headingClassName?: string
@@ -11,9 +11,7 @@ interface PriceFilterProps {
 }
 
 export function PriceFilter({ headingClassName, selectedPriceRange }: PriceFilterProps) {
-  const searchParams = useSearchParams()
-  const router = useRouter()
-  const pathname = usePathname()
+  const { searchParams, pathname, push } = useFilterNavigation()
 
   const handleMinPrice = (e: React.MouseEvent, priceRange: PriceRange) => {
     e.stopPropagation() // 이벤트 버블링 방지
@@ -33,7 +31,7 @@ export function PriceFilter({ headingClassName, selectedPriceRange }: PriceFilte
         params.delete('maxPrice')
       }
     }
-    router.push(`${pathname}?${params.toString()}`)
+    push(`${pathname}?${params.toString()}`)
   }
   return (
     <div className="flex flex-col gap-2">

--- a/src/features/home/components/product-section/ProductsSection.tsx
+++ b/src/features/home/components/product-section/ProductsSection.tsx
@@ -4,7 +4,7 @@ import ProductList from '@/components/product/ProductList'
 import SelectDropdown from '@/components/commons/select/SelectDropdown'
 import { PRODUCT_TYPE_TABS, SORT_TYPE, type ProductTypeTabId } from '@/constants/constants'
 import type { Product } from '@/types/product'
-import { useSearchParams, useRouter, usePathname } from 'next/navigation'
+import { useFilterNavigation } from '@/hooks/useFilterNavigation'
 
 interface ProductListHeaderProps {
   totalElements: number
@@ -31,9 +31,7 @@ export function ProductsSection({
   activeTab,
   selectedSort = '최신순',
 }: ProductsSectionProps) {
-  const searchParams = useSearchParams()
-  const router = useRouter()
-  const pathname = usePathname()
+  const { searchParams, pathname, push } = useFilterNavigation()
 
   const activeTabCode = PRODUCT_TYPE_TABS.find((tab) => tab.id === activeTab)?.code
 
@@ -55,7 +53,7 @@ export function ProductsSection({
         params.set('sortBy', sortItem.id)
         params.delete('sortOrder')
     }
-    router.push(`${pathname}?${params.toString()}`)
+    push(`${pathname}?${params.toString()}`)
   }
 
   return (

--- a/src/hooks/useFilterNavigation.tsx
+++ b/src/hooks/useFilterNavigation.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import { createContext, useContext, useState, useCallback, useEffect, type ReactNode } from 'react'
+import { useSearchParams, useRouter, usePathname } from 'next/navigation'
+
+interface FilterNavigation {
+  searchParams: URLSearchParams
+  pathname: string
+  push: (url: string) => void
+}
+
+const FilterNavigationContext = createContext<FilterNavigation | null>(null)
+
+export function FilterNavigationProvider({ children }: { children: ReactNode }) {
+  const serverParams = useSearchParams()
+  const pathname = usePathname()
+
+  // 클라이언트 필터 변경 시 사용되는 내부 state (null = 서버 params 사용)
+  const [clientParams, setClientParams] = useState<URLSearchParams | null>(null)
+
+  // 서버 params 변경 감지 (다른 페이지에서 홈으로 Link 네비게이션 시)
+  const [prevServerParams, setPrevServerParams] = useState(serverParams)
+  if (serverParams !== prevServerParams) {
+    setPrevServerParams(serverParams)
+    setClientParams(null)
+  }
+
+  const searchParams = clientParams ?? serverParams
+
+  const push = useCallback((url: string) => {
+    const currentUrl = `${window.location.pathname}${window.location.search}`
+    if (url === currentUrl) return
+    window.history.pushState(null, '', url)
+    const urlObj = new URL(url, window.location.origin)
+    setClientParams(new URLSearchParams(urlObj.search))
+  }, [])
+
+  // 뒤로가기/앞으로가기 처리
+  useEffect(() => {
+    const handlePopState = () => {
+      setClientParams(new URLSearchParams(window.location.search))
+    }
+    window.addEventListener('popstate', handlePopState)
+    return () => window.removeEventListener('popstate', handlePopState)
+  }, [])
+
+  return (
+    <FilterNavigationContext.Provider value={{ searchParams, pathname, push }}>
+      {children}
+    </FilterNavigationContext.Provider>
+  )
+}
+
+/**
+ * Provider 내부: pushState로 빠른 클라이언트 네비게이션
+ * Provider 외부: Next.js router fallback (공유 컴포넌트용)
+ */
+export function useFilterNavigation(): FilterNavigation {
+  const ctx = useContext(FilterNavigationContext)
+  const serverSearchParams = useSearchParams()
+  const router = useRouter()
+  const pathname = usePathname()
+
+  if (ctx) return ctx
+
+  return {
+    searchParams: serverSearchParams,
+    pathname,
+    push: (url: string) => router.push(url),
+  }
+}


### PR DESCRIPTION
## 📌 개요

- PR #327(HydrationBoundary SSR) 이후 필터 전환 시 ~398ms 지연 발생. `router.push()`가 Next.js 서버 재렌더링을 트리거하여 4-hop 경로(Browser→Vercel→API→Vercel→Browser) 발생.
- `window.history.pushState()` + `FilterNavigationProvider` Context로 서버 round trip 제거하여 2-hop(Browser→API→Browser, ~200ms)으로 최적화.

## 🔧 작업 내용

- [x] `FilterNavigationProvider` Context + `useFilterNavigation()` hook 생성 (`src/hooks/useFilterNavigation.tsx`)
- [x] `page.tsx`에 `<FilterNavigationProvider>` 래핑 추가
- [x] `Home.tsx` 및 6개 필터 컴포넌트에서 `router.push()` → `push()` (pushState) 교체
- [x] `ProductStateFilter.tsx` fallback 처리 (Provider 외부에서는 기존 `router.push` 동작)
- [x] 초기 로드 SSR/SEO 유지 (HydrationBoundary 변경 없음)
- [x] 뒤로가기/앞으로가기 처리 (popstate 이벤트)

## 📎 관련 이슈

Closes #328

## 💬 리뷰어 참고 사항

- `useFilterNavigation()` hook은 Provider 내부에서는 `pushState`로 빠른 클라이언트 네비게이션, Provider 외부에서는 기존 `router.push()` fallback으로 동작합니다.
- SSR/SEO는 기존 HydrationBoundary 방식 그대로 유지됩니다 (page.tsx 변경 최소화).
- 필터 전환 속도: ~398ms → ~200ms (서버 hop 제거)