### PR TITLE
fix: 채팅방 전환 시 스크롤 플리커 현상 수정(#401)

### DIFF
--- a/src/features/chatting-page/ChattingPage.tsx
+++ b/src/features/chatting-page/ChattingPage.tsx
@@ -245,6 +245,7 @@ export default function ChattingPage() {
               </div>
               <div className="bg-primary-50 min-h-0 flex-1 p-3.5 pb-20 md:pb-3.5">
                 <ChatLog
+                  key={chatRoomId}
                   isLoadingMessages={isLoadingMessages}
                   errorMessages={errorMessages}
                   roomMessages={allMessages}

--- a/src/features/chatting-page/components/ChatLog.tsx
+++ b/src/features/chatting-page/components/ChatLog.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useLayoutEffect, useRef } from 'react'
 import Image from 'next/image'
 import type { Message } from '@/types'
 import { cn } from '@/lib/utils/cn'
@@ -126,15 +126,15 @@ export function ChatLog({
     }
   }
 
-  // 맨 아래 근처에 있을 때만 자동 스크롤
-  useEffect(() => {
+  // 맨 아래 근처에 있을 때만 자동 스크롤 (페인트 전에 실행하여 플리커 방지)
+  useLayoutEffect(() => {
     if (scrollRef.current && isNearBottom) {
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight
     }
   }, [roomMessages, isNearBottom])
 
-  // 이전 메시지 로드 후 스크롤 위치 복원
-  useEffect(() => {
+  // 이전 메시지 로드 후 스크롤 위치 복원 (페인트 전에 실행하여 플리커 방지)
+  useLayoutEffect(() => {
     if (scrollRef.current && prevScrollHeightRef.current > 0) {
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight - prevScrollHeightRef.current
       prevScrollHeightRef.current = 0


### PR DESCRIPTION
## 📌 개요

- 채팅방 목록에서 다른 채팅방 클릭 시 이전 채팅 내역이 맨 위부터 잠깐 보였다가 최신 위치로 스크롤되는 플리커 현상 수정

## 🔧 작업 내용

- [x] `ChatLog.tsx`의 스크롤 관련 `useEffect` → `useLayoutEffect`로 변경 (페인트 전 실행)
- [x] `ChattingPage.tsx`의 `ChatLog`에 `key={chatRoomId}` 추가 (채팅방 전환 시 컴포넌트 리마운트)

## 📎 관련 이슈

Closes #401

## 💬 리뷰어 참고 사항

- `useLayoutEffect`는 DOM 변경 후 브라우저 페인트 전에 동기적으로 실행되어, 스크롤 위치 이동이 화면에 반영되기 전에 완료됩니다
- `key={chatRoomId}`로 채팅방 전환 시 `isNearBottom` 등 내부 상태가 초기값으로 리셋됩니다