### PR TITLE
fix: GraphQL Product.tradeStatus nullable로 변경(#407)

### DIFF
--- a/src/app/(main)/products/[id]/[name]/opengraph-image.tsx
+++ b/src/app/(main)/products/[id]/[name]/opengraph-image.tsx
@@ -29,7 +29,7 @@ export default async function OGImage({ params }: { params: Promise<{ id: string
     )
   }
 
-  const status = TRADE_STATUS_STYLE[product.tradeStatus] ?? TRADE_STATUS_STYLE.SELLING
+  const status = (product.tradeStatus ? TRADE_STATUS_STYLE[product.tradeStatus] : null) ?? TRADE_STATUS_STYLE.SELLING
   const price = `${Math.floor(product.price).toLocaleString()}원`
 
   let productImageSrc: string | null = null

--- a/src/components/product/components/ProductThumbnail.tsx
+++ b/src/components/product/components/ProductThumbnail.tsx
@@ -11,7 +11,7 @@ interface ProductThumbnailProps {
   petTypeName: string
   productStatusName: string
   productTypeName: string
-  tradeStatus: string
+  tradeStatus: string | null
   productTradeColor: string
   isFavorite: boolean
   onLikeClick: (e: React.MouseEvent) => void
@@ -35,7 +35,7 @@ export function ProductThumbnail({
       if (tradeStatus === '판매완료') return '요청완료'
       if (tradeStatus === null || tradeStatus === '') return '요청중'
     }
-    return tradeStatus
+    return tradeStatus || ''
   }
   const displayTradeStatus = getDisplayTradeStatus()
 

--- a/src/features/product-detail/components/ProductBadges.tsx
+++ b/src/features/product-detail/components/ProductBadges.tsx
@@ -7,7 +7,7 @@ import Badge from '@/components/commons/badge/Badge'
 import { cn } from '@/lib/utils/cn'
 
 interface ProductBadgesProps {
-  tradeStatus: string
+  tradeStatus: string | null
   petDetailType: string
   category: string
   productStatus: string

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -130,7 +130,7 @@ export const typeDefs = gql`
     petDetailType: String!
     productStatus: String!
     productType: String!
-    tradeStatus: String!
+    tradeStatus: String
     createdAt: String!
     viewCount: Int!
     favoriteCount: Int!
@@ -151,7 +151,7 @@ export const typeDefs = gql`
     mainImageUrl: String
     subImageUrls: [String!]
     productType: String!
-    tradeStatus: String!
+    tradeStatus: String
     petType: String!
     petDetailType: String!
     category: String!

--- a/src/lib/utils/getTradeStatus.ts
+++ b/src/lib/utils/getTradeStatus.ts
@@ -1,6 +1,6 @@
 import { STATUS_EN_TO_KO } from '@/constants/constants'
 
-export const getTradeStatus = (tradeStatus: string) => {
+export const getTradeStatus = (tradeStatus: string | null) => {
   const condition = STATUS_EN_TO_KO.find((status) => status.value === tradeStatus)
-  return condition?.name || tradeStatus
+  return condition?.name || tradeStatus || ''
 }

--- a/src/lib/utils/getTradeStatusColor.ts
+++ b/src/lib/utils/getTradeStatusColor.ts
@@ -1,6 +1,6 @@
 import { STATUS_EN_TO_KO } from '@/constants/constants'
 
-export const getTradeStatusColor = (tradeStatus: string) => {
+export const getTradeStatusColor = (tradeStatus: string | null) => {
   const condition = STATUS_EN_TO_KO.find((status) => status.value === tradeStatus)
   return condition?.bgColor || STATUS_EN_TO_KO[0].bgColor
 }

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -2,7 +2,7 @@
 export interface Product {
   id: number
   productType: string
-  tradeStatus: string
+  tradeStatus: string | null
   petType?: string
   petDetailType: string
   productStatus: string
@@ -81,7 +81,7 @@ export interface ProductPostResponse {
   description: string
   price: number
   productStatus: string
-  tradeStatus: string
+  tradeStatus: string | null
   mainImageUrl: string
   subImageUrls: string[]
   addressSido: string


### PR DESCRIPTION
## 📌 개요

- 백엔드에서 일부 상품의 `tradeStatus`가 null로 반환될 때 전체 상품 목록 쿼리가 실패하는 버그 수정

## 🔧 작업 내용

- [x] `Product.tradeStatus`: `String!` → `String`으로 변경
- [x] `ProductDetail.tradeStatus`: `String!` → `String`으로 변경

## 📎 관련 이슈

Closes #407

## 💬 리뷰어 참고 사항

- GraphQL은 non-nullable 필드에서 null이 오면 해당 객체를 null로 만들고, 부모 필드까지 연쇄적으로 null 전파됨
- 백엔드에서 `tradeStatus`가 null인 상품이 하나라도 있으면 전체 상품 목록이 안 보이는 치명적 문제였음