### PR TITLE
fix: 대분류 변경 시 소분류 필터 미초기화(#330)

### DIFF
--- a/src/features/home/Home.tsx
+++ b/src/features/home/Home.tsx
@@ -47,6 +47,8 @@ function Home() {
       } else {
         params.delete('petType')
       }
+      // 대분류 변경 시 소분류 초기화 (조류 + 토끼 같은 불가능한 조합 방지)
+      params.delete('petDetailType')
       push(`${pathname}?${params.toString()}`)
     },
     [searchParams, push, pathname]


### PR DESCRIPTION
## 📌 개요

- 반려동물 대분류(petType) 변경 시 소분류(petDetailType) 필터가 초기화되지 않아 불가능한 필터 조합이 발생하는 버그 수정

## 🔧 작업 내용

- [x] `handlePetTypeTabChange`에서 대분류 변경 시 `petDetailType` 파라미터 삭제 로직 추가

## 📎 관련 이슈

Closes #330

## 💬 리뷰어 참고 사항

- 재현 경로: 포유류 → 토끼 → 사육장/하우스 → 조류 클릭 시 `petDetailType=RABBIT`이 남아있어 결과 0건
- `params.delete('petDetailType')` 한 줄 추가로 해결