### PR TITLE
fix: 채팅방 클릭 시 lastMessage 깜빡임 버그 수정(#399)

### DIFF
--- a/src/features/chatting-page/components/ChatRooms.tsx
+++ b/src/features/chatting-page/components/ChatRooms.tsx
@@ -31,9 +31,9 @@ export function ChatRooms({ rooms, handleSelectRoom, selectedRoomId, hasNextPage
     if (update) {
       return {
         ...room,
-        lastMessage: update.lastMessage,
-        lastMessageTime: update.lastMessageTime,
-        unreadCount: update.unreadCount,
+        lastMessage: update.lastMessage ?? room.lastMessage,
+        lastMessageTime: update.lastMessageTime ?? room.lastMessageTime,
+        unreadCount: update.unreadCount ?? room.unreadCount,
       }
     }
     return room


### PR DESCRIPTION
## 📌 개요

- 채팅방 목록에서 채팅방 클릭 시 lastMessage가 "채팅방에 입장해주세요"로 잠깐 깜빡이는 버그 수정

## 🔧 작업 내용

- [x] `ChatRooms.tsx`의 `getRoomData`에서 nullish coalescing(`??`)으로 원본 room 데이터 fallback 적용

## 📎 관련 이슈

Closes #399

## 💬 리뷰어 참고 사항

- `clearUnreadCount`가 `{ unreadCount: 0 }`만 있는 불완전한 엔트리를 생성하여 `lastMessage`가 `undefined`로 덮어씌워지는 것이 원인이었습니다
- `update.lastMessage ?? room.lastMessage` 패턴으로 `undefined`일 때 원본 데이터를 유지하도록 수정했습니다