### PR TITLE
fix: 신고 모달 재오픈 시 첨부 이미지 초기화(#368)

### DIFF
--- a/src/components/modal/ReportModalBase.tsx
+++ b/src/components/modal/ReportModalBase.tsx
@@ -125,20 +125,22 @@ export default function ReportModalBase({ isOpen, heading, description, reasons,
             </div>
           </div>
 
-          <div className="flex w-full flex-col gap-3">
-            <ImageUploadField
-              setValue={setValue}
-              errors={errors}
-              setError={setError}
-              clearErrors={clearErrors}
-              mainImageField="imageFiles"
-              heading="신고 이미지 첨부 (선택항목/최대 3장)"
-              showSection={false}
-              maxFiles={3}
-              className="gap-1"
-              headingClassName="text-gray-900 font-semibold"
-            />
-          </div>
+          {isOpen && (
+            <div className="flex w-full flex-col gap-3">
+              <ImageUploadField
+                setValue={setValue}
+                errors={errors}
+                setError={setError}
+                clearErrors={clearErrors}
+                mainImageField="imageFiles"
+                heading="신고 이미지 첨부 (선택항목/최대 3장)"
+                showSection={false}
+                maxFiles={3}
+                className="gap-1"
+                headingClassName="text-gray-900 font-semibold"
+              />
+            </div>
+          )}
         </div>
 
         <div className="flex justify-end gap-3">


### PR DESCRIPTION
## 📌 개요

- 신고 모달을 닫고 다시 열었을 때 이전에 첨부한 이미지가 초기화되지 않는 버그 수정

## 🔧 작업 내용

- [x] `ReportModalBase.tsx`: `isOpen`이 false일 때 ImageUploadField를 언마운트하여 내부 `previewUrls` 상태 초기화

## 📎 관련 이슈

Closes #368

## 💬 리뷰어 참고 사항

- `react-hook-form`의 `reset()`은 form 값만 초기화하고 ImageUploadField 내부 `useState`(`previewUrls`)는 초기화하지 못함
- `isOpen` 조건부 렌더링으로 컴포넌트를 언마운트/리마운트하여 해결