### PR TITLE
fix: 채팅방 목록 상대방 프로필/닉네임 필드명 불일치 수정(#403)

### DIFF
--- a/src/features/chatting-page/ChattingPage.tsx
+++ b/src/features/chatting-page/ChattingPage.tsx
@@ -86,7 +86,7 @@ export default function ChattingPage() {
       const data = await fetchGraphQL<{ chatRooms: any }>(`
         query ChatRooms($page: Int!, $size: Int!) {
           chatRooms(page: $page, size: $size) {
-            chatRooms { chatRoomId productId productTitle productMainImageUrl otherUserNickname otherUserProfileImageUrl lastMessage lastMessageTime unreadCount }
+            chatRooms { chatRoomId productId productTitle productMainImageUrl opponentNickname opponentProfileImageUrl lastMessage lastMessageTime unreadCount }
             currentPage hasNext
           }
         }

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -163,8 +163,13 @@ export const resolvers = {
 
     chatRooms: async (_parent: unknown, args: { page: number; size: number }, context: Context) => {
       const json = await fetchAPIRaw(`/chat/rooms?page=${args.page}&size=${args.size}`, context)
+      const chatRooms = (json.data?.chatRooms || []).map((room: Record<string, unknown>) => ({
+        ...room,
+        opponentNickname: room.otherUserNickname ?? room.opponentNickname,
+        opponentProfileImageUrl: room.otherUserProfileImageUrl ?? room.opponentProfileImageUrl,
+      }))
       return {
-        chatRooms: json.data?.chatRooms || [],
+        chatRooms,
         currentPage: json.currentPage ?? json.data?.page ?? 0,
         hasNext: json.hasNext ?? json.data?.hasNext ?? false,
       }

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -234,8 +234,8 @@ export const typeDefs = gql`
     productId: Int
     productTitle: String
     productMainImageUrl: String
-    otherUserNickname: String
-    otherUserProfileImageUrl: String
+    opponentNickname: String
+    opponentProfileImageUrl: String
     lastMessage: String
     lastMessageTime: String
     unreadCount: Int


### PR DESCRIPTION
## 📌 개요

- 채팅방 목록에서 상대방 프로필 이미지와 닉네임이 표시되지 않는 버그 수정

## 🔧 작업 내용

- [x] GraphQL 스키마 필드명 `otherUserNickname/ProfileImageUrl` → `opponentNickname/ProfileImageUrl`로 변경
- [x] Resolver에서 REST API 응답 필드(`otherUser*`)를 `opponent*`로 매핑 추가
- [x] ChattingPage GraphQL 쿼리 필드명 변경

## 📎 관련 이슈

Closes #403

## 💬 리뷰어 참고 사항

- REST API는 `otherUserNickname`으로 응답하지만, 프론트엔드 타입/컴포넌트는 `opponentNickname`으로 통일되어 있어 GraphQL BFF 레이어에서 매핑하는 방식으로 수정했습니다