### PR TITLE
feat: 탈퇴 관리 + 사유 분석 차트

### DIFF
--- a/src/features/admin/components/members/WithdrawalReasonChart.tsx
+++ b/src/features/admin/components/members/WithdrawalReasonChart.tsx
@@ -7,7 +7,7 @@ import {
   Tooltip,
   ResponsiveContainer,
 } from 'recharts'
-import { WiTH_DRAW_REASON } from '@/constants/constants'
+import { WITHDRAW_REASON } from '@/constants/constants'
 import type { WithdrawalReasonStat } from '@/features/admin/mocks/mockMemberStats'
 
 const REASON_COLORS: Record<string, string> = {
@@ -19,7 +19,7 @@ const REASON_COLORS: Record<string, string> = {
 }
 
 const reasonLabelMap = Object.fromEntries(
-  WiTH_DRAW_REASON.map((r) => [r.id, r.label]),
+  WITHDRAW_REASON.map((r) => [r.id, r.label]),
 )
 
 interface WithdrawalReasonChartProps {

--- a/src/features/admin/components/members/WithdrawalReasonTrendChart.tsx
+++ b/src/features/admin/components/members/WithdrawalReasonTrendChart.tsx
@@ -11,7 +11,7 @@ import {
   Legend,
   ResponsiveContainer,
 } from 'recharts'
-import { WiTH_DRAW_REASON } from '@/constants/constants'
+import { WITHDRAW_REASON } from '@/constants/constants'
 import type { MonthlyWithdrawalReasonStat } from '@/features/admin/mocks/mockMemberStats'
 
 const REASON_COLORS: Record<string, string> = {
@@ -22,7 +22,7 @@ const REASON_COLORS: Record<string, string> = {
   OTHER: '#6b7280',
 }
 
-const REASON_BARS = WiTH_DRAW_REASON.map((r) => ({
+const REASON_BARS = WITHDRAW_REASON.map((r) => ({
   dataKey: r.id,
   name: r.label,
   fill: REASON_COLORS[r.id] ?? '#6b7280',


### PR DESCRIPTION
## 📌 개요

- 어드민 탈퇴 관리 페이지 및 탈퇴 사유 분석 차트 구현

## 🔧 작업 내용

- [x] WithdrawalsManagement 페이지 (탈퇴 회원 목록 테이블)
- [x] WithdrawalReasonChart (탈퇴 사유별 비율 파이 차트)
- [x] WithdrawalReasonTrendChart (월별 탈퇴 사유 추이 스택 막대 차트)
- [x] withdrawalTableConfig 생성 (탈퇴 테이블 컬럼, 필터, 액션 정의)
- [x] WITHDRAW_REASON 상수명 오타 수정 (WiTH_DRAW_REASON → WITHDRAW_REASON)

## 📎 관련 이슈

- Close #377

## 📸 스크린샷 (선택)

해당 없음

## 💬 리뷰어 참고 사항

- 탈퇴 사유 5종: 서비스 불만족, 개인정보 우려, 이용 빈도 낮음, 경쟁 서비스, 기타
- PieChart + BarChart 조합으로 사유를 다각도 분석