### PR TITLE
fix: Google 검색 snippet 필터 텍스트 노출 방지(#342)

### DIFF
--- a/src/features/home/Home.tsx
+++ b/src/features/home/Home.tsx
@@ -207,7 +207,7 @@ function Home() {
         <h1 className="sr-only">커들마켓</h1>
         <div className="px-lg mx-auto max-w-7xl">
           <div className="flex flex-col gap-12">
-            <section aria-label="상품 필터" className="flex flex-col gap-7">
+            <section aria-label="상품 필터" className="flex flex-col gap-7" data-nosnippet>
               <PetTypeFilter
                 activeTab={activePetTypeTab}
                 onTabChange={handlePetTypeTabChange}
@@ -225,12 +225,14 @@ function Home() {
               />
             </section>
             <section aria-label="상품 목록" className="flex flex-col gap-3">
-              <Tabs
-                tabs={PRODUCT_TYPE_TABS}
-                activeTab={activeProductTypeTab}
-                onTabChange={handleProductTypeTabChange}
-                ariaLabel="상품 타입 분류"
-              />
+              <div data-nosnippet>
+                <Tabs
+                  tabs={PRODUCT_TYPE_TABS}
+                  activeTab={activeProductTypeTab}
+                  onTabChange={handleProductTypeTabChange}
+                  ariaLabel="상품 타입 분류"
+                />
+              </div>
               {isLoading && allProducts.length === 0 ? (
                 <HomeSkeleton />
               ) : (


### PR DESCRIPTION
## 📌 개요

- Google 검색 결과에서 meta description 대신 필터 UI 텍스트(사료/간식, 포유류, 조류 등)가 snippet으로 노출되는 문제 수정

## 🔧 작업 내용

- [x] 필터 section에 `data-nosnippet` 속성 추가
- [x] 상품 타입 Tabs를 `data-nosnippet` div로 감싸기

## 📎 관련 이슈

Closes #342

## 💬 리뷰어 참고 사항

- `data-nosnippet`은 Google이 공식 지원하는 속성으로, 해당 요소의 텍스트를 검색 snippet 후보에서 제외합니다
- 시각적 표시와 접근성에는 영향 없음
- 반영 후 Google 재크롤링까지 수일 소요될 수 있음