### PR TITLE
feat: 닉네임 중복체크 버튼 로딩 상태 추가(#334)

### DIFF
--- a/src/components/commons/InputWithButton.tsx
+++ b/src/components/commons/InputWithButton.tsx
@@ -13,6 +13,7 @@ interface InputWithButtonProps {
   registration: UseFormRegisterReturn
   buttonText: string
   buttonClassName?: string
+  buttonDisabled?: boolean
   onButtonClick?: () => void
   size?: string
   buttonSize?: 'xs' | 'sm' | 'md' | 'lg'
@@ -28,6 +29,7 @@ export default function InputWithButton({
   registration,
   buttonText,
   buttonClassName = 'bg-primary-50 text-primary-500 cursor-pointer font-semibold',
+  buttonDisabled,
   onButtonClick,
   size = 'text-sm',
   buttonSize = 'md',
@@ -47,7 +49,7 @@ export default function InputWithButton({
         className="flex-1"
         registration={registration}
       />
-      <Button size={buttonSize} className={buttonClassName} type="button" onClick={onButtonClick}>
+      <Button size={buttonSize} className={buttonClassName} type="button" onClick={onButtonClick} disabled={buttonDisabled}>
         {buttonText}
       </Button>
     </div>

--- a/src/features/signup/components/NicknameField.tsx
+++ b/src/features/signup/components/NicknameField.tsx
@@ -15,7 +15,7 @@ import {
 import { signupValidationRules } from '../validationRules'
 import { checkNickname } from '@/lib/api/auth'
 import { isAxiosError } from 'axios'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 
 interface NicknameFieldProps<T extends FieldValues> {
   control: Control<T>
@@ -38,7 +38,10 @@ export function NicknameField<T extends FieldValues>({
 }: NicknameFieldProps<T>) {
   const nickname = useWatch({ control, name: 'nickname' as Path<T> })
 
+  const [isChecking, setIsChecking] = useState(false)
+
   const handleNicknameCheck = async () => {
+    setIsChecking(true)
     try {
       const response = await checkNickname(nickname)
 
@@ -70,6 +73,8 @@ export function NicknameField<T extends FieldValues>({
         })
       }
       setIsNicknameVerified(false)
+    } finally {
+      setIsChecking(false)
     }
   }
 
@@ -88,8 +93,9 @@ export function NicknameField<T extends FieldValues>({
         error={errors.nickname as FieldError | undefined}
         checkResult={checkResult}
         registration={register('nickname' as Path<T>, signupValidationRules.nickname)}
-        buttonText="중복체크"
+        buttonText={isChecking ? '체크 중...' : '중복체크'}
         onButtonClick={handleNicknameCheck}
+        buttonDisabled={isChecking}
       />
     </div>
   )


### PR DESCRIPTION
## 📌 개요

- 회원가입 페이지의 닉네임 중복체크 버튼에 로딩 상태를 추가하여 API 호출 중임을 사용자에게 표시

## 🔧 작업 내용

- [x] NicknameField에 isChecking 로딩 상태 추가
- [x] 중복체크 API 호출 중 버튼 텍스트를 "체크 중..."으로 변경
- [x] 로딩 중 버튼 비활성화 처리
- [x] InputWithButton 컴포넌트에 buttonDisabled prop 추가

## 📎 관련 이슈

Closes #334

## 💬 리뷰어 참고 사항

- 회원가입 버튼의 "가입 중..." 패턴과 동일한 방식으로 구현했습니다
- InputWithButton에 buttonDisabled prop을 추가하여 다른 곳에서도 재사용 가능합니다