### PR TITLE
fix: fetchGraphQL 401 토큰 만료 시 자동 갱신 및 재시도 로직 추가(#397)

### DIFF
--- a/src/lib/api/graphql.ts
+++ b/src/lib/api/graphql.ts
@@ -1,6 +1,38 @@
+import axios from 'axios'
 import { useUserStore } from '@/store/userStore'
 
-export async function fetchGraphQL<T>(query: string, variables?: Record<string, unknown>): Promise<T> {
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || '/api'
+
+let tokenRefreshPromise: Promise<string | null> | null = null
+
+async function refreshAccessToken(): Promise<string | null> {
+  if (!tokenRefreshPromise) {
+    tokenRefreshPromise = (async () => {
+      try {
+        const refreshToken = useUserStore.getState().refreshToken
+        if (!refreshToken) throw new Error('No refresh token')
+
+        const response = await axios.post(`${API_BASE_URL}/auth/refresh`, { refreshToken })
+        const newAccessToken = response.data?.data?.accessToken ?? null
+        useUserStore.getState().setAccessToken(newAccessToken)
+        return newAccessToken
+      } catch {
+        useUserStore.getState().clearAll()
+        if (typeof window !== 'undefined') window.location.href = '/auth/login'
+        return null
+      }
+    })().finally(() => {
+      tokenRefreshPromise = null
+    })
+  }
+  return tokenRefreshPromise
+}
+
+function isUnauthorizedError(json: { errors?: { message: string }[] }): boolean {
+  return json.errors?.some((e) => e.message.includes('401')) ?? false
+}
+
+async function executeGraphQL<T>(query: string, variables?: Record<string, unknown>): Promise<T> {
   const token = useUserStore.getState().accessToken
   const headers: Record<string, string> = { 'Content-Type': 'application/json' }
   if (token) headers['Authorization'] = `Bearer ${token}`
@@ -11,7 +43,21 @@ export async function fetchGraphQL<T>(query: string, variables?: Record<string, 
     body: JSON.stringify({ query, variables }),
   })
   if (!res.ok) throw new Error(`GraphQL request failed: ${res.status}`)
-  const json = await res.json()
+  return await res.json()
+}
+
+export async function fetchGraphQL<T>(query: string, variables?: Record<string, unknown>): Promise<T> {
+  const json = await executeGraphQL<{ data: T; errors?: { message: string }[] }>(query, variables)
+
+  if (isUnauthorizedError(json)) {
+    const newToken = await refreshAccessToken()
+    if (newToken) {
+      const retryJson = await executeGraphQL<{ data: T; errors?: { message: string }[] }>(query, variables)
+      if (retryJson.errors) throw new Error(retryJson.errors[0].message)
+      return retryJson.data
+    }
+  }
+
   if (json.errors) throw new Error(json.errors[0].message)
   return json.data
 }


### PR DESCRIPTION
## 📌 개요

- 채팅 페이지에서 액세스 토큰 만료 시 "채팅 목록을 불러올 수 없습니다" 에러가 발생하는 문제 수정
- GraphQL BFF 경로(`fetchGraphQL`)에 토큰 자동 갱신 로직이 없어 REST API 401 에러가 그대로 전파되던 문제

## 🔧 작업 내용

- [x] `fetchGraphQL`에 401 에러 감지 시 refreshToken으로 토큰 갱신 + 재시도 로직 추가
- [x] `api.ts` Axios 인터셉터와 동일한 패턴 적용 (중복 갱신 방지, 갱신 실패 시 로그인 리다이렉트)
- [x] 빌드 검증 완료

## 📎 관련 이슈

Closes #397

## 💬 리뷰어 참고 사항

- `api.ts`의 Axios 응답 인터셉터에는 401 시 토큰 갱신 로직이 있었으나, `fetchGraphQL`은 plain `fetch`를 사용하여 해당 로직이 빠져있었습니다
- GraphQL 응답은 HTTP 200이지만 body의 errors에 "REST API error: 401"이 포함되는 형태이므로, 에러 메시지 기반으로 401을 감지합니다