### PR TITLE
fix: 신고 API GraphQL 필드명 백엔드 스펙에 맞게 수정(#364)

### DIFF
--- a/src/components/modal/UserReportModal.tsx
+++ b/src/components/modal/UserReportModal.tsx
@@ -18,10 +18,10 @@ export default function UserReportModal({ isOpen, userNickname, userId, onCancel
   const handleSubmit = async (data: ReportFormValues) => {
     try {
       await fetchGraphQL(`
-        mutation ReportUser($userId: Int!, $reason: String!, $details: String) {
-          reportUser(userId: $userId, reason: $reason, details: $details) { success }
+        mutation ReportUser($userId: Int!, $reasonCode: String!, $detailReason: String, $imageFiles: [String!]) {
+          reportUser(userId: $userId, reasonCode: $reasonCode, detailReason: $detailReason, imageFiles: $imageFiles) { success }
         }
-      `, { userId, reason: data.reasonCode, details: data.detailReason })
+      `, { userId, reasonCode: data.reasonCode, detailReason: data.detailReason, imageFiles: data.imageFiles })
       queryClient.invalidateQueries({ queryKey: ['userPage'] })
       onCancel()
     } catch {

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -370,12 +370,12 @@ export const resolvers = {
 
     reportUser: async (
       _parent: unknown,
-      args: { userId: number; reason: string; details?: string },
+      args: { userId: number; reasonCode: string; detailReason?: string; imageFiles?: string[] },
       context: Context
     ) => {
       await fetchAPI(`/reports/users/${args.userId}`, context, {
         method: 'POST',
-        body: JSON.stringify({ reason: args.reason, details: args.details }),
+        body: JSON.stringify({ reasonCode: args.reasonCode, detailReason: args.detailReason, imageFiles: args.imageFiles }),
       })
       return { success: true }
     },

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -363,7 +363,7 @@ export const typeDefs = gql`
     withdraw(reason: String!, detailReason: String!): MutationResponse!
     blockUser(userId: Int!): MutationResponse!
     unblockUser(userId: Int!): MutationResponse!
-    reportUser(userId: Int!, reason: String!, details: String): MutationResponse!
+    reportUser(userId: Int!, reasonCode: String!, detailReason: String, imageFiles: [String!]): MutationResponse!
 
     # Notifications
     markAllNotificationsRead: MutationResponse!


### PR DESCRIPTION
## 📌 개요

- 신고하기 기능에서 GraphQL 뮤테이션이 백엔드 REST API와 다른 필드명을 사용하여 400 Bad Request 에러 발생하는 문제 수정

## 🔧 작업 내용

- [x] GraphQL 스키마 `reportUser` 매개변수명 수정 (`reason`→`reasonCode`, `details`→`detailReason`, `imageFiles` 추가)
- [x] GraphQL 리졸버 args 타입 및 REST API body 필드명 수정
- [x] `UserReportModal` 뮤테이션 변수명 수정 및 `imageFiles` 전달 추가

## 📎 관련 이슈

Closes #364

## 💬 리뷰어 참고 사항

- 기존 Vite 프로젝트의 `ReportedRequestData` 타입(`{ reasonCode, detailReason, imageFiles }`)에 맞춰 수정했습니다
- #362에서 활성화한 ImageUploadField의 이미지 URL도 이제 백엔드까지 전달됩니다