### PR TITLE
chore: CDN preconnect 추가로 LCP 리소스 로드 지연 개선(#346)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,6 +19,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko">
+      <head>
+        <link rel="preconnect" href="https://df1xl13ui5mlo.cloudfront.net" />
+      </head>
       <body>
         <Providers>
           {children}


### PR DESCRIPTION
## 📌 개요

- PageSpeed Insights LCP 분석에서 리소스 로드 지연 610ms로 측정되어, CloudFront CDN 도메인에 preconnect를 추가하여 개선

## 🔧 작업 내용

- [x] root layout에 `<link rel="preconnect" href="https://df1xl13ui5mlo.cloudfront.net" />` 추가

## 📎 관련 이슈

Closes #346

## 💬 리뷰어 참고 사항

- preconnect는 브라우저가 HTML 파싱 시점에 CDN과 DNS 조회 + TCP 연결 + TLS 핸드셰이크를 미리 수행하여 이미지 요청 시 연결 대기 시간을 줄임
- 모든 페이지에 적용되므로 CDN 이미지를 사용하는 모든 페이지의 LCP에 긍정적 영향
- 배포 후 PageSpeed Insights 재측정으로 효과 확인 필요