### PR TITLE
fix: 신고 API 409 에러 핸들링 및 imageFiles 배열 정규화(#366)

### DIFF
--- a/src/components/modal/UserReportModal.tsx
+++ b/src/components/modal/UserReportModal.tsx
@@ -21,14 +21,16 @@ export default function UserReportModal({ isOpen, userNickname, userId, onCancel
         mutation ReportUser($userId: Int!, $reasonCode: String!, $detailReason: String, $imageFiles: [String!]) {
           reportUser(userId: $userId, reasonCode: $reasonCode, detailReason: $detailReason, imageFiles: $imageFiles) { success }
         }
-      `, { userId, reasonCode: data.reasonCode, detailReason: data.detailReason, imageFiles: data.imageFiles })
+      `, { userId, reasonCode: data.reasonCode, detailReason: data.detailReason, imageFiles: data.imageFiles ? [data.imageFiles].flat() : [] })
       queryClient.invalidateQueries({ queryKey: ['userPage'] })
       onCancel()
-    } catch {
+    } catch (error) {
+      const message = error instanceof Error ? error.message : ''
+      const isDuplicate = message.includes('이미 신고한 사용자입니다')
       setUserReportError(
         <div className="flex flex-col gap-0.5">
-          <p className="text-base font-semibold">사용자 신고에 실패했습니다.</p>
-          <p>잠시 후 다시 시도해주세요.</p>
+          <p className="text-base font-semibold">{isDuplicate ? '이미 신고한 사용자입니다.' : '사용자 신고에 실패했습니다.'}</p>
+          {!isDuplicate && <p>잠시 후 다시 시도해주세요.</p>}
         </div>,
       )
     }

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -373,10 +373,15 @@ export const resolvers = {
       args: { userId: number; reasonCode: string; detailReason?: string; imageFiles?: string[] },
       context: Context
     ) => {
-      await fetchAPI(`/reports/users/${args.userId}`, context, {
-        method: 'POST',
-        body: JSON.stringify({ reasonCode: args.reasonCode, detailReason: args.detailReason, imageFiles: args.imageFiles }),
-      })
+      try {
+        await fetchAPI(`/reports/users/${args.userId}`, context, {
+          method: 'POST',
+          body: JSON.stringify({ reasonCode: args.reasonCode, detailReason: args.detailReason, imageFiles: args.imageFiles }),
+        })
+      } catch (error) {
+        if (error instanceof Error && error.message.includes('409')) throw new Error('이미 신고한 사용자입니다.')
+        throw error
+      }
       return { success: true }
     },
 


### PR DESCRIPTION
## 📌 개요

- 이미 신고한 사용자 재신고 시 409 에러에 대한 사용자 친화적 메시지 표시
- ImageUploadField가 세팅하는 단일 문자열을 배열로 정규화하여 백엔드 스펙 충족

## 🔧 작업 내용

- [x] `resolvers.ts`: reportUser 리졸버에서 409 응답 시 "이미 신고한 사용자입니다." 에러 메시지 반환
- [x] `UserReportModal.tsx`: 409 에러 시 "이미 신고한 사용자입니다." InlineNotification 표시, 그 외 에러는 기존 메시지 유지
- [x] `UserReportModal.tsx`: imageFiles를 `[].flat()`으로 배열 정규화하여 전달

## 📎 관련 이슈

Closes #366

## 💬 리뷰어 참고 사항

- `fetchGraphQL`이 `json.errors[0].message`를 throw하므로 리졸버에서 던진 한글 메시지가 프론트까지 그대로 전달됩니다
- ImageUploadField는 상품 등록용(`mainImageField`=단일 URL)으로 설계되어 신고 모달에서는 배열 정규화가 필요합니다