### PR TITLE
fix: 회원가입 성공 후 페이지 이동 전 로딩 상태 해제 수정(#338)

### DIFF
--- a/src/features/signup/components/SignUpForm.tsx
+++ b/src/features/signup/components/SignUpForm.tsx
@@ -138,7 +138,6 @@ export function SignUpForm() {
       } else {
         setSignupNotification({ message: '네트워크 연결을 확인해주세요.', type: 'warning' })
       }
-    } finally {
       setIsSubmitting(false)
     }
   }


### PR DESCRIPTION
## 📌 개요

- 회원가입 성공 후 `router.push()`로 페이지 이동 시, RSC 데이터 로딩이 완료되기 전에 '가입 중...' 텍스트가 '회원가입'으로 돌아오는 문제 수정

## 🔧 작업 내용

- [x] `setIsSubmitting(false)`를 `finally` 블록에서 `catch` 블록으로 이동
- [x] 회원가입 성공 시 페이지 이동이 완료될 때까지 로딩 상태 유지

## 📎 관련 이슈

Closes #338

## 💬 리뷰어 참고 사항

- `router.push()`는 non-blocking으로 동작하여 호출 직후 다음 코드가 실행됩니다
- `finally` 블록에 `setIsSubmitting(false)`가 있으면 페이지 이동 전에 로딩 상태가 해제됩니다
- 성공 시에는 페이지가 이동되므로 `setIsSubmitting(false)`가 필요 없고, 실패 시에만 `catch` 블록에서 해제하면 됩니다