### PR TITLE
fix: ProductConnection 스키마에 total 필드 추가(#360)

### DIFF
--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -169,6 +169,7 @@ export const typeDefs = gql`
   type ProductConnection {
     content: [Product!]!
     page: Int
+    total: Int
     totalPages: Int
     totalElements: Int!
     hasNext: Boolean!


### PR DESCRIPTION
## 📌 개요

- 로그인 후 마이페이지 접속 시 GraphQL 400 Bad Request 에러로 페이지 완전 불능
- `ProductConnection` 스키마에 `total` 필드가 누락되어 마이페이지 쿼리 3개가 유효성 검증 실패

## 🔧 작업 내용

- [x] `src/graphql/schema.ts`의 `ProductConnection`에 `total: Int` 필드 추가

## 📎 관련 이슈

Closes #360

## 💬 리뷰어 참고 사항

- 변경 파일: `src/graphql/schema.ts` 1개 (1줄 추가)
- REST API는 이미 `total` 필드를 반환하고 있었으나 스키마에만 정의되지 않은 상태였음
- `BlockedUserConnection`에는 `total`이 있었으나 `ProductConnection`에만 빠져있던 불일치 수정