### PR TITLE
refactor: 코어 웹 바이탈 성능 최적화(#413)

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,62 +1,13 @@
-'use client'
-
-import { usePathname } from 'next/navigation'
-import { useMediaQuery } from '@/hooks/useMediaQuery'
-import { ROUTES } from '@/constants/routes'
 import Header from '@/components/header/Header'
 import type { ReactNode } from 'react'
 
-// ========== 공통 동적 경로 패턴 ==========
-const COMMUNITY_DETAIL = /^\/community\/\d+$/
-const COMMUNITY_EDIT = /^\/community\/\d+\/edit$/
-
-// Header 숨김 패턴 (모바일에서만 숨김)
-const HIDE_HEADER_MOBILE_PATTERNS = [COMMUNITY_DETAIL, COMMUNITY_EDIT, new RegExp(`^${ROUTES.COMMUNITY_POST}$`)]
-
-// SearchBar 숨김 경로 - 모바일만 (정적 경로)
-const HIDE_SEARCHBAR_MOBILE_PATHS: string[] = [ROUTES.MYPAGE]
-
-// SearchBar 숨김 경로 - 항상 (정적 경로)
-const HIDE_SEARCHBAR_ALWAYS_PATHS: string[] = [
-  ROUTES.COMMUNITY,
-  ROUTES.COMMUNITY_POST,
-  ROUTES.LOGIN,
-  ROUTES.SIGNUP,
-  ROUTES.FIND_PASSWORD,
-  ROUTES.PROFILE_UPDATE,
-  ROUTES.PRODUCT_POST,
-  ROUTES.CHAT,
-]
-
-// 메뉴 버튼 숨김 경로
-const HIDE_MENU_BUTTON_PATHS: string[] = [ROUTES.LOGIN, ROUTES.SIGNUP]
-
-// SearchBar 숨김 패턴 - 모바일만 (동적 경로)
-const HIDE_SEARCHBAR_MOBILE_PATTERNS = [/^\/user-profile\/\d+$/]
-
-// SearchBar 숨김 패턴 - 항상 (동적 경로)
-const HIDE_SEARCHBAR_ALWAYS_PATTERNS = [COMMUNITY_DETAIL, COMMUNITY_EDIT, /^\/products\/\d+\/edit$/, /^\/chat\/\d+$/]
-
 export default function MainLayout({ children }: { children: ReactNode }) {
-  const isXl = useMediaQuery('(min-width: 1280px)')
-  const pathname = usePathname()
-
-  const hideHeaderMobile = !isXl && HIDE_HEADER_MOBILE_PATTERNS.some((pattern) => pattern.test(pathname))
-  const showHeader = !hideHeaderMobile
-  const hideSearchBarMobile =
-    !isXl &&
-    (HIDE_SEARCHBAR_MOBILE_PATHS.includes(pathname) || HIDE_SEARCHBAR_MOBILE_PATTERNS.some((pattern) => pattern.test(pathname)))
-  const hideSearchBarAlways =
-    HIDE_SEARCHBAR_ALWAYS_PATHS.includes(pathname) || HIDE_SEARCHBAR_ALWAYS_PATTERNS.some((pattern) => pattern.test(pathname))
-  const hideSearchBar = hideSearchBarMobile || hideSearchBarAlways
-  const hideMenuButton = HIDE_MENU_BUTTON_PATHS.includes(pathname)
-
   return (
     <div className="flex min-h-screen flex-col">
-      {showHeader && <Header hideSearchBar={hideSearchBar} hideMenuButton={hideMenuButton} />}
+      <Header />
       <main
         className="w-full flex-1 transition-[padding-top] duration-300"
-        style={{ paddingTop: showHeader ? 'var(--header-height, 72px)' : '0' }}
+        style={{ paddingTop: 'var(--header-height, 72px)' }}
       >
         {children}
       </main>

--- a/src/components/ClientComponents.tsx
+++ b/src/components/ClientComponents.tsx
@@ -3,6 +3,8 @@
 import { useEffect } from 'react'
 import dynamic from 'next/dynamic'
 import { useUserStore } from '@/store/userStore'
+import { useLoginModalStore } from '@/store/modalStore'
+import { useToastStore } from '@/store/toastStore'
 
 // SSR 비활성화로 클라이언트에서만 렌더링
 const AuthValidator = dynamic(() => import('@/components/AuthValidator'), { ssr: false })
@@ -13,10 +15,13 @@ const ToastContainer = dynamic(() => import('@/components/commons/ToastContainer
  * 클라이언트에서만 렌더링되는 전역 컴포넌트들
  * - StoreHydration: Zustand persist 스토어를 클라이언트에서 rehydrate
  * - AuthValidator: 앱 시작 시 인증 상태 검증
- * - LoginModal: 전역 로그인/로그아웃 모달
- * - ToastContainer: 전역 토스트 알림
+ * - LoginModal: 전역 로그인/로그아웃 모달 (열릴 때만 로드)
+ * - ToastContainer: 전역 토스트 알림 (토스트가 있을 때만 로드)
  */
 export default function ClientComponents() {
+  const isLoginModalOpen = useLoginModalStore((state) => state.isOpen)
+  const hasToasts = useToastStore((state) => state.visible.length > 0 || state.queue.length > 0)
+
   useEffect(() => {
     useUserStore.persist.rehydrate()
   }, [])
@@ -24,8 +29,8 @@ export default function ClientComponents() {
   return (
     <>
       <AuthValidator />
-      <LoginModal />
-      <ToastContainer />
+      {isLoginModalOpen && <LoginModal />}
+      {hasToasts && <ToastContainer />}
     </>
   )
 }

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -7,36 +7,75 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { ROUTES } from '@/constants/routes'
 import { useMediaQuery } from '@/hooks/useMediaQuery'
-import { Suspense, useEffect, useRef, useState } from 'react'
+import { Suspense, useEffect, useState } from 'react'
 import IconButton from '@/components/commons/button/IconButton'
 import SearchBar from '@/components/header/components/SearchBar'
 import { Search } from 'lucide-react'
 import UserControls from '@/components/header/components/UserControls'
 import MobileNavigation from '@/components/header/components/MobileNavigation'
 
-interface HeaderProps {
-  hideSearchBar?: boolean
-  hideMenuButton?: boolean
-}
+// ========== 공통 동적 경로 패턴 ==========
+const COMMUNITY_DETAIL = /^\/community\/\d+$/
+const COMMUNITY_EDIT = /^\/community\/\d+\/edit$/
 
-export default function Header({ hideSearchBar = false, hideMenuButton = false }: HeaderProps) {
+// Header 숨김 패턴 (모바일에서만 숨김)
+const HIDE_HEADER_MOBILE_PATTERNS = [COMMUNITY_DETAIL, COMMUNITY_EDIT, new RegExp(`^${ROUTES.COMMUNITY_POST}$`)]
+
+// SearchBar 숨김 경로 - 모바일만 (정적 경로)
+const HIDE_SEARCHBAR_MOBILE_PATHS: string[] = [ROUTES.MYPAGE]
+
+// SearchBar 숨김 경로 - 항상 (정적 경로)
+const HIDE_SEARCHBAR_ALWAYS_PATHS: string[] = [
+  ROUTES.COMMUNITY,
+  ROUTES.COMMUNITY_POST,
+  ROUTES.LOGIN,
+  ROUTES.SIGNUP,
+  ROUTES.FIND_PASSWORD,
+  ROUTES.PROFILE_UPDATE,
+  ROUTES.PRODUCT_POST,
+  ROUTES.CHAT,
+]
+
+// 메뉴 버튼 숨김 경로
+const HIDE_MENU_BUTTON_PATHS: string[] = [ROUTES.LOGIN, ROUTES.SIGNUP]
+
+// SearchBar 숨김 패턴 - 모바일만 (동적 경로)
+const HIDE_SEARCHBAR_MOBILE_PATTERNS = [/^\/user-profile\/\d+$/]
+
+// SearchBar 숨김 패턴 - 항상 (동적 경로)
+const HIDE_SEARCHBAR_ALWAYS_PATTERNS = [COMMUNITY_DETAIL, COMMUNITY_EDIT, /^\/products\/\d+\/edit$/, /^\/chat\/\d+$/]
+
+export default function Header() {
   const isXl = useMediaQuery('(min-width: 1280px)')
   const [isSideOpen, setIsSideOpen] = useState(false)
   const [isSearchOpen, setIsSearchOpen] = useState(false)
-  const searchBarRef = useRef<HTMLDivElement>(null)
-  const [searchBarHeight, setSearchBarHeight] = useState(0)
+  // 검색바 높이: h-8(32px) 고정 디자인이므로 상수 사용 (scrollHeight 접근에 의한 강제 리플로우 방지)
+  const searchBarHeight = 32
   const pathname = usePathname()
+
+  // 가시성 계산
+  const hideHeaderMobile = !isXl && HIDE_HEADER_MOBILE_PATTERNS.some((pattern) => pattern.test(pathname))
+  const showHeader = !hideHeaderMobile
+  const hideSearchBarMobile =
+    !isXl &&
+    (HIDE_SEARCHBAR_MOBILE_PATHS.includes(pathname) || HIDE_SEARCHBAR_MOBILE_PATTERNS.some((pattern) => pattern.test(pathname)))
+  const hideSearchBarAlways =
+    HIDE_SEARCHBAR_ALWAYS_PATHS.includes(pathname) || HIDE_SEARCHBAR_ALWAYS_PATTERNS.some((pattern) => pattern.test(pathname))
+  const hideSearchBar = hideSearchBarMobile || hideSearchBarAlways
+  const hideMenuButton = HIDE_MENU_BUTTON_PATHS.includes(pathname)
+
   const isMarketActive = pathname === '/' || pathname.startsWith('/market')
   const isCommunityActive = pathname.startsWith('/community')
 
+  // 헤더 높이를 CSS 변수로 설정 (검색바 열림/닫힘 및 헤더 가시성에 따라)
   useEffect(() => {
-    if (searchBarRef.current) {
-      setSearchBarHeight(searchBarRef.current.scrollHeight)
+    if (!showHeader) {
+      document.documentElement.style.setProperty('--header-height', '0px')
+      return () => {
+        document.documentElement.style.removeProperty('--header-height')
+      }
     }
-  }, [])
 
-  // 헤더 높이를 CSS 변수로 설정 (검색바 열림/닫힘에 따라)
-  useEffect(() => {
     // 기본 헤더 높이: pt-3(12px) + h-12(48px) + pb-3(12px) = 72px
     // 검색바 열림 시: 72px + marginTop(12px) + searchBarHeight + marginBottom(12px)
     const baseHeight = 72
@@ -51,7 +90,9 @@ export default function Header({ hideSearchBar = false, hideMenuButton = false }
     return () => {
       document.documentElement.style.removeProperty('--header-height')
     }
-  }, [isSearchOpen, searchBarHeight, isXl])
+  }, [showHeader, isSearchOpen, isXl])
+
+  if (!showHeader) return null
 
   return (
     <>
@@ -100,7 +141,6 @@ export default function Header({ hideSearchBar = false, hideMenuButton = false }
           {/* 모바일 검색바 - 아코디언 */}
           {!hideSearchBar && (
             <div
-              ref={searchBarRef}
               className="overflow-hidden transition-all duration-300 xl:hidden"
               style={{
                 height: isSearchOpen ? `${searchBarHeight}px` : '0',


### PR DESCRIPTION
## 📌 개요

- Lighthouse 성능 점수 63점 → TBT 1,050ms, Style & Layout 2,133ms 병목 해결을 위한 최적화

## 🔧 작업 내용

- [ ] `(main)/layout.tsx`에서 `'use client'` 제거 → 서버 컴포넌트로 전환 (65줄 → 15줄)
- [ ] 헤더 가시성 로직(경로 패턴 매칭, useMediaQuery, usePathname)을 Header 내부로 이동
- [ ] Header `scrollHeight` 측정 → 상수(32px) 대체로 강제 리플로우 제거
- [ ] ToastContainer를 toast 존재 시에만 로드하여 framer-motion 초기 번들 제거
- [ ] LoginModal을 모달 열림 시에만 로드하여 불필요한 초기 JS 제거

## 📎 관련 이슈

Closes #413

## 💬 리뷰어 참고 사항

- layout이 서버 컴포넌트가 되면서 `--header-height` CSS 변수의 기본값이 `72px`로 설정됩니다. 헤더가 숨겨지는 모바일 경로에서는 Header가 `--header-height: 0px`을 설정한 후 `return null`합니다.
- `searchBarHeight`를 `h-8`(32px) 기준 상수로 변경했으므로, 검색바 높이 디자인이 변경되면 이 상수도 함께 수정해야 합니다.