### PR TITLE
fix: 신고 모달 이미지 첨부 기능 활성화(#362)

### DIFF
--- a/src/components/modal/ReportModalBase.tsx
+++ b/src/components/modal/ReportModalBase.tsx
@@ -3,8 +3,7 @@ import ModalTitle from './ModalTitle'
 import RequiredLabel from '../commons/RequiredLabel'
 import { useForm, useWatch } from 'react-hook-form'
 import { ReportApiErrors } from '@/constants/validationRules'
-// TODO: ImageUploadField 마이그레이션 후 활성화 (#42-#43)
-// import ImageUploadField from '@/components/product/imageUploadField/ImageUploadField'
+import ImageUploadField from '@/features/product-post/components/imageUploadField/ImageUploadField'
 import { useEffect, useRef, type ReactNode } from 'react'
 import { AnimatePresence } from 'framer-motion'
 import InlineNotification from '../commons/InlineNotification'
@@ -37,6 +36,9 @@ export default function ReportModalBase({ isOpen, heading, description, reasons,
     register,
     control,
     reset,
+    setValue,
+    setError,
+    clearErrors,
     formState: { errors, isValid },
   } = useForm<ReportFormValues>({
     mode: 'onChange',
@@ -123,8 +125,7 @@ export default function ReportModalBase({ isOpen, heading, description, reasons,
             </div>
           </div>
 
-          {/* TODO: ImageUploadField 마이그레이션 후 활성화 (#42-#43) */}
-          {/* <div className="flex w-full flex-col gap-3">
+          <div className="flex w-full flex-col gap-3">
             <ImageUploadField
               setValue={setValue}
               errors={errors}
@@ -137,7 +138,7 @@ export default function ReportModalBase({ isOpen, heading, description, reasons,
               className="gap-1"
               headingClassName="text-gray-900 font-semibold"
             />
-          </div> */}
+          </div>
         </div>
 
         <div className="flex justify-end gap-3">


### PR DESCRIPTION
## 📌 개요

- 신고 모달(ReportModalBase)에서 주석 처리되어 있던 이미지 첨부 기능을 활성화

## 🔧 작업 내용

- [x] `ImageUploadField` import 주석 해제 및 경로 수정 (`@/features/product-post/components/imageUploadField/ImageUploadField`)
- [x] `useForm`에서 `setValue`, `setError`, `clearErrors` destructuring 추가
- [x] JSX 주석 해제하여 `ImageUploadField` 컴포넌트 활성화

## 📎 관련 이슈

Closes #362

## 💬 리뷰어 참고 사항

- `ImageUploadField`는 이미 `src/features/product-post/components/imageUploadField/`에 마이그레이션 완료된 상태로, import 경로 수정 + 주석 해제만 수행했습니다
- `npx next build` 성공 확인 완료