### PR TITLE
fix: sitemap lastmod 날짜 형식 W3C 표준 준수(#356)

### DIFF
--- a/src/app/sitemap.xml/route.ts
+++ b/src/app/sitemap.xml/route.ts
@@ -1,6 +1,10 @@
 import { toUrlName } from '@/lib/utils/toUrlName'
 import { fetchProductSitemapEntries, fetchCommunitySitemapEntries } from '@/lib/api/server/sitemap'
 
+function formatLastmod(dateStr: string): string {
+  return dateStr.slice(0, 10)
+}
+
 export const revalidate = 3600
 
 const SITE_URL = 'https://cuddle-market.vercel.app'
@@ -40,7 +44,7 @@ export async function GET() {
     urls.push(`
   <url>
     <loc>${sitemapUrl(`${SITE_URL}/products/${product.id}/${toUrlName(product.title)}`)}</loc>
-    <lastmod>${product.createdAt}</lastmod>
+    <lastmod>${formatLastmod(product.createdAt)}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>`)
@@ -51,7 +55,7 @@ export async function GET() {
     urls.push(`
   <url>
     <loc>${sitemapUrl(`${SITE_URL}/community/${post.id}/${toUrlName(post.title)}`)}</loc>
-    <lastmod>${post.updatedAt || post.createdAt}</lastmod>
+    <lastmod>${formatLastmod(post.updatedAt || post.createdAt)}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>`)


### PR DESCRIPTION
## 📌 개요

- Google Search Console에서 sitemap.xml의 `lastmod` 날짜 형식 오류 75개 감지
- API 응답 날짜(`2026-01-17T22:36:10.312642`, 타임존 없음)를 W3C Datetime 표준 `YYYY-MM-DD` 형식으로 변환

## 🔧 작업 내용

- [x] `formatLastmod()` 함수 추가 (`dateStr.slice(0, 10)`으로 `YYYY-MM-DD` 추출)
- [x] Product URL의 `lastmod`에 적용
- [x] Community URL의 `lastmod`에 적용

## 📎 관련 이슈

Closes #356

## 💬 리뷰어 참고 사항

- 변경 파일: `src/app/sitemap.xml/route.ts` 1개
- 배포 후 Google Search Console에서 sitemap 재제출 필요