### PR TITLE
feat: 어드민 상품/커뮤니티 실제 API 연동(#411)

### DIFF
--- a/src/features/admin/components/CommunityManagement.tsx
+++ b/src/features/admin/components/CommunityManagement.tsx
@@ -4,24 +4,24 @@ import { useState } from 'react'
 import AdminTable from './table/AdminTable'
 import { communityTableConfig } from '../configs/communityTableConfig'
 import { fetchAdminCommunityPosts } from '@/lib/api/admin'
-import type { MockCommunityPost } from '../mocks/mockCommunityPosts'
+import type { CommunityItem } from '@/types/community'
 import CommunityDetailModal from './community/CommunityDetailModal'
 
 export default function CommunityManagement() {
-  const [selectedPost, setSelectedPost] = useState<MockCommunityPost | null>(null)
+  const [selectedPostId, setSelectedPostId] = useState<number | null>(null)
 
   return (
     <>
-      <AdminTable<MockCommunityPost>
+      <AdminTable<CommunityItem>
         config={communityTableConfig}
         queryKey="admin-community"
         fetchFn={fetchAdminCommunityPosts}
-        onRowClick={(post) => setSelectedPost(post)}
+        onRowClick={(post) => setSelectedPostId(post.id)}
       />
       <CommunityDetailModal
-        isOpen={selectedPost !== null}
-        post={selectedPost}
-        onClose={() => setSelectedPost(null)}
+        isOpen={selectedPostId !== null}
+        postId={selectedPostId}
+        onClose={() => setSelectedPostId(null)}
       />
     </>
   )

--- a/src/features/admin/components/ProductsManagement.tsx
+++ b/src/features/admin/components/ProductsManagement.tsx
@@ -4,23 +4,23 @@ import { useState } from 'react'
 import AdminTable from './table/AdminTable'
 import { productTableConfig } from '../configs/productTableConfig'
 import { fetchAdminProducts } from '@/lib/api/admin'
-import type { MockProduct } from '../mocks/mockProducts'
+import type { Product } from '@/types/product'
 import ProductDetailModal from './products/ProductDetailModal'
 
 export default function ProductsManagement() {
-  const [selectedProduct, setSelectedProduct] = useState<MockProduct | null>(null)
+  const [selectedProductId, setSelectedProductId] = useState<number | null>(null)
   return (
     <>
-      <AdminTable<MockProduct>
+      <AdminTable<Product>
         config={productTableConfig}
         queryKey="admin-products"
         fetchFn={fetchAdminProducts}
-        onRowClick={(product) => setSelectedProduct(product)}
+        onRowClick={(product) => setSelectedProductId(product.id)}
       />
       <ProductDetailModal
-        isOpen={selectedProduct !== null}
-        product={selectedProduct}
-        onClose={() => setSelectedProduct(null)}
+        isOpen={selectedProductId !== null}
+        productId={selectedProductId}
+        onClose={() => setSelectedProductId(null)}
       />
     </>
   )

--- a/src/features/admin/components/community/CommunityDetailModal.tsx
+++ b/src/features/admin/components/community/CommunityDetailModal.tsx
@@ -2,11 +2,15 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { X, Trash2 } from 'lucide-react'
-import type { MockCommunityPost } from '../../mocks/mockCommunityPosts'
+import { useQuery } from '@tanstack/react-query'
+import { fetchAdminCommunityDetail } from '@/lib/api/admin'
+import { api } from '@/lib/api/api'
+import type { Comment, CommentResponse } from '@/types/community'
+import { BOARD_TYPE_EN_TO_KO } from '../../configs/communityTableConfig'
 
 interface CommunityDetailModalProps {
   isOpen: boolean
-  post: MockCommunityPost | null
+  postId: number | null
   onClose: () => void
 }
 
@@ -90,23 +94,44 @@ function DeleteConfirmDialog({
 }
 
 const BOARD_TYPE_COLORS: Record<string, string> = {
-  '질문있어요': 'bg-blue-100 text-blue-800',
-  '정보공유': 'bg-green-100 text-green-800',
+  QUESTION: 'bg-blue-100 text-blue-800',
+  INFO: 'bg-green-100 text-green-800',
 }
 
-export default function CommunityDetailModal({ isOpen, post, onClose }: CommunityDetailModalProps) {
+async function fetchComments(postId: number): Promise<Comment[]> {
+  try {
+    const { data } = await api.get<CommentResponse>(`/community/posts/${postId}/comments`)
+    return data.data.comments
+  } catch {
+    return []
+  }
+}
+
+export default function CommunityDetailModal({ isOpen, postId, onClose }: CommunityDetailModalProps) {
   const dialogRef = useRef<HTMLDialogElement>(null)
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const [deleteCommentId, setDeleteCommentId] = useState<number | null>(null)
 
+  const { data: post, isLoading } = useQuery({
+    queryKey: ['admin-community-detail', postId],
+    queryFn: () => fetchAdminCommunityDetail(postId!),
+    enabled: isOpen && postId !== null,
+  })
+
+  const { data: comments = [] } = useQuery({
+    queryKey: ['admin-community-comments', postId],
+    queryFn: () => fetchComments(postId!),
+    enabled: isOpen && postId !== null,
+  })
+
   useEffect(() => {
     const dialog = dialogRef.current
-    if (isOpen && post && !dialog?.open) {
+    if (isOpen && postId && !dialog?.open) {
       dialog?.showModal()
     } else if (!isOpen && dialog?.open) {
       dialog?.close()
     }
-  }, [isOpen, post])
+  }, [isOpen, postId])
 
   const handleClose = () => {
     setShowDeleteConfirm(false)
@@ -123,6 +148,11 @@ export default function CommunityDetailModal({ isOpen, post, onClose }: Communit
       }}
       onClose={handleClose}
     >
+      {isLoading && (
+        <div className="flex items-center justify-center py-20">
+          <p className="text-sm text-gray-500">로딩 중...</p>
+        </div>
+      )}
       {post && (
         <>
           {/* Header */}
@@ -144,23 +174,31 @@ export default function CommunityDetailModal({ isOpen, post, onClose }: Communit
               <div className="flex w-1/2 shrink-0 flex-col">
                 {/* Main image */}
                 <div className="mb-2 flex h-[260px] w-full items-center justify-center overflow-hidden rounded-lg border border-gray-200 bg-gray-100">
-                  <img
-                    src={post.image}
-                    alt={post.title}
-                    className="h-full w-full object-cover"
-                  />
+                  {post.imageUrls?.[0] ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={post.imageUrls[0]}
+                      alt={post.title}
+                      className="h-full w-full object-cover"
+                    />
+                  ) : (
+                    <svg className="h-12 w-12 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M2.25 15.75l5.159-5.159a2.25 2.25 0 013.182 0l5.159 5.159m-1.5-1.5l1.409-1.409a2.25 2.25 0 013.182 0l2.909 2.909M3.75 21h16.5A2.25 2.25 0 0022.5 18.75V5.25A2.25 2.25 0 0020.25 3H3.75A2.25 2.25 0 001.5 5.25v13.5A2.25 2.25 0 003.75 21z" />
+                    </svg>
+                  )}
                 </div>
 
                 {/* Sub images (always 4 cells) */}
                 <div className="mb-5 flex gap-2">
                   {Array.from({ length: 4 }, (_, idx) => {
-                    const src = post.subImages?.[idx]
+                    const src = post.imageUrls?.[idx + 1]
                     return (
                       <div
                         key={idx}
                         className="flex h-[60px] w-[60px] items-center justify-center overflow-hidden rounded-md border border-gray-200 bg-gray-50"
                       >
                         {src ? (
+                          // eslint-disable-next-line @next/next/no-img-element
                           <img
                             src={src}
                             alt={`서브이미지 ${idx + 1}`}
@@ -179,7 +217,7 @@ export default function CommunityDetailModal({ isOpen, post, onClose }: Communit
                 {/* Left info fields */}
                 <div className="grid grid-cols-2 gap-x-4 gap-y-4">
                   <Field label="게시글 ID" value={String(post.id)} />
-                  <Field label="닉네임" value={post.nickname} />
+                  <Field label="닉네임" value={post.authorNickname} />
                 </div>
                 <div className="mt-4">
                   <Field label="제목" value={post.title} />
@@ -204,25 +242,25 @@ export default function CommunityDetailModal({ isOpen, post, onClose }: Communit
                 <div className="mb-4">
                   <p className="mb-1.5 text-sm font-medium text-gray-500">유형</p>
                   <span
-                    className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${BOARD_TYPE_COLORS[post.boardType] ?? 'bg-gray-100 text-gray-800'}`}
+                    className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${BOARD_TYPE_COLORS[post.boardType ?? ''] ?? 'bg-gray-100 text-gray-800'}`}
                   >
-                    {post.boardType}
+                    {BOARD_TYPE_EN_TO_KO[post.boardType ?? ''] ?? post.boardType}
                   </span>
                 </div>
 
                 {/* 댓글 목록 */}
                 <div className="flex-1">
                   <p className="mb-1.5 text-sm font-medium text-gray-500">
-                    댓글 목록 ({post.comments.length})
+                    댓글 목록 ({comments.length})
                   </p>
                   <div className="max-h-[240px] overflow-y-auto rounded-lg border border-gray-200">
-                    {post.comments.length === 0 ? (
+                    {comments.length === 0 ? (
                       <div className="flex items-center justify-center py-8 text-sm text-gray-400">
                         댓글이 없습니다.
                       </div>
                     ) : (
                       <div className="divide-y divide-gray-100">
-                        {post.comments.map((comment) => (
+                        {comments.map((comment) => (
                           <div
                             key={comment.id}
                             className={`flex items-start justify-between gap-2 py-2.5 pr-3 ${comment.depth === 1 ? 'pl-7' : 'pl-3'}`}
@@ -230,7 +268,7 @@ export default function CommunityDetailModal({ isOpen, post, onClose }: Communit
                             <div className="min-w-0 flex-1">
                               <div className="flex items-center gap-2">
                                 <span className="text-sm font-semibold text-gray-900">
-                                  {comment.nickname}
+                                  {comment.authorNickname}
                                 </span>
                                 <span className="text-xs text-gray-400">
                                   {formatDateTime(comment.createdAt)}

--- a/src/features/admin/components/products/ProductDetailModal.tsx
+++ b/src/features/admin/components/products/ProductDetailModal.tsx
@@ -2,11 +2,18 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { X } from 'lucide-react'
-import type { MockProduct } from '../../mocks/mockProducts'
+import { useQuery } from '@tanstack/react-query'
+import { fetchAdminProductDetail } from '@/lib/api/admin'
+import {
+  PRODUCT_TYPE_EN_TO_KO,
+  TRADE_STATUS_EN_TO_KO,
+  PRODUCT_STATUS_EN_TO_KO,
+  CATEGORY_EN_TO_KO,
+} from '../../configs/productTableConfig'
 
 interface ProductDetailModalProps {
   isOpen: boolean
-  product: MockProduct | null
+  productId: number | null
   onClose: () => void
 }
 
@@ -24,7 +31,6 @@ function formatPrice(price: number) {
   return `${price.toLocaleString('ko-KR')}원`
 }
 
-/** Bordered field (left column) */
 function Field({ label, value }: { label: string; value: string }) {
   return (
     <div>
@@ -36,7 +42,6 @@ function Field({ label, value }: { label: string; value: string }) {
   )
 }
 
-/** Plain label + value (right column) */
 function SimpleField({ label, value }: { label: string; value: string }) {
   return (
     <div>
@@ -46,7 +51,6 @@ function SimpleField({ label, value }: { label: string; value: string }) {
   )
 }
 
-/** Plain label + badge (right column) */
 function SimpleBadgeField({ label, value, color }: { label: string; value: string; color: string }) {
   return (
     <div>
@@ -59,23 +63,22 @@ function SimpleBadgeField({ label, value, color }: { label: string; value: strin
 }
 
 const TRADE_STATUS_COLORS: Record<string, string> = {
-  요청중: 'bg-[#DCFCE7] text-green-800',
-  요청완료: 'bg-[#F3F4F6] text-gray-800',
-  판매중: 'bg-[#DCFCE7] text-green-800',
-  예약중: 'bg-[#FEF9C3] text-yellow-800',
-  판매완료: 'bg-[#F3F4F6] text-gray-800',
+  SELLING: 'bg-[#DCFCE7] text-green-800',
+  BUYING: 'bg-[#DCFCE7] text-green-800',
+  RESERVED: 'bg-[#FEF9C3] text-yellow-800',
+  COMPLETED: 'bg-[#F3F4F6] text-gray-800',
 }
 
 const PRODUCT_TYPE_COLORS: Record<string, string> = {
-  팝니다: 'bg-[#7BA5D6] text-white',
-  삽니다: 'bg-[#FFF7ED] text-orange-800',
+  SELL: 'bg-[#7BA5D6] text-white',
+  REQUEST: 'bg-[#FFF7ED] text-orange-800',
 }
 
 const CONDITION_COLORS: Record<string, string> = {
-  '새 상품': 'bg-[#DCFCE7] text-green-800',
-  '거의 새것': 'bg-[#DBEAFE] text-blue-800',
-  '사용감 있음': 'bg-[#FEF9C3] text-yellow-800',
-  '수리 필요': 'bg-[#FEE2E2] text-red-800',
+  NEW: 'bg-[#DCFCE7] text-green-800',
+  LIKE_NEW: 'bg-[#DBEAFE] text-blue-800',
+  USED: 'bg-[#FEF9C3] text-yellow-800',
+  NEED_REPAIR: 'bg-[#FEE2E2] text-red-800',
 }
 
 function DeleteConfirmDialog({
@@ -134,18 +137,24 @@ function DeleteConfirmDialog({
   )
 }
 
-export default function ProductDetailModal({ isOpen, product, onClose }: ProductDetailModalProps) {
+export default function ProductDetailModal({ isOpen, productId, onClose }: ProductDetailModalProps) {
   const dialogRef = useRef<HTMLDialogElement>(null)
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
 
+  const { data: product, isLoading } = useQuery({
+    queryKey: ['admin-product-detail', productId],
+    queryFn: () => fetchAdminProductDetail(productId!),
+    enabled: isOpen && productId !== null,
+  })
+
   useEffect(() => {
     const dialog = dialogRef.current
-    if (isOpen && product && !dialog?.open) {
+    if (isOpen && productId && !dialog?.open) {
       dialog?.showModal()
     } else if (!isOpen && dialog?.open) {
       dialog?.close()
     }
-  }, [isOpen, product])
+  }, [isOpen, productId])
 
   const handleClose = () => {
     setShowDeleteConfirm(false)
@@ -161,6 +170,11 @@ export default function ProductDetailModal({ isOpen, product, onClose }: Product
       }}
       onClose={handleClose}
     >
+      {isLoading && (
+        <div className="flex items-center justify-center py-20">
+          <p className="text-sm text-gray-500">로딩 중...</p>
+        </div>
+      )}
       {product && (
         <>
           {/* Header */}
@@ -182,22 +196,25 @@ export default function ProductDetailModal({ isOpen, product, onClose }: Product
               <div className="flex w-1/2 shrink-0 flex-col">
                 {/* Main image */}
                 <div className="mb-2 flex h-[260px] w-full items-center justify-center overflow-hidden rounded-lg border border-gray-200 bg-gray-100">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
                   <img
-                    src={product.image}
-                    alt={product.name}
+                    src={product.mainImageUrl}
+                    alt={product.title}
                     className="h-full w-full object-cover"
                   />
                 </div>
 
                 {/* Sub images */}
                 <div className="mb-5 flex gap-2">
-                  {(product.subImages?.length > 0 ? product.subImages : [null, null, null, null]).map(
-                    (src, idx) => (
+                  {Array.from({ length: 4 }, (_, idx) => {
+                    const src = product.subImageUrls?.[idx]
+                    return (
                       <div
                         key={idx}
                         className="flex h-[60px] w-[60px] items-center justify-center overflow-hidden rounded-md border border-gray-200 bg-gray-50"
                       >
                         {src ? (
+                          // eslint-disable-next-line @next/next/no-img-element
                           <img
                             src={src}
                             alt={`서브이미지 ${idx + 1}`}
@@ -209,17 +226,17 @@ export default function ProductDetailModal({ isOpen, product, onClose }: Product
                           </svg>
                         )}
                       </div>
-                    ),
-                  )}
+                    )
+                  })}
                 </div>
 
                 {/* Left info fields */}
                 <div className="grid grid-cols-2 gap-x-4 gap-y-4">
                   <Field label="상품 ID" value={String(product.id)} />
-                  <Field label="닉네임" value={product.nickname} />
+                  <Field label="판매자" value={product.sellerInfo?.sellerNickname ?? '-'} />
                 </div>
                 <div className="mt-4">
-                  <Field label="상품명" value={product.name} />
+                  <Field label="상품명" value={product.title} />
                 </div>
                 <div className="mt-4">
                   <Field label="지역" value={`${product.addressSido} ${product.addressGugun}`} />
@@ -232,7 +249,7 @@ export default function ProductDetailModal({ isOpen, product, onClose }: Product
                 <div className="mb-5">
                   <p className="mb-1.5 text-sm font-medium text-gray-500">상품 설명</p>
                   <div className="max-h-[200px] overflow-y-auto rounded-lg border border-gray-200 bg-gray-50/50 px-3 py-2.5 text-sm leading-relaxed text-gray-900">
-                    {product.description}
+                    {product.description || '-'}
                   </div>
                 </div>
 
@@ -240,24 +257,24 @@ export default function ProductDetailModal({ isOpen, product, onClose }: Product
                 <div className="grid grid-cols-2 gap-x-5 gap-y-5">
                   <SimpleBadgeField
                     label="거래 상태"
-                    value={product.tradeStatus}
-                    color={TRADE_STATUS_COLORS[product.tradeStatus] ?? 'bg-gray-100 text-gray-800'}
+                    value={TRADE_STATUS_EN_TO_KO[product.tradeStatus ?? ''] ?? product.tradeStatus ?? '-'}
+                    color={TRADE_STATUS_COLORS[product.tradeStatus ?? ''] ?? 'bg-gray-100 text-gray-800'}
                   />
                   <SimpleBadgeField
                     label="상품 상태"
-                    value={product.condition}
-                    color={CONDITION_COLORS[product.condition] ?? 'bg-gray-100 text-gray-800'}
+                    value={PRODUCT_STATUS_EN_TO_KO[product.productStatus] ?? product.productStatus}
+                    color={CONDITION_COLORS[product.productStatus] ?? 'bg-gray-100 text-gray-800'}
                   />
                   <SimpleBadgeField
                     label="유형"
-                    value={product.productType}
+                    value={PRODUCT_TYPE_EN_TO_KO[product.productType] ?? product.productType}
                     color={PRODUCT_TYPE_COLORS[product.productType] ?? 'bg-gray-100 text-gray-800'}
                   />
+                  <SimpleField label="카테고리" value={CATEGORY_EN_TO_KO[product.category] ?? product.category ?? '-'} />
                   <SimpleField label="가격" value={formatPrice(product.price)} />
-                  <SimpleField label="조회수" value={String(product.viewCount)} />
-                  <SimpleField label="찜 갯수" value={String(product.likeCount)} />
+                  <SimpleField label="조회수" value={String(product.viewCount ?? 0)} />
+                  <SimpleField label="찜 수" value={String(product.favoriteCount)} />
                   <SimpleField label="작성일시" value={formatDateTime(product.createdAt)} />
-                  <SimpleField label="수정일시" value={formatDateTime(product.updatedAt)} />
                 </div>
               </div>
             </div>

--- a/src/features/admin/configs/communityTableConfig.ts
+++ b/src/features/admin/configs/communityTableConfig.ts
@@ -1,7 +1,14 @@
 import type { TableConfig } from '../types/adminTable'
-import type { MockCommunityPost } from '../mocks/mockCommunityPosts'
+import type { CommunityItem } from '@/types/community'
 
-export const communityTableConfig: TableConfig<MockCommunityPost> = {
+const BOARD_TYPE_EN_TO_KO: Record<string, string> = {
+  QUESTION: '질문있어요',
+  INFO: '정보공유',
+}
+
+export { BOARD_TYPE_EN_TO_KO }
+
+export const communityTableConfig: TableConfig<CommunityItem> = {
   title: '커뮤니티 관리',
   rowKey: 'id',
   searchable: true,
@@ -15,12 +22,19 @@ export const communityTableConfig: TableConfig<MockCommunityPost> = {
       sortable: true,
       width: '110px',
       badgeOptions: [
-        { value: '질문있어요', label: '질문있어요', color: 'bg-blue-100 text-blue-800' },
-        { value: '정보공유', label: '정보공유', color: 'bg-green-100 text-green-800' },
+        { value: 'QUESTION', label: '질문있어요', color: 'bg-blue-100 text-blue-800' },
+        { value: 'INFO', label: '정보공유', color: 'bg-green-100 text-green-800' },
       ],
     },
     { key: 'title', label: '제목', type: 'text', sortable: true },
-    { key: 'nickname', label: '닉네임', type: 'text', sortable: true, width: '120px' },
+    { key: 'authorNickname', label: '닉네임', type: 'text', sortable: true, width: '120px' },
+    {
+      key: 'commentCount',
+      label: '댓글',
+      type: 'number',
+      sortable: true,
+      width: '70px',
+    },
     {
       key: 'createdAt',
       label: '작성일자',
@@ -51,14 +65,6 @@ export const communityTableConfig: TableConfig<MockCommunityPost> = {
       options: [
         { value: '질문있어요', label: '질문있어요' },
         { value: '정보공유', label: '정보공유' },
-      ],
-    },
-    {
-      key: 'sortOrder',
-      label: '정렬',
-      options: [
-        { value: '최신순', label: '최신순' },
-        { value: '오래된 순', label: '오래된 순' },
       ],
     },
   ],

--- a/src/features/admin/configs/productTableConfig.ts
+++ b/src/features/admin/configs/productTableConfig.ts
@@ -1,7 +1,30 @@
 import type { TableConfig } from '../types/adminTable'
-import type { MockProduct } from '../mocks/mockProducts'
+import type { Product } from '@/types/product'
+import { STATUS_EN_TO_KO, PRODUCT_CATEGORIES, CONDITION_ITEMS } from '@/constants/constants'
 
-export const productTableConfig: TableConfig<MockProduct> = {
+const PRODUCT_TYPE_EN_TO_KO: Record<string, string> = {
+  SELL: '팝니다',
+  REQUEST: '삽니다',
+}
+
+const TRADE_STATUS_EN_TO_KO: Record<string, string> = {
+  SELLING: '판매중',
+  BUYING: '요청중',
+  RESERVED: '예약중',
+  COMPLETED: '완료',
+}
+
+const PRODUCT_STATUS_EN_TO_KO: Record<string, string> = Object.fromEntries(
+  CONDITION_ITEMS.map((item) => [item.value, item.title]),
+)
+
+const CATEGORY_EN_TO_KO: Record<string, string> = Object.fromEntries(
+  PRODUCT_CATEGORIES.map((cat) => [cat.code, cat.name]),
+)
+
+export { PRODUCT_TYPE_EN_TO_KO, TRADE_STATUS_EN_TO_KO, PRODUCT_STATUS_EN_TO_KO, CATEGORY_EN_TO_KO }
+
+export const productTableConfig: TableConfig<Product> = {
   title: '상품 관리',
   rowKey: 'id',
   searchable: true,
@@ -15,14 +38,24 @@ export const productTableConfig: TableConfig<MockProduct> = {
       sortable: true,
       width: '90px',
       badgeOptions: [
-        { value: '팝니다', label: '팝니다', color: 'bg-[#7BA5D6] text-white' },
-        { value: '삽니다', label: '삽니다', color: 'bg-[#FFF7ED] text-orange-800' },
+        { value: 'SELL', label: '팝니다', color: 'bg-[#7BA5D6] text-white' },
+        { value: 'REQUEST', label: '삽니다', color: 'bg-[#FFF7ED] text-orange-800' },
       ],
     },
-    { key: 'image', label: '이미지', type: 'image', width: '80px' },
-    { key: 'name', label: '상품명', type: 'text', sortable: true },
-    { key: 'nickname', label: '닉네임', type: 'text', sortable: true },
-    { key: 'category', label: '카테고리', type: 'text', sortable: true, width: '120px' },
+    { key: 'mainImageUrl', label: '이미지', type: 'image', width: '80px' },
+    { key: 'title', label: '상품명', type: 'text', sortable: true },
+    {
+      key: 'productStatus',
+      label: '상품 상태',
+      type: 'badge',
+      width: '110px',
+      badgeOptions: [
+        { value: 'NEW', label: '새 상품', color: 'bg-[#DCFCE7] text-green-800' },
+        { value: 'LIKE_NEW', label: '거의 새것', color: 'bg-[#DBEAFE] text-blue-800' },
+        { value: 'USED', label: '사용감 있음', color: 'bg-[#FEF9C3] text-yellow-800' },
+        { value: 'NEED_REPAIR', label: '수리 필요', color: 'bg-[#FEE2E2] text-red-800' },
+      ],
+    },
     { key: 'price', label: '가격', type: 'currency', sortable: true, width: '120px' },
     {
       key: 'tradeStatus',
@@ -31,27 +64,15 @@ export const productTableConfig: TableConfig<MockProduct> = {
       sortable: true,
       width: '100px',
       badgeOptions: [
-        { value: '요청중', label: '요청중', color: 'bg-[#DCFCE7] text-green-800' },
-        { value: '요청완료', label: '요청완료', color: 'bg-[#F3F4F6] text-gray-800' },
-        { value: '판매중', label: '판매중', color: 'bg-[#DCFCE7] text-green-800' },
-        { value: '예약중', label: '예약중', color: 'bg-[#FEF9C3] text-yellow-800' },
-        { value: '판매완료', label: '판매완료', color: 'bg-[#F3F4F6] text-gray-800' },
+        { value: 'SELLING', label: '판매중', color: 'bg-[#DCFCE7] text-green-800' },
+        { value: 'BUYING', label: '요청중', color: 'bg-[#DCFCE7] text-green-800' },
+        { value: 'RESERVED', label: '예약중', color: 'bg-[#FEF9C3] text-yellow-800' },
+        { value: 'COMPLETED', label: '완료', color: 'bg-[#F3F4F6] text-gray-800' },
       ],
     },
     {
       key: 'createdAt',
       label: '작성일자',
-      type: 'date',
-      sortable: true,
-      width: '120px',
-      format: (v) => {
-        const d = new Date(v as string)
-        return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
-      },
-    },
-    {
-      key: 'updatedAt',
-      label: '수정일자',
       type: 'date',
       sortable: true,
       width: '120px',
@@ -66,26 +87,14 @@ export const productTableConfig: TableConfig<MockProduct> = {
       key: 'tradeStatus',
       label: '거래 상태',
       options: [
+        ...STATUS_EN_TO_KO.map((s) => ({ value: s.name, label: s.name })),
         { value: '요청중', label: '요청중' },
-        { value: '요청완료', label: '요청완료' },
-        { value: '판매중', label: '판매중' },
-        { value: '예약중', label: '예약중' },
-        { value: '판매완료', label: '판매완료' },
       ],
     },
     {
       key: 'category',
       label: '카테고리',
-      options: [
-        { value: '사료/간식', label: '사료/간식' },
-        { value: '장난감', label: '장난감' },
-        { value: '사육장/하우스', label: '사육장/하우스' },
-        { value: '건강/위생', label: '건강/위생' },
-        { value: '의류/악세사리', label: '의류/악세사리' },
-        { value: '이동장/목줄', label: '이동장/목줄' },
-        { value: '미용용품', label: '미용용품' },
-        { value: '기타', label: '기타' },
-      ],
+      options: PRODUCT_CATEGORIES.map((cat) => ({ value: cat.name, label: cat.name })),
     },
     {
       key: 'productType',

--- a/src/lib/api/admin.ts
+++ b/src/lib/api/admin.ts
@@ -1,11 +1,11 @@
 import { api } from './api'
 import { useUserStore } from '@/store/userStore'
 import type { AdminTableResponse, SortState, FilterState } from '@/features/admin/types/adminTable'
-import type { MockProduct } from '@/features/admin/mocks/mockProducts'
+import type { Product, ProductResponse, ProductDetailItem, ProductDetailItemResponse } from '@/types/product'
+import type { CommunityItem, CommunityResponse, CommunityDetailItem, CommunityDetailItemResponse } from '@/types/community'
 import type { MockUser } from '@/features/admin/mocks/mockUsers'
 import type { MockWithdrawal } from '@/features/admin/mocks/mockWithdrawals'
 import type { MonthlyMemberStat, WithdrawalReasonStat, MonthlyWithdrawalReasonStat } from '@/features/admin/mocks/mockMemberStats'
-import type { MockCommunityPost } from '@/features/admin/mocks/mockCommunityPosts'
 import type { MockUserReport } from '@/features/admin/mocks/mockUserReports'
 import type { MockProductSellReport } from '@/features/admin/mocks/mockProductSellReports'
 import type { MockProductRequestReport } from '@/features/admin/mocks/mockProductRequestReports'
@@ -24,156 +24,191 @@ function hasAuth(): boolean {
   return !!useUserStore.getState().accessToken
 }
 
-// 상품 목록 조회
-export async function fetchAdminProducts(params: FetchParams): Promise<AdminTableResponse<MockProduct>> {
+// ========== 응답 변환 ==========
+
+/** Spring Boot Page 응답 → AdminTableResponse 변환 */
+function toAdminTableResponse<T>(
+  data: { content: T[]; totalElements: number; page: number; size: number },
+  page: number,
+  pageSize: number,
+): AdminTableResponse<T> {
+  return {
+    data: data.content,
+    total: data.totalElements ?? data.content.length,
+    page,
+    pageSize,
+  }
+}
+
+// ========== Enum 매핑 (필터용: 한글 → 영문) ==========
+
+const PRODUCT_TYPE_KO_TO_EN: Record<string, string> = {
+  '팝니다': 'SELL',
+  '삽니다': 'REQUEST',
+}
+
+const TRADE_STATUS_KO_TO_EN: Record<string, string> = {
+  '판매중': 'SELLING',
+  '요청중': 'BUYING',
+  '예약중': 'RESERVED',
+  '판매완료': 'COMPLETED',
+  '요청완료': 'COMPLETED',
+}
+
+const CATEGORY_KO_TO_EN: Record<string, string> = {
+  '사료/간식': 'FOOD',
+  '장난감': 'TOY',
+  '사육장/하우스': 'HOUSE',
+  '건강/위생': 'HEALTH',
+  '의류/악세사리': 'CLOTHING',
+  '이동장/목줄': 'WALKING',
+  '미용용품': 'GROOMING',
+  '기타': 'ETC',
+}
+
+const BOARD_TYPE_KO_TO_EN: Record<string, string> = {
+  '질문있어요': 'QUESTION',
+  '정보공유': 'INFO',
+}
+
+// ========== 상품 API ==========
+
+export async function fetchAdminProducts(params: FetchParams): Promise<AdminTableResponse<Product>> {
   if (hasAuth()) {
     try {
-      const { data } = await api.get('/admin/products', { params })
-      return data
+      const searchParams = new URLSearchParams({
+        page: String(params.page - 1), // Spring은 0-based
+        size: String(params.pageSize),
+      })
+
+      if (params.search) {
+        searchParams.set('keyword', params.search)
+      }
+      if (params.filters?.productType) {
+        searchParams.set('productType', PRODUCT_TYPE_KO_TO_EN[params.filters.productType] || params.filters.productType)
+      }
+      if (params.filters?.tradeStatus) {
+        // tradeStatus는 검색 API에서 직접 지원하지 않을 수 있음
+      }
+      if (params.filters?.category) {
+        searchParams.set('categories', CATEGORY_KO_TO_EN[params.filters.category] || params.filters.category)
+      }
+      if (params.sort?.direction) {
+        searchParams.set('sortBy', params.sort.key)
+        searchParams.set('sortOrder', params.sort.direction === 'asc' ? 'ASC' : 'DESC')
+      }
+
+      const { data } = await api.get<ProductResponse>(`/products/search?${searchParams.toString()}`)
+      return toAdminTableResponse(data.data, params.page, params.pageSize)
     } catch {
       // API 실패 시 목 데이터 fallback
     }
   }
   const { getMockProducts } = await import('@/features/admin/mocks/mockProducts')
-  return getMockProducts(params)
+  return getMockProducts(params) as unknown as AdminTableResponse<Product>
 }
 
-// 사용자 목록 조회
-export async function fetchAdminUsers(params: FetchParams): Promise<AdminTableResponse<MockUser>> {
+export async function fetchAdminProductDetail(id: number): Promise<ProductDetailItem | null> {
+  try {
+    const { data } = await api.get<ProductDetailItemResponse>(`/products/${id}`)
+    return data.data
+  } catch {
+    return null
+  }
+}
+
+// ========== 커뮤니티 API ==========
+
+export async function fetchAdminCommunityPosts(params: FetchParams): Promise<AdminTableResponse<CommunityItem>> {
   if (hasAuth()) {
     try {
-      const { data } = await api.get('/admin/users', { params })
-      return data
+      const searchParams = new URLSearchParams({
+        page: String(params.page - 1),
+        size: String(params.pageSize),
+      })
+
+      if (params.filters?.boardType) {
+        searchParams.set('boardType', BOARD_TYPE_KO_TO_EN[params.filters.boardType] || params.filters.boardType)
+      }
+      if (params.search) {
+        searchParams.set('keyword', params.search)
+        searchParams.set('searchType', 'TITLE')
+      }
+      if (params.sort?.direction) {
+        searchParams.set('sortBy', params.sort.key === 'createdAt' ? 'LATEST' : params.sort.key)
+      }
+
+      const { data } = await api.get<CommunityResponse>(`/community/posts?${searchParams.toString()}`)
+      return toAdminTableResponse(data.data, params.page, params.pageSize)
     } catch {
       // API 실패 시 목 데이터 fallback
     }
   }
+  const { getMockCommunityPosts } = await import('@/features/admin/mocks/mockCommunityPosts')
+  return getMockCommunityPosts(params) as unknown as AdminTableResponse<CommunityItem>
+}
+
+export async function fetchAdminCommunityDetail(id: number): Promise<CommunityDetailItem | null> {
+  try {
+    const { data } = await api.get<CommunityDetailItemResponse>(`/community/posts/${id}`)
+    return data.data
+  } catch {
+    return null
+  }
+}
+
+// ========== 이하 아직 실제 API 없는 도메인 (mock 유지) ==========
+
+// 사용자 목록 조회
+export async function fetchAdminUsers(params: FetchParams): Promise<AdminTableResponse<MockUser>> {
   const { getMockUsers } = await import('@/features/admin/mocks/mockUsers')
   return getMockUsers(params)
 }
 
 // 탈퇴 회원 목록 조회
 export async function fetchAdminWithdrawals(params: FetchParams): Promise<AdminTableResponse<MockWithdrawal>> {
-  if (hasAuth()) {
-    try {
-      const { data } = await api.get('/admin/withdrawals', { params })
-      return data
-    } catch {
-      // API 실패 시 목 데이터 fallback
-    }
-  }
   const { getMockWithdrawals } = await import('@/features/admin/mocks/mockWithdrawals')
   return getMockWithdrawals(params)
 }
 
 // 월별 가입/탈퇴 추세 데이터
 export async function fetchMemberStats(): Promise<MonthlyMemberStat[]> {
-  if (hasAuth()) {
-    try {
-      const { data } = await api.get('/admin/members/stats')
-      return data
-    } catch {
-      // API 실패 시 목 데이터 fallback
-    }
-  }
   const { mockMemberStats } = await import('@/features/admin/mocks/mockMemberStats')
   return mockMemberStats
 }
 
 // 탈퇴 사유별 통계
 export async function fetchWithdrawalReasons(): Promise<WithdrawalReasonStat[]> {
-  if (hasAuth()) {
-    try {
-      const { data } = await api.get('/admin/members/withdrawal-reasons')
-      return data
-    } catch {
-      // API 실패 시 목 데이터 fallback
-    }
-  }
   const { mockWithdrawalReasons } = await import('@/features/admin/mocks/mockMemberStats')
   return mockWithdrawalReasons
 }
 
 // 탈퇴 사유별 월별 추세
 export async function fetchMonthlyWithdrawalReasons(): Promise<MonthlyWithdrawalReasonStat[]> {
-  if (hasAuth()) {
-    try {
-      const { data } = await api.get('/admin/members/monthly-withdrawal-reasons')
-      return data
-    } catch {
-      // API 실패 시 목 데이터 fallback
-    }
-  }
   const { mockMonthlyWithdrawalReasons } = await import('@/features/admin/mocks/mockMemberStats')
   return mockMonthlyWithdrawalReasons
 }
 
-// 커뮤니티 게시글 목록 조회
-export async function fetchAdminCommunityPosts(params: FetchParams): Promise<AdminTableResponse<MockCommunityPost>> {
-  if (hasAuth()) {
-    try {
-      const { data } = await api.get('/admin/community', { params })
-      return data
-    } catch {
-      // API 실패 시 목 데이터 fallback
-    }
-  }
-  const { getMockCommunityPosts } = await import('@/features/admin/mocks/mockCommunityPosts')
-  return getMockCommunityPosts(params)
-}
-
 // 유저신고 목록 조회
 export async function fetchAdminUserReports(params: FetchParams): Promise<AdminTableResponse<MockUserReport>> {
-  if (hasAuth()) {
-    try {
-      const { data } = await api.get('/admin/reports/user', { params })
-      return data
-    } catch {
-      // API 실패 시 목 데이터 fallback
-    }
-  }
   const { getMockUserReports } = await import('@/features/admin/mocks/mockUserReports')
   return getMockUserReports(params)
 }
 
 // 판매상품 신고 목록 조회
 export async function fetchAdminProductSellReports(params: FetchParams): Promise<AdminTableResponse<MockProductSellReport>> {
-  if (hasAuth()) {
-    try {
-      const { data } = await api.get('/admin/reports/product-sell', { params })
-      return data
-    } catch {
-      // API 실패 시 목 데이터 fallback
-    }
-  }
   const { getMockProductSellReports } = await import('@/features/admin/mocks/mockProductSellReports')
   return getMockProductSellReports(params)
 }
 
 // 판매요청 상품 신고 목록 조회
 export async function fetchAdminProductRequestReports(params: FetchParams): Promise<AdminTableResponse<MockProductRequestReport>> {
-  if (hasAuth()) {
-    try {
-      const { data } = await api.get('/admin/reports/product-request', { params })
-      return data
-    } catch {
-      // API 실패 시 목 데이터 fallback
-    }
-  }
   const { getMockProductRequestReports } = await import('@/features/admin/mocks/mockProductRequestReports')
   return getMockProductRequestReports(params)
 }
 
 // 커뮤니티 신고 목록 조회
 export async function fetchAdminCommunityReports(params: FetchParams): Promise<AdminTableResponse<MockCommunityReport>> {
-  if (hasAuth()) {
-    try {
-      const { data } = await api.get('/admin/reports/community', { params })
-      return data
-    } catch {
-      // API 실패 시 목 데이터 fallback
-    }
-  }
   const { getMockCommunityReports } = await import('@/features/admin/mocks/mockCommunityReports')
   return getMockCommunityReports(params)
 }
@@ -187,14 +222,6 @@ export interface DashboardStats {
 }
 
 export async function fetchDashboardStats(): Promise<DashboardStats> {
-  if (hasAuth()) {
-    try {
-      const { data } = await api.get('/admin/dashboard/stats')
-      return data
-    } catch {
-      // API 실패 시 목 데이터 fallback
-    }
-  }
   return {
     totalProducts: 50,
     totalUsers: 30,


### PR DESCRIPTION
## 📌 개요

- 어드민 페이지의 상품/커뮤니티 관리를 mock 데이터에서 실제 REST API 연동으로 전환

## 🔧 작업 내용

- [x] `admin.ts`: 상품 목록(`/products/search`), 상세(`/products/{id}`) API 호출 추가
- [x] `admin.ts`: 커뮤니티 목록(`/community/posts`), 상세(`/community/posts/{id}`) API 호출 추가
- [x] `admin.ts`: 한글→영문 enum 매핑 (필터용), Spring Boot Page 응답 변환 함수 추가
- [x] `productTableConfig.ts`: 실제 API 응답 필드에 맞게 컬럼/필터/배지 재구성
- [x] `communityTableConfig.ts`: 실제 API 응답 필드에 맞게 컬럼/필터/배지 재구성
- [x] `ProductDetailModal.tsx`: useQuery로 상세 데이터 fetch, 실제 필드명 적용
- [x] `CommunityDetailModal.tsx`: useQuery로 상세 데이터 및 댓글 API fetch 적용
- [x] `ProductsManagement.tsx`, `CommunityManagement.tsx`: Product/CommunityItem 타입으로 전환
- [x] 인증 실패 또는 API 미응답 시 mock 데이터 fallback 유지

## 📎 관련 이슈

Closes #411

## 💬 리뷰어 참고 사항

- 사용자/탈퇴회원/신고/통계 등 나머지 도메인은 아직 백엔드 admin API가 없어 mock 데이터를 유지합니다
- API 실패 시 자동으로 mock fallback되므로 백엔드 미연결 환경에서도 정상 동작합니다