### PR TITLE
fix: 홈페이지 SSR 하이드레이션 데이터 shape 정규화(#358)

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -42,15 +42,22 @@ export default async function HomePage({ searchParams }: HomePageProps) {
   const queryClient = new QueryClient()
 
   const initialData = await fetchProducts(filterParams)
-  if (initialData) {
+  const pageData = initialData?.data?.data
+  if (pageData) {
     queryClient.setQueryData(queryKey, {
-      pages: [initialData],
+      pages: [{
+        content: pageData.content,
+        page: pageData.page,
+        totalPages: pageData.totalPages,
+        totalElements: pageData.totalElements,
+        hasNext: pageData.hasNext,
+      }],
       pageParams: [0],
     })
   }
 
-  const products = initialData?.data?.data?.content ?? []
-  const totalElements = initialData?.data?.data?.totalElements ?? 0
+  const products = pageData?.content ?? []
+  const totalElements = pageData?.totalElements ?? 0
   const firstImageUrl = products[0]?.mainImageUrl
 
   const jsonLd = {


### PR DESCRIPTION
## 📌 개요

- 배포 사이트 접속 시 `Cannot read properties of undefined (reading 'id')` 에러로 홈페이지 완전 불능
- GraphQL BFF 마이그레이션(PR #355) 이후 SSR 하이드레이션 데이터 shape과 클라이언트 queryFn 반환 shape 불일치가 원인

## 🔧 작업 내용

- [x] `src/app/(main)/page.tsx`에서 SSR 하이드레이션 데이터를 GraphQL queryFn과 동일한 shape으로 정규화
- Before: `pages: [initialData]` (REST 원본 shape)
- After: `pages: [{ content, page, totalPages, totalElements, hasNext }]` (GraphQL shape)

## 📎 관련 이슈

Closes #358

## 💬 리뷰어 참고 사항

- 변경 파일: `src/app/(main)/page.tsx` 1개
- `data.pages.flatMap(page => page.content)`가 정상 동작하도록 shape을 맞춤