### PR TITLE
refactor: Tabs 데스크탑 스타일 및 MyPageTitle heading 레벨 개선(#405)

### DIFF
--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -57,7 +57,7 @@ export default function Tabs({ tabs, activeTab, onTabChange, ariaLabel, excludeT
       role="tablist"
       aria-label={ariaLabel}
       onKeyDown={handleKeyDown}
-      className={cn('border-b-primary-200 flex gap-1 rounded-lg bg-gray-100 p-2 md:gap-1.5 md:border-b-2')}
+      className={cn('border-b-primary-200 flex gap-1 md:gap-2.5 md:border-b-2 md:pb-1')}
     >
       {filteredTabs.map((tab) => (
         <Button
@@ -68,10 +68,10 @@ export default function Tabs({ tabs, activeTab, onTabChange, ariaLabel, excludeT
           type="button"
           onClick={() => onTabChange(tab.id)}
           className={cn(
-            'flex-1 cursor-pointer rounded-full bg-white text-base whitespace-nowrap md:rounded-md md:bg-transparent',
+            'flex-1 cursor-pointer rounded-full bg-white text-base whitespace-nowrap md:rounded-2xl md:bg-transparent',
             activeTab === tab.id
               ? 'md:bg-primary-300 bg-primary-500 font-bold text-white'
-              : 'md:hover:bg-primary-100 bg-gray-100 text-gray-900 md:bg-transparent'
+              : 'md:hover:bg-primary-100 bg-gray-100 text-gray-900'
           )}
           aria-selected={activeTab === tab.id}
           aria-controls={`panel-${tab.code}`}


### PR DESCRIPTION
## 📌 개요

- Tabs 컴포넌트 데스크탑 스타일 조정 및 MyPageTitle heading 시맨틱 레벨 개선

## 🔧 작업 내용

- [x] Tabs 데스크탑 스타일 변경 (간격, 패딩, 라운딩 조정)
- [x] MyPageTitle heading 레벨 h2 → h4로 변경

## 📎 관련 이슈

Closes #405