### PR TITLE
feat: 어드민 전체 도메인 실제 API 연동(#415)

### DIFF
--- a/src/features/admin/components/ProductsManagement.tsx
+++ b/src/features/admin/components/ProductsManagement.tsx
@@ -4,14 +4,14 @@ import { useState } from 'react'
 import AdminTable from './table/AdminTable'
 import { productTableConfig } from '../configs/productTableConfig'
 import { fetchAdminProducts } from '@/lib/api/admin'
-import type { Product } from '@/types/product'
+import type { AdminProduct } from '../types/adminApi'
 import ProductDetailModal from './products/ProductDetailModal'
 
 export default function ProductsManagement() {
   const [selectedProductId, setSelectedProductId] = useState<number | null>(null)
   return (
     <>
-      <AdminTable<Product>
+      <AdminTable<AdminProduct>
         config={productTableConfig}
         queryKey="admin-products"
         fetchFn={fetchAdminProducts}

--- a/src/features/admin/components/UsersManagement.tsx
+++ b/src/features/admin/components/UsersManagement.tsx
@@ -4,15 +4,15 @@ import { useState } from 'react'
 import AdminTable from './table/AdminTable'
 import { userTableConfig } from '../configs/userTableConfig'
 import { fetchAdminUsers } from '@/lib/api/admin'
-import type { MockUser } from '../mocks/mockUsers'
+import type { AdminUser } from '../types/adminApi'
 import UserDetailModal from './users/UserDetailModal'
 
 export default function UsersManagement() {
-  const [selectedUser, setSelectedUser] = useState<MockUser | null>(null)
+  const [selectedUser, setSelectedUser] = useState<AdminUser | null>(null)
 
   return (
     <>
-      <AdminTable<MockUser>
+      <AdminTable<AdminUser>
         config={userTableConfig}
         queryKey="admin-users"
         fetchFn={fetchAdminUsers}

--- a/src/features/admin/components/WithdrawalsManagement.tsx
+++ b/src/features/admin/components/WithdrawalsManagement.tsx
@@ -3,11 +3,11 @@
 import AdminTable from './table/AdminTable'
 import { withdrawalTableConfig } from '../configs/withdrawalTableConfig'
 import { fetchAdminWithdrawals } from '@/lib/api/admin'
-import type { MockWithdrawal } from '../mocks/mockWithdrawals'
+import type { AdminWithdrawal } from '../types/adminApi'
 
 export default function WithdrawalsManagement() {
   return (
-    <AdminTable<MockWithdrawal>
+    <AdminTable<AdminWithdrawal>
       config={withdrawalTableConfig}
       queryKey="admin-withdrawals"
       fetchFn={fetchAdminWithdrawals}

--- a/src/features/admin/components/dashboard/AdminDashboard.tsx
+++ b/src/features/admin/components/dashboard/AdminDashboard.tsx
@@ -1,8 +1,7 @@
 'use client'
 
 import { useQuery } from '@tanstack/react-query'
-import { Package, Users, ArrowLeftRight, Banknote } from 'lucide-react'
-import { formatPrice } from '@/lib/utils/formatPrice'
+import { Package, Users, UserCheck, UserX, ShoppingBag } from 'lucide-react'
 import { fetchDashboardStats } from '@/lib/api/admin'
 import StatCard from './StatCard'
 
@@ -15,26 +14,31 @@ export default function AdminDashboard() {
   return (
     <div>
       <h1 className="mb-6 text-2xl font-bold text-gray-900">대시보드</h1>
-      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
+      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
         <StatCard
-          title="총 상품"
-          value={stats ? `${stats.totalProducts.toLocaleString()}개` : '-'}
-          icon={Package}
-        />
-        <StatCard
-          title="총 사용자"
-          value={stats ? `${stats.totalUsers.toLocaleString()}명` : '-'}
+          title="전체 회원"
+          value={stats ? `${stats.totalUserCount.toLocaleString()}명` : '-'}
           icon={Users}
         />
         <StatCard
-          title="총 거래"
-          value={stats ? `${stats.totalTransactions.toLocaleString()}건` : '-'}
-          icon={ArrowLeftRight}
+          title="활성 회원"
+          value={stats ? `${stats.activeUserCount.toLocaleString()}명` : '-'}
+          icon={UserCheck}
         />
         <StatCard
-          title="총 거래액"
-          value={stats ? `${formatPrice(stats.totalRevenue)}원` : '-'}
-          icon={Banknote}
+          title="탈퇴 회원"
+          value={stats ? `${stats.withdrawnUserCount.toLocaleString()}명` : '-'}
+          icon={UserX}
+        />
+        <StatCard
+          title="전체 상품"
+          value={stats ? `${stats.totalProductCount.toLocaleString()}개` : '-'}
+          icon={Package}
+        />
+        <StatCard
+          title="활성 상품"
+          value={stats ? `${stats.activeProductCount.toLocaleString()}개` : '-'}
+          icon={ShoppingBag}
         />
       </div>
     </div>

--- a/src/features/admin/components/members/MembersDashboard.tsx
+++ b/src/features/admin/components/members/MembersDashboard.tsx
@@ -6,8 +6,9 @@ import SignupTrendChart from './SignupTrendChart'
 import WithdrawalTrendChart from './WithdrawalTrendChart'
 import WithdrawalReasonChart from './WithdrawalReasonChart'
 import WithdrawalReasonTrendChart from './WithdrawalReasonTrendChart'
-import { fetchMemberStats, fetchWithdrawalReasons, fetchMonthlyWithdrawalReasons } from '@/lib/api/admin'
-import type { MonthlyMemberStat, WithdrawalReasonStat, MonthlyWithdrawalReasonStat } from '@/features/admin/mocks/mockMemberStats'
+import { fetchMemberStats, fetchWithdrawalReasons } from '@/lib/api/admin'
+import type { MemberTrendStat, WithdrawalReasonStat } from '@/features/admin/types/adminApi'
+import type { MonthlyWithdrawalReasonStat } from '@/features/admin/mocks/mockMemberStats'
 
 const DASHBOARD_TABS = [
   { id: 'signup', label: '회원 가입 추세', code: 'signup' },
@@ -17,7 +18,7 @@ const DASHBOARD_TABS = [
 
 export default function MembersDashboard() {
   const [activeTab, setActiveTab] = useState('signup')
-  const [stats, setStats] = useState<MonthlyMemberStat[]>([])
+  const [stats, setStats] = useState<MemberTrendStat[]>([])
   const [reasons, setReasons] = useState<WithdrawalReasonStat[]>([])
   const [monthlyReasons, setMonthlyReasons] = useState<MonthlyWithdrawalReasonStat[]>([])
 
@@ -25,11 +26,13 @@ export default function MembersDashboard() {
     Promise.all([
       fetchMemberStats(),
       fetchWithdrawalReasons(),
-      fetchMonthlyWithdrawalReasons(),
-    ]).then(([statsData, reasonsData, monthlyData]) => {
+    ]).then(([statsData, reasonsData]) => {
       setStats(statsData)
       setReasons(reasonsData)
-      setMonthlyReasons(monthlyData)
+    })
+    // Monthly withdrawal reasons - still mock only (no API endpoint)
+    import('@/features/admin/mocks/mockMemberStats').then(({ mockMonthlyWithdrawalReasons }) => {
+      setMonthlyReasons(mockMonthlyWithdrawalReasons)
     })
   }, [])
 

--- a/src/features/admin/components/members/SignupTrendChart.tsx
+++ b/src/features/admin/components/members/SignupTrendChart.tsx
@@ -10,21 +10,21 @@ import {
   Tooltip,
   ResponsiveContainer,
 } from 'recharts'
-import type { MonthlyMemberStat } from '@/features/admin/mocks/mockMemberStats'
+import type { MemberTrendStat } from '@/features/admin/types/adminApi'
 
 type Period = 'monthly' | 'yearly'
 
 interface SignupTrendChartProps {
-  data: MonthlyMemberStat[]
+  data: MemberTrendStat[]
 }
 
-function aggregateByYear(data: MonthlyMemberStat[]) {
+function aggregateByYear(data: MemberTrendStat[]) {
   const map = new Map<string, number>()
   for (const item of data) {
-    const year = item.month.slice(0, 4)
-    map.set(year, (map.get(year) ?? 0) + item.signups)
+    const year = item.yearMonth.slice(0, 4)
+    map.set(year, (map.get(year) ?? 0) + item.signupCount)
   }
-  return Array.from(map, ([year, signups]) => ({ year, signups }))
+  return Array.from(map, ([year, signupCount]) => ({ year, signupCount }))
 }
 
 export default function SignupTrendChart({ data }: SignupTrendChartProps) {
@@ -53,10 +53,10 @@ export default function SignupTrendChart({ data }: SignupTrendChartProps) {
       <ResponsiveContainer width="100%" height={360}>
         <BarChart data={chartData}>
           <CartesianGrid strokeDasharray="3 3" />
-          <XAxis dataKey={period === 'yearly' ? 'year' : 'month'} tick={{ fontSize: 12 }} />
+          <XAxis dataKey={period === 'yearly' ? 'year' : 'yearMonth'} tick={{ fontSize: 12 }} />
           <YAxis tick={{ fontSize: 12 }} />
           <Tooltip />
-          <Bar dataKey="signups" name="가입자 수" fill="#3b82f6" radius={[4, 4, 0, 0]} />
+          <Bar dataKey="signupCount" name="가입자 수" fill="#3b82f6" radius={[4, 4, 0, 0]} />
         </BarChart>
       </ResponsiveContainer>
     </div>

--- a/src/features/admin/components/members/WithdrawalReasonChart.tsx
+++ b/src/features/admin/components/members/WithdrawalReasonChart.tsx
@@ -8,7 +8,7 @@ import {
   ResponsiveContainer,
 } from 'recharts'
 import { WITHDRAW_REASON } from '@/constants/constants'
-import type { WithdrawalReasonStat } from '@/features/admin/mocks/mockMemberStats'
+import type { WithdrawalReasonStat } from '@/features/admin/types/adminApi'
 
 const REASON_COLORS: Record<string, string> = {
   SERVICE_DISSATISFACTION: '#ef4444',

--- a/src/features/admin/components/members/WithdrawalTrendChart.tsx
+++ b/src/features/admin/components/members/WithdrawalTrendChart.tsx
@@ -10,21 +10,21 @@ import {
   Tooltip,
   ResponsiveContainer,
 } from 'recharts'
-import type { MonthlyMemberStat } from '@/features/admin/mocks/mockMemberStats'
+import type { MemberTrendStat } from '@/features/admin/types/adminApi'
 
 type Period = 'monthly' | 'yearly'
 
 interface WithdrawalTrendChartProps {
-  data: MonthlyMemberStat[]
+  data: MemberTrendStat[]
 }
 
-function aggregateByYear(data: MonthlyMemberStat[]) {
+function aggregateByYear(data: MemberTrendStat[]) {
   const map = new Map<string, number>()
   for (const item of data) {
-    const year = item.month.slice(0, 4)
-    map.set(year, (map.get(year) ?? 0) + item.withdrawals)
+    const year = item.yearMonth.slice(0, 4)
+    map.set(year, (map.get(year) ?? 0) + item.withdrawalCount)
   }
-  return Array.from(map, ([year, withdrawals]) => ({ year, withdrawals }))
+  return Array.from(map, ([year, withdrawalCount]) => ({ year, withdrawalCount }))
 }
 
 export default function WithdrawalTrendChart({ data }: WithdrawalTrendChartProps) {
@@ -53,10 +53,10 @@ export default function WithdrawalTrendChart({ data }: WithdrawalTrendChartProps
       <ResponsiveContainer width="100%" height={360}>
         <BarChart data={chartData}>
           <CartesianGrid strokeDasharray="3 3" />
-          <XAxis dataKey={period === 'yearly' ? 'year' : 'month'} tick={{ fontSize: 12 }} />
+          <XAxis dataKey={period === 'yearly' ? 'year' : 'yearMonth'} tick={{ fontSize: 12 }} />
           <YAxis tick={{ fontSize: 12 }} />
           <Tooltip />
-          <Bar dataKey="withdrawals" name="탈퇴자 수" fill="#ef4444" radius={[4, 4, 0, 0]} />
+          <Bar dataKey="withdrawalCount" name="탈퇴자 수" fill="#ef4444" radius={[4, 4, 0, 0]} />
         </BarChart>
       </ResponsiveContainer>
     </div>

--- a/src/features/admin/components/reports/CommunityReportDetailModal.tsx
+++ b/src/features/admin/components/reports/CommunityReportDetailModal.tsx
@@ -2,14 +2,15 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { X } from 'lucide-react'
-import type { MockCommunityReport } from '../../mocks/mockCommunityReports'
+import type { AdminReport } from '../../types/adminApi'
+import { COMMUNITY_REPORT_REASON_EN_TO_KO } from '../../configs/communityReportTableConfig'
 import { formatDate } from '../common/formatDate'
 import Field from '../common/Field'
 import DeleteConfirmDialog from '../common/DeleteConfirmDialog'
 
 interface CommunityReportDetailModalProps {
   isOpen: boolean
-  report: MockCommunityReport | null
+  report: AdminReport | null
   onClose: () => void
 }
 
@@ -61,27 +62,12 @@ export default function CommunityReportDetailModal({
           {/* Body */}
           <div className="max-h-[60vh] overflow-y-auto px-6 py-5">
             <div className="grid grid-cols-2 gap-x-5 gap-y-4">
-              {/* Row 1 */}
               <Field label="신고 ID" value={String(report.id)} />
-              <Field label="신고자 닉네임" value={report.reporterNickname} />
-              {/* Row 2 */}
-              <Field label="작성자 닉네임" value={report.authorNickname} />
-              <Field label="신고항목" value={report.reasonCode} />
-              {/* Row 3 */}
+              <Field label="신고자 ID" value={String(report.reporterId)} />
+              <Field label="게시글 ID" value={String(report.targetId)} />
+              <Field label="신고항목" value={report.reasonCodes.map((c) => COMMUNITY_REPORT_REASON_EN_TO_KO[c] || c).join(', ')} />
+              <Field label="처리 상태" value={report.status} />
               <Field label="신고 일자" value={formatDate(report.createdAt)} />
-              <Field label="게시글 유형" value={report.boardType} />
-              {/* Row 4 */}
-              <div className="col-span-2">
-                <Field label="게시글 제목" value={report.postTitle} />
-              </div>
-              {/* Row 5: 게시글 내용 */}
-              <div className="col-span-2">
-                <p className="mb-1.5 text-sm font-medium text-gray-500">게시글 내용</p>
-                <div className="max-h-[120px] overflow-y-auto whitespace-pre-line rounded-lg border border-gray-200 bg-gray-50/50 px-3 py-2.5 text-sm leading-relaxed text-gray-900">
-                  {report.postContent}
-                </div>
-              </div>
-              {/* Row 6: 신고 상세 사유 */}
               {report.detailReason && (
                 <div className="col-span-2">
                   <p className="mb-1.5 text-sm font-medium text-gray-500">신고 상세 사유</p>
@@ -93,31 +79,21 @@ export default function CommunityReportDetailModal({
             </div>
 
             {/* 첨부 이미지 */}
-            <div className="mt-4">
-              <p className="mb-1.5 text-sm font-medium text-gray-500">첨부 이미지</p>
-              <div className="grid grid-cols-3 gap-3">
-                {Array.from({ length: 3 }, (_, idx) => {
-                  const src = report.images?.[idx]
-                  return src ? (
+            {report.imageUrls && report.imageUrls.length > 0 && (
+              <div className="mt-4">
+                <p className="mb-1.5 text-sm font-medium text-gray-500">첨부 이미지</p>
+                <div className="grid grid-cols-3 gap-3">
+                  {report.imageUrls.map((src, idx) => (
                     <img
                       key={idx}
                       src={src}
                       alt={`첨부 이미지 ${idx + 1}`}
                       className="aspect-square w-full rounded-lg object-cover border border-gray-200"
                     />
-                  ) : (
-                    <div
-                      key={idx}
-                      className="flex aspect-square w-full items-center justify-center rounded-lg border border-gray-200 bg-gray-50"
-                    >
-                      <svg className="h-6 w-6 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M2.25 15.75l5.159-5.159a2.25 2.25 0 013.182 0l5.159 5.159m-1.5-1.5l1.409-1.409a2.25 2.25 0 013.182 0l2.909 2.909M3.75 21h16.5A2.25 2.25 0 0022.5 18.75V5.25A2.25 2.25 0 0020.25 3H3.75A2.25 2.25 0 001.5 5.25v13.5A2.25 2.25 0 003.75 21z" />
-                      </svg>
-                    </div>
-                  )
-                })}
+                  ))}
+                </div>
               </div>
-            </div>
+            )}
           </div>
 
           {/* Footer */}

--- a/src/features/admin/components/reports/CommunityReportManagement.tsx
+++ b/src/features/admin/components/reports/CommunityReportManagement.tsx
@@ -4,15 +4,15 @@ import { useState } from 'react'
 import AdminTable from '../table/AdminTable'
 import { communityReportTableConfig } from '../../configs/communityReportTableConfig'
 import { fetchAdminCommunityReports } from '@/lib/api/admin'
-import type { MockCommunityReport } from '../../mocks/mockCommunityReports'
+import type { AdminReport } from '../../types/adminApi'
 import CommunityReportDetailModal from './CommunityReportDetailModal'
 
 export default function CommunityReportManagement() {
-  const [selectedReport, setSelectedReport] = useState<MockCommunityReport | null>(null)
+  const [selectedReport, setSelectedReport] = useState<AdminReport | null>(null)
 
   return (
     <>
-      <AdminTable<MockCommunityReport>
+      <AdminTable<AdminReport>
         config={communityReportTableConfig}
         queryKey="admin-community-reports"
         fetchFn={fetchAdminCommunityReports}

--- a/src/features/admin/components/reports/ProductRequestReportDetailModal.tsx
+++ b/src/features/admin/components/reports/ProductRequestReportDetailModal.tsx
@@ -2,14 +2,15 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { X } from 'lucide-react'
-import type { MockProductRequestReport } from '../../mocks/mockProductRequestReports'
+import type { AdminReport } from '../../types/adminApi'
+import { PRODUCT_REPORT_REASON_EN_TO_KO } from '../../configs/productSellReportTableConfig'
 import { formatDate } from '../common/formatDate'
 import Field from '../common/Field'
 import DeleteConfirmDialog from '../common/DeleteConfirmDialog'
 
 interface ProductRequestReportDetailModalProps {
   isOpen: boolean
-  report: MockProductRequestReport | null
+  report: AdminReport | null
   onClose: () => void
 }
 
@@ -61,21 +62,12 @@ export default function ProductRequestReportDetailModal({
           {/* Body */}
           <div className="max-h-[60vh] overflow-y-auto px-6 py-5">
             <div className="grid grid-cols-2 gap-x-5 gap-y-4">
-              {/* Row 1 */}
               <Field label="신고 ID" value={String(report.id)} />
-              <Field label="신고자 닉네임" value={report.reporterNickname} />
-              {/* Row 2: 상품명 full width */}
-              <div className="col-span-2">
-                <Field label="상품명" value={report.productName} />
-              </div>
-              {/* Row 3: 요청자 닉네임 | 신고항목 */}
-              <Field label="요청자 닉네임" value={report.requesterNickname} />
-              <Field label="신고항목" value={report.reasonCode} />
-              {/* Row 4: 신고 일자 full width */}
-              <div className="col-span-2">
-                <Field label="신고 일자" value={formatDate(report.createdAt)} />
-              </div>
-              {/* 신고 상세 사유 */}
+              <Field label="신고자 ID" value={String(report.reporterId)} />
+              <Field label="상품 ID" value={String(report.targetId)} />
+              <Field label="신고항목" value={report.reasonCodes.map((c) => PRODUCT_REPORT_REASON_EN_TO_KO[c] || c).join(', ')} />
+              <Field label="처리 상태" value={report.status} />
+              <Field label="신고 일자" value={formatDate(report.createdAt)} />
               {report.detailReason && (
                 <div className="col-span-2">
                   <p className="mb-1.5 text-sm font-medium text-gray-500">신고 상세 사유</p>
@@ -87,31 +79,21 @@ export default function ProductRequestReportDetailModal({
             </div>
 
             {/* 첨부 이미지 */}
-            <div className="mt-4">
-              <p className="mb-1.5 text-sm font-medium text-gray-500">첨부 이미지</p>
-              <div className="grid grid-cols-3 gap-3">
-                {Array.from({ length: 3 }, (_, idx) => {
-                  const src = report.images?.[idx]
-                  return src ? (
+            {report.imageUrls && report.imageUrls.length > 0 && (
+              <div className="mt-4">
+                <p className="mb-1.5 text-sm font-medium text-gray-500">첨부 이미지</p>
+                <div className="grid grid-cols-3 gap-3">
+                  {report.imageUrls.map((src, idx) => (
                     <img
                       key={idx}
                       src={src}
                       alt={`첨부 이미지 ${idx + 1}`}
                       className="aspect-square w-full rounded-lg object-cover border border-gray-200"
                     />
-                  ) : (
-                    <div
-                      key={idx}
-                      className="flex aspect-square w-full items-center justify-center rounded-lg border border-gray-200 bg-gray-50"
-                    >
-                      <svg className="h-6 w-6 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M2.25 15.75l5.159-5.159a2.25 2.25 0 013.182 0l5.159 5.159m-1.5-1.5l1.409-1.409a2.25 2.25 0 013.182 0l2.909 2.909M3.75 21h16.5A2.25 2.25 0 0022.5 18.75V5.25A2.25 2.25 0 0020.25 3H3.75A2.25 2.25 0 001.5 5.25v13.5A2.25 2.25 0 003.75 21z" />
-                      </svg>
-                    </div>
-                  )
-                })}
+                  ))}
+                </div>
               </div>
-            </div>
+            )}
           </div>
 
           {/* Footer */}

--- a/src/features/admin/components/reports/ProductRequestReportManagement.tsx
+++ b/src/features/admin/components/reports/ProductRequestReportManagement.tsx
@@ -3,19 +3,19 @@
 import { useState } from 'react'
 import AdminTable from '../table/AdminTable'
 import { productRequestReportTableConfig } from '../../configs/productRequestReportTableConfig'
-import { fetchAdminProductRequestReports } from '@/lib/api/admin'
-import type { MockProductRequestReport } from '../../mocks/mockProductRequestReports'
+import { fetchAdminProductReports } from '@/lib/api/admin'
+import type { AdminReport } from '../../types/adminApi'
 import ProductRequestReportDetailModal from './ProductRequestReportDetailModal'
 
 export default function ProductRequestReportManagement() {
-  const [selectedReport, setSelectedReport] = useState<MockProductRequestReport | null>(null)
+  const [selectedReport, setSelectedReport] = useState<AdminReport | null>(null)
 
   return (
     <>
-      <AdminTable<MockProductRequestReport>
+      <AdminTable<AdminReport>
         config={productRequestReportTableConfig}
         queryKey="admin-product-request-reports"
-        fetchFn={fetchAdminProductRequestReports}
+        fetchFn={fetchAdminProductReports}
         onRowClick={(report) => setSelectedReport(report)}
       />
       <ProductRequestReportDetailModal

--- a/src/features/admin/components/reports/ProductSellReportDetailModal.tsx
+++ b/src/features/admin/components/reports/ProductSellReportDetailModal.tsx
@@ -2,14 +2,15 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { X } from 'lucide-react'
-import type { MockProductSellReport } from '../../mocks/mockProductSellReports'
+import type { AdminReport } from '../../types/adminApi'
+import { PRODUCT_REPORT_REASON_EN_TO_KO } from '../../configs/productSellReportTableConfig'
 import { formatDate } from '../common/formatDate'
 import Field from '../common/Field'
 import DeleteConfirmDialog from '../common/DeleteConfirmDialog'
 
 interface ProductSellReportDetailModalProps {
   isOpen: boolean
-  report: MockProductSellReport | null
+  report: AdminReport | null
   onClose: () => void
 }
 
@@ -57,21 +58,12 @@ export default function ProductSellReportDetailModal({ isOpen, report, onClose }
           {/* Body */}
           <div className="max-h-[60vh] overflow-y-auto px-6 py-5">
             <div className="grid grid-cols-2 gap-x-5 gap-y-4">
-              {/* Row 1 */}
               <Field label="신고 ID" value={String(report.id)} />
-              <Field label="신고자 닉네임" value={report.reporterNickname} />
-              {/* Row 2: 상품명 full width */}
-              <div className="col-span-2">
-                <Field label="상품명" value={report.productName} />
-              </div>
-              {/* Row 3: 판매자 닉네임 | 신고항목 */}
-              <Field label="판매자 닉네임" value={report.sellerNickname} />
-              <Field label="신고항목" value={report.reasonCode} />
-              {/* Row 4: 신고 일자 full width */}
-              <div className="col-span-2">
-                <Field label="신고 일자" value={formatDate(report.createdAt)} />
-              </div>
-              {/* 신고 상세 사유 */}
+              <Field label="신고자 ID" value={String(report.reporterId)} />
+              <Field label="상품 ID" value={String(report.targetId)} />
+              <Field label="신고항목" value={report.reasonCodes.map((c) => PRODUCT_REPORT_REASON_EN_TO_KO[c] || c).join(', ')} />
+              <Field label="처리 상태" value={report.status} />
+              <Field label="신고 일자" value={formatDate(report.createdAt)} />
               {report.detailReason && (
                 <div className="col-span-2">
                   <p className="mb-1.5 text-sm font-medium text-gray-500">신고 상세 사유</p>
@@ -83,31 +75,21 @@ export default function ProductSellReportDetailModal({ isOpen, report, onClose }
             </div>
 
             {/* 첨부 이미지 */}
-            <div className="mt-4">
-              <p className="mb-1.5 text-sm font-medium text-gray-500">첨부 이미지</p>
-              <div className="grid grid-cols-3 gap-3">
-                {Array.from({ length: 3 }, (_, idx) => {
-                  const src = report.images?.[idx]
-                  return src ? (
+            {report.imageUrls && report.imageUrls.length > 0 && (
+              <div className="mt-4">
+                <p className="mb-1.5 text-sm font-medium text-gray-500">첨부 이미지</p>
+                <div className="grid grid-cols-3 gap-3">
+                  {report.imageUrls.map((src, idx) => (
                     <img
                       key={idx}
                       src={src}
                       alt={`첨부 이미지 ${idx + 1}`}
                       className="aspect-square w-full rounded-lg object-cover border border-gray-200"
                     />
-                  ) : (
-                    <div
-                      key={idx}
-                      className="flex aspect-square w-full items-center justify-center rounded-lg border border-gray-200 bg-gray-50"
-                    >
-                      <svg className="h-6 w-6 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M2.25 15.75l5.159-5.159a2.25 2.25 0 013.182 0l5.159 5.159m-1.5-1.5l1.409-1.409a2.25 2.25 0 013.182 0l2.909 2.909M3.75 21h16.5A2.25 2.25 0 0022.5 18.75V5.25A2.25 2.25 0 0020.25 3H3.75A2.25 2.25 0 001.5 5.25v13.5A2.25 2.25 0 003.75 21z" />
-                      </svg>
-                    </div>
-                  )
-                })}
+                  ))}
+                </div>
               </div>
-            </div>
+            )}
           </div>
 
           {/* Footer */}

--- a/src/features/admin/components/reports/ProductSellReportManagement.tsx
+++ b/src/features/admin/components/reports/ProductSellReportManagement.tsx
@@ -3,19 +3,19 @@
 import { useState } from 'react'
 import AdminTable from '../table/AdminTable'
 import { productSellReportTableConfig } from '../../configs/productSellReportTableConfig'
-import { fetchAdminProductSellReports } from '@/lib/api/admin'
-import type { MockProductSellReport } from '../../mocks/mockProductSellReports'
+import { fetchAdminProductReports } from '@/lib/api/admin'
+import type { AdminReport } from '../../types/adminApi'
 import ProductSellReportDetailModal from './ProductSellReportDetailModal'
 
 export default function ProductSellReportManagement() {
-  const [selectedReport, setSelectedReport] = useState<MockProductSellReport | null>(null)
+  const [selectedReport, setSelectedReport] = useState<AdminReport | null>(null)
 
   return (
     <>
-      <AdminTable<MockProductSellReport>
+      <AdminTable<AdminReport>
         config={productSellReportTableConfig}
         queryKey="admin-product-sell-reports"
-        fetchFn={fetchAdminProductSellReports}
+        fetchFn={fetchAdminProductReports}
         onRowClick={(report) => setSelectedReport(report)}
       />
       <ProductSellReportDetailModal

--- a/src/features/admin/components/reports/UserReportDetailModal.tsx
+++ b/src/features/admin/components/reports/UserReportDetailModal.tsx
@@ -2,14 +2,23 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { X } from 'lucide-react'
-import type { MockUserReport } from '../../mocks/mockUserReports'
+import type { AdminReport } from '../../types/adminApi'
 import { formatDate } from '../common/formatDate'
 import Field from '../common/Field'
 import DeleteConfirmDialog from '../common/DeleteConfirmDialog'
 
+const USER_REPORT_REASON_EN_TO_KO: Record<string, string> = {
+  ABUSE_OR_HATE: '욕설/비방/혐오',
+  SPAM_OR_AD: '스팸/광고',
+  INAPPROPRIATE_CONTENT: '음란물/불건전',
+  REPETITIVE_POST: '도배 게시물',
+  SELF_HARM_OR_SUICIDE: '자해/자살 의도',
+  ETC: '기타',
+}
+
 interface UserReportDetailModalProps {
   isOpen: boolean
-  report: MockUserReport | null
+  report: AdminReport | null
   onClose: () => void
 }
 
@@ -57,17 +66,12 @@ export default function UserReportDetailModal({ isOpen, report, onClose }: UserR
           {/* Body */}
           <div className="max-h-[60vh] overflow-y-auto px-6 py-5">
             <div className="grid grid-cols-2 gap-x-5 gap-y-4">
-              {/* Row 1 */}
               <Field label="신고 ID" value={String(report.id)} />
-              <Field label="신고자 닉네임" value={report.reporterNickname} />
-              {/* Row 2 */}
-              <Field label="신고 대상자 닉네임" value={report.targetNickname} />
-              <Field label="신고항목" value={report.reasonCode} />
-              {/* Row 3 */}
-              <div className="col-span-2">
-                <Field label="신고일자" value={formatDate(report.createdAt)} />
-              </div>
-              {/* 신고 상세 사유 */}
+              <Field label="신고자 ID" value={String(report.reporterId)} />
+              <Field label="신고 대상 ID" value={String(report.targetId)} />
+              <Field label="신고항목" value={report.reasonCodes.map((c) => USER_REPORT_REASON_EN_TO_KO[c] || c).join(', ')} />
+              <Field label="처리 상태" value={report.status} />
+              <Field label="신고일자" value={formatDate(report.createdAt)} />
               {report.detailReason && (
                 <div className="col-span-2">
                   <p className="mb-1.5 text-sm font-medium text-gray-500">신고 상세 사유</p>
@@ -79,31 +83,21 @@ export default function UserReportDetailModal({ isOpen, report, onClose }: UserR
             </div>
 
             {/* 첨부 이미지 */}
-            <div className="mt-4">
-              <p className="mb-1.5 text-sm font-medium text-gray-500">첨부 이미지</p>
-              <div className="grid grid-cols-3 gap-3">
-                {Array.from({ length: 3 }, (_, idx) => {
-                  const src = report.images?.[idx]
-                  return src ? (
+            {report.imageUrls && report.imageUrls.length > 0 && (
+              <div className="mt-4">
+                <p className="mb-1.5 text-sm font-medium text-gray-500">첨부 이미지</p>
+                <div className="grid grid-cols-3 gap-3">
+                  {report.imageUrls.map((src, idx) => (
                     <img
                       key={idx}
                       src={src}
                       alt={`첨부 이미지 ${idx + 1}`}
                       className="aspect-square w-full rounded-lg object-cover border border-gray-200"
                     />
-                  ) : (
-                    <div
-                      key={idx}
-                      className="flex aspect-square w-full items-center justify-center rounded-lg border border-gray-200 bg-gray-50"
-                    >
-                      <svg className="h-6 w-6 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M2.25 15.75l5.159-5.159a2.25 2.25 0 013.182 0l5.159 5.159m-1.5-1.5l1.409-1.409a2.25 2.25 0 013.182 0l2.909 2.909M3.75 21h16.5A2.25 2.25 0 0022.5 18.75V5.25A2.25 2.25 0 0020.25 3H3.75A2.25 2.25 0 001.5 5.25v13.5A2.25 2.25 0 003.75 21z" />
-                      </svg>
-                    </div>
-                  )
-                })}
+                  ))}
+                </div>
               </div>
-            </div>
+            )}
           </div>
 
           {/* Footer */}

--- a/src/features/admin/components/reports/UserReportManagement.tsx
+++ b/src/features/admin/components/reports/UserReportManagement.tsx
@@ -4,15 +4,15 @@ import { useState } from 'react'
 import AdminTable from '../table/AdminTable'
 import { userReportTableConfig } from '../../configs/userReportTableConfig'
 import { fetchAdminUserReports } from '@/lib/api/admin'
-import type { MockUserReport } from '../../mocks/mockUserReports'
+import type { AdminReport } from '../../types/adminApi'
 import UserReportDetailModal from './UserReportDetailModal'
 
 export default function UserReportManagement() {
-  const [selectedReport, setSelectedReport] = useState<MockUserReport | null>(null)
+  const [selectedReport, setSelectedReport] = useState<AdminReport | null>(null)
 
   return (
     <>
-      <AdminTable<MockUserReport>
+      <AdminTable<AdminReport>
         config={userReportTableConfig}
         queryKey="admin-user-reports"
         fetchFn={fetchAdminUserReports}

--- a/src/features/admin/components/users/UserDetailModal.tsx
+++ b/src/features/admin/components/users/UserDetailModal.tsx
@@ -2,11 +2,11 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { X } from 'lucide-react'
-import type { MockUser } from '../../mocks/mockUsers'
+import type { AdminUser } from '../../types/adminApi'
 
 interface UserDetailModalProps {
   isOpen: boolean
-  user: MockUser | null
+  user: AdminUser | null
   onClose: () => void
 }
 
@@ -96,6 +96,9 @@ function DeleteConfirmDialog({
   )
 }
 
+const ROLE_EN_TO_KO: Record<string, string> = { USER: '일반회원', ADMIN: '관리자' }
+const STATUS_EN_TO_KO: Record<string, string> = { ACTIVE: '활성', WITHDRAWN: '탈퇴' }
+
 export default function UserDetailModal({ isOpen, user, onClose }: UserDetailModalProps) {
   const dialogRef = useRef<HTMLDialogElement>(null)
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
@@ -141,17 +144,9 @@ export default function UserDetailModal({ isOpen, user, onClose }: UserDetailMod
           <div className="px-6 py-5">
             {/* Profile */}
             <div className="mb-6 flex items-center gap-4">
-              {user.profileImageUrl ? (
-                <img
-                  src={user.profileImageUrl}
-                  alt={user.nickname}
-                  className="h-16 w-16 shrink-0 rounded-full object-cover"
-                />
-              ) : (
-                <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-full bg-gray-200 text-xl font-bold text-gray-500">
-                  {user.nickname.charAt(0)}
-                </div>
-              )}
+              <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-full bg-gray-200 text-xl font-bold text-gray-500">
+                {user.nickname.charAt(0)}
+              </div>
               <div>
                 <p className="text-lg font-semibold text-gray-900">{user.name}</p>
                 <p className="text-sm text-gray-500">{user.email}</p>
@@ -164,14 +159,13 @@ export default function UserDetailModal({ isOpen, user, onClose }: UserDetailMod
               <Field label="이름" value={user.name} />
               <Field label="닉네임" value={user.nickname} />
               <Field label="이메일" value={user.email} />
-              <Field label="생년월일" value={formatDate(user.birthDate)} />
-              <Field label="지역" value={`${user.addressSido} ${user.addressGugun}`} />
-              <Field label="권한" value={user.role} />
-              <Field label="상태" value={user.status} />
-              <Field label="회원가입 일시" value={formatDateTime(user.joinedAt)} />
-              {user.withdrawalRequestedAt && (
-                <Field label="탈퇴요청 일시" value={formatDateTime(user.withdrawalRequestedAt)} />
+              {user.birthDate && <Field label="생년월일" value={formatDate(user.birthDate)} />}
+              {(user.addressSido || user.addressGugun) && (
+                <Field label="지역" value={`${user.addressSido ?? ''} ${user.addressGugun ?? ''}`.trim()} />
               )}
+              <Field label="권한" value={ROLE_EN_TO_KO[user.role] ?? user.role} />
+              <Field label="상태" value={STATUS_EN_TO_KO[user.status] ?? user.status} />
+              <Field label="회원가입 일시" value={formatDateTime(user.createdAt)} />
             </div>
           </div>
 

--- a/src/features/admin/configs/communityReportTableConfig.ts
+++ b/src/features/admin/configs/communityReportTableConfig.ts
@@ -1,18 +1,47 @@
 import type { TableConfig } from '../types/adminTable'
-import type { MockCommunityReport } from '../mocks/mockCommunityReports'
+import type { AdminReport } from '../types/adminApi'
 
-export const communityReportTableConfig: TableConfig<MockCommunityReport> = {
+const COMMUNITY_REPORT_REASON_EN_TO_KO: Record<string, string> = {
+  ABUSE_OR_HATE: '욕설/비방/혐오',
+  SPAM_OR_AD: '스팸/광고',
+  INAPPROPRIATE_CONTENT: '음란물/불건전',
+  REPETITIVE_POST: '도배 게시물',
+  SELF_HARM_OR_SUICIDE: '자해/자살 의도',
+  ETC: '기타',
+}
+
+export { COMMUNITY_REPORT_REASON_EN_TO_KO }
+
+export const communityReportTableConfig: TableConfig<AdminReport> = {
   title: '커뮤니티 신고 관리',
   rowKey: 'id',
-  searchable: true,
-  searchPlaceholder: '게시글 제목 또는 작성자 검색...',
+  searchable: false,
   columns: [
     { key: 'id', label: '신고 ID', type: 'number', sortable: true, width: '90px' },
-    { key: 'boardType', label: '게시글 유형', type: 'text', sortable: true, width: '110px' },
-    { key: 'reporterNickname', label: '신고자', type: 'text', sortable: true },
-    { key: 'postTitle', label: '제목', type: 'text', sortable: true },
-    { key: 'authorNickname', label: '작성자', type: 'text', sortable: true },
-    { key: 'reasonCode', label: '신고 항목', type: 'text', sortable: true },
+    { key: 'reporterId', label: '신고자 ID', type: 'number', width: '100px' },
+    { key: 'targetId', label: '게시글 ID', type: 'number', width: '100px' },
+    {
+      key: 'reasonCodes',
+      label: '신고 사유',
+      type: 'text',
+      format: (v) => {
+        const codes = v as string[]
+        return codes.map((c) => COMMUNITY_REPORT_REASON_EN_TO_KO[c] || c).join(', ')
+      },
+    },
+    {
+      key: 'status',
+      label: '처리 상태',
+      type: 'badge',
+      sortable: true,
+      width: '110px',
+      badgeOptions: [
+        { value: 'PENDING', label: '대기중', color: 'bg-yellow-100 text-yellow-800' },
+        { value: 'REVIEWED', label: '검토완료', color: 'bg-green-100 text-green-800' },
+        { value: 'REJECTED', label: '거절', color: 'bg-gray-100 text-gray-800' },
+        { value: 'ACTION_TAKEN', label: '조치완료', color: 'bg-blue-100 text-blue-800' },
+      ],
+    },
     {
       key: 'createdAt',
       label: '신고일자',
@@ -27,23 +56,13 @@ export const communityReportTableConfig: TableConfig<MockCommunityReport> = {
   ],
   filters: [
     {
-      key: 'reasonCode',
-      label: '신고 항목',
+      key: 'status',
+      label: '처리 상태',
       options: [
-        { value: '욕설, 비방, 혐오 표현', label: '욕설, 비방, 혐오 표현' },
-        { value: '도배 게시물', label: '도배 게시물' },
-        { value: '음란물/불건전 콘텐츠', label: '음란물/불건전 콘텐츠' },
-        { value: '스팸/광고성 메시지', label: '스팸/광고성 메시지' },
-        { value: '자해 또는 자살 의도를 포함', label: '자해 또는 자살 의도를 포함' },
-        { value: '기타', label: '기타' },
-      ],
-    },
-    {
-      key: 'sort',
-      label: '정렬',
-      options: [
-        { value: '최신순', label: '최신순' },
-        { value: '오래된 순', label: '오래된 순' },
+        { value: '대기중', label: '대기중' },
+        { value: '검토완료', label: '검토완료' },
+        { value: '거절', label: '거절' },
+        { value: '조치완료', label: '조치완료' },
       ],
     },
   ],

--- a/src/features/admin/configs/productRequestReportTableConfig.ts
+++ b/src/features/admin/configs/productRequestReportTableConfig.ts
@@ -1,56 +1,8 @@
+import { productSellReportTableConfig } from './productSellReportTableConfig'
 import type { TableConfig } from '../types/adminTable'
-import type { MockProductRequestReport } from '../mocks/mockProductRequestReports'
+import type { AdminReport } from '../types/adminApi'
 
-export const productRequestReportTableConfig: TableConfig<MockProductRequestReport> = {
+export const productRequestReportTableConfig: TableConfig<AdminReport> = {
+  ...productSellReportTableConfig,
   title: '판매요청 상품 신고 관리',
-  rowKey: 'id',
-  searchable: true,
-  searchPlaceholder: '상품명 검색...',
-  columns: [
-    { key: 'id', label: '신고 ID', type: 'number', sortable: true, width: '90px' },
-    { key: 'image', label: '이미지', type: 'image', width: '80px' },
-    { key: 'productName', label: '상품명', type: 'text', sortable: true },
-    { key: 'reporterNickname', label: '신고자', type: 'text', sortable: true },
-    { key: 'requesterNickname', label: '요청자', type: 'text', sortable: true },
-    { key: 'reasonCode', label: '신고 항목', type: 'text', sortable: true },
-    {
-      key: 'createdAt',
-      label: '신고일자',
-      type: 'date',
-      sortable: true,
-      width: '120px',
-      format: (v) => {
-        const d = new Date(v as string)
-        return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
-      },
-    },
-  ],
-  filters: [
-    {
-      key: 'reasonCode',
-      label: '신고 항목',
-      options: [
-        { value: '욕설, 비방, 괴롭힘', label: '욕설, 비방, 괴롭힘' },
-        { value: '사기, 허위 거래 시도', label: '사기, 허위 거래 시도' },
-        { value: '음란물 또는 불건전 행위', label: '음란물 또는 불건전 행위' },
-        { value: '스팸/광고성 메시지', label: '스팸/광고성 메시지' },
-        { value: '불쾌한 사용자 정보 내용', label: '불쾌한 사용자 정보 내용' },
-        { value: '만 14세 미만 유저', label: '만 14세 미만 유저' },
-        { value: '기타', label: '기타' },
-      ],
-    },
-    {
-      key: 'sort',
-      label: '정렬',
-      options: [
-        { value: '최신순', label: '최신순' },
-        { value: '오래된 순', label: '오래된 순' },
-      ],
-    },
-  ],
-  actions: [],
-  pagination: {
-    defaultPageSize: 10,
-    pageSizeOptions: [5, 10, 20, 50],
-  },
 }

--- a/src/features/admin/configs/productSellReportTableConfig.ts
+++ b/src/features/admin/configs/productSellReportTableConfig.ts
@@ -1,18 +1,49 @@
 import type { TableConfig } from '../types/adminTable'
-import type { MockProductSellReport } from '../mocks/mockProductSellReports'
+import type { AdminReport } from '../types/adminApi'
 
-export const productSellReportTableConfig: TableConfig<MockProductSellReport> = {
-  title: '판매상품 신고 관리',
+const PRODUCT_REPORT_REASON_EN_TO_KO: Record<string, string> = {
+  FALSE_OR_SCAM: '허위/사기성 상품',
+  ILLEGAL_ITEM: '불법/금지 품목',
+  INAPPROPRIATE_IMAGE: '부적절한 이미지',
+  DUPLICATE_POST: '중복 게시물',
+  SPAM_OR_AD: '스팸/광고',
+  PROXY_PAYMENT_OR_TRADE: '대리 결제/거래',
+  PROFESSIONAL_SELLER: '전문 판매 업자',
+  ETC: '기타',
+}
+
+export { PRODUCT_REPORT_REASON_EN_TO_KO }
+
+export const productSellReportTableConfig: TableConfig<AdminReport> = {
+  title: '상품 신고 관리',
   rowKey: 'id',
-  searchable: true,
-  searchPlaceholder: '상품명 검색...',
+  searchable: false,
   columns: [
     { key: 'id', label: '신고 ID', type: 'number', sortable: true, width: '90px' },
-    { key: 'image', label: '이미지', type: 'image', width: '80px' },
-    { key: 'productName', label: '상품명', type: 'text', sortable: true },
-    { key: 'reporterNickname', label: '신고자', type: 'text', sortable: true },
-    { key: 'sellerNickname', label: '판매자', type: 'text', sortable: true },
-    { key: 'reasonCode', label: '신고 항목', type: 'text', sortable: true },
+    { key: 'reporterId', label: '신고자 ID', type: 'number', width: '100px' },
+    { key: 'targetId', label: '상품 ID', type: 'number', width: '100px' },
+    {
+      key: 'reasonCodes',
+      label: '신고 사유',
+      type: 'text',
+      format: (v) => {
+        const codes = v as string[]
+        return codes.map((c) => PRODUCT_REPORT_REASON_EN_TO_KO[c] || c).join(', ')
+      },
+    },
+    {
+      key: 'status',
+      label: '처리 상태',
+      type: 'badge',
+      sortable: true,
+      width: '110px',
+      badgeOptions: [
+        { value: 'PENDING', label: '대기중', color: 'bg-yellow-100 text-yellow-800' },
+        { value: 'REVIEWED', label: '검토완료', color: 'bg-green-100 text-green-800' },
+        { value: 'REJECTED', label: '거절', color: 'bg-gray-100 text-gray-800' },
+        { value: 'ACTION_TAKEN', label: '조치완료', color: 'bg-blue-100 text-blue-800' },
+      ],
+    },
     {
       key: 'createdAt',
       label: '신고일자',
@@ -27,24 +58,13 @@ export const productSellReportTableConfig: TableConfig<MockProductSellReport> = 
   ],
   filters: [
     {
-      key: 'reasonCode',
-      label: '신고 항목',
+      key: 'status',
+      label: '처리 상태',
       options: [
-        { value: '욕설, 비방, 괴롭힘', label: '욕설, 비방, 괴롭힘' },
-        { value: '사기, 허위 거래 시도', label: '사기, 허위 거래 시도' },
-        { value: '음란물 또는 불건전 행위', label: '음란물 또는 불건전 행위' },
-        { value: '스팸/광고성 메시지', label: '스팸/광고성 메시지' },
-        { value: '불쾌한 사용자 정보 내용', label: '불쾌한 사용자 정보 내용' },
-        { value: '만 14세 미만 유저', label: '만 14세 미만 유저' },
-        { value: '기타', label: '기타' },
-      ],
-    },
-    {
-      key: 'sort',
-      label: '정렬',
-      options: [
-        { value: '최신순', label: '최신순' },
-        { value: '오래된 순', label: '오래된 순' },
+        { value: '대기중', label: '대기중' },
+        { value: '검토완료', label: '검토완료' },
+        { value: '거절', label: '거절' },
+        { value: '조치완료', label: '조치완료' },
       ],
     },
   ],

--- a/src/features/admin/configs/productTableConfig.ts
+++ b/src/features/admin/configs/productTableConfig.ts
@@ -1,5 +1,5 @@
 import type { TableConfig } from '../types/adminTable'
-import type { Product } from '@/types/product'
+import type { AdminProduct } from '../types/adminApi'
 import { STATUS_EN_TO_KO, PRODUCT_CATEGORIES, CONDITION_ITEMS } from '@/constants/constants'
 
 const PRODUCT_TYPE_EN_TO_KO: Record<string, string> = {
@@ -24,7 +24,7 @@ const CATEGORY_EN_TO_KO: Record<string, string> = Object.fromEntries(
 
 export { PRODUCT_TYPE_EN_TO_KO, TRADE_STATUS_EN_TO_KO, PRODUCT_STATUS_EN_TO_KO, CATEGORY_EN_TO_KO }
 
-export const productTableConfig: TableConfig<Product> = {
+export const productTableConfig: TableConfig<AdminProduct> = {
   title: '상품 관리',
   rowKey: 'id',
   searchable: true,
@@ -42,8 +42,19 @@ export const productTableConfig: TableConfig<Product> = {
         { value: 'REQUEST', label: '삽니다', color: 'bg-[#FFF7ED] text-orange-800' },
       ],
     },
-    { key: 'mainImageUrl', label: '이미지', type: 'image', width: '80px' },
     { key: 'title', label: '상품명', type: 'text', sortable: true },
+    { key: 'sellerNickname', label: '판매자', type: 'text', sortable: true, width: '120px' },
+    {
+      key: 'category',
+      label: '카테고리',
+      type: 'badge',
+      width: '120px',
+      badgeOptions: PRODUCT_CATEGORIES.map((cat) => ({
+        value: cat.code,
+        label: cat.name,
+        color: 'bg-gray-100 text-gray-800',
+      })),
+    },
     {
       key: 'productStatus',
       label: '상품 상태',

--- a/src/features/admin/configs/userReportTableConfig.ts
+++ b/src/features/admin/configs/userReportTableConfig.ts
@@ -1,16 +1,48 @@
 import type { TableConfig } from '../types/adminTable'
-import type { MockUserReport } from '../mocks/mockUserReports'
+import type { AdminReport } from '../types/adminApi'
 
-export const userReportTableConfig: TableConfig<MockUserReport> = {
+const USER_REPORT_REASON_EN_TO_KO: Record<string, string> = {
+  HARASSMENT: '욕설/비방/괴롭힘',
+  FRAUD: '사기/허위 거래',
+  INAPPROPRIATE_CONTENT: '음란물/불건전 행위',
+  SPAM: '스팸/광고성 메시지',
+  OFFENSIVE_PROFILE: '불쾌한 프로필',
+  UNDERAGE: '만 14세 미만',
+  OTHER: '기타',
+}
+
+export { USER_REPORT_REASON_EN_TO_KO }
+
+export const userReportTableConfig: TableConfig<AdminReport> = {
   title: '유저 신고 관리',
   rowKey: 'id',
-  searchable: true,
-  searchPlaceholder: '신고자 또는 신고 대상자 닉네임 검색...',
+  searchable: false,
   columns: [
     { key: 'id', label: '신고 ID', type: 'number', sortable: true, width: '90px' },
-    { key: 'reporterNickname', label: '신고자', type: 'text', sortable: true },
-    { key: 'targetNickname', label: '신고 대상자 닉네임', type: 'text', sortable: true },
-    { key: 'reasonCode', label: '신고 항목', type: 'text', sortable: true },
+    { key: 'reporterId', label: '신고자 ID', type: 'number', width: '100px' },
+    { key: 'targetId', label: '대상 ID', type: 'number', width: '100px' },
+    {
+      key: 'reasonCodes',
+      label: '신고 사유',
+      type: 'text',
+      format: (v) => {
+        const codes = v as string[]
+        return codes.map((c) => USER_REPORT_REASON_EN_TO_KO[c] || c).join(', ')
+      },
+    },
+    {
+      key: 'status',
+      label: '처리 상태',
+      type: 'badge',
+      sortable: true,
+      width: '110px',
+      badgeOptions: [
+        { value: 'PENDING', label: '대기중', color: 'bg-yellow-100 text-yellow-800' },
+        { value: 'REVIEWED', label: '검토완료', color: 'bg-green-100 text-green-800' },
+        { value: 'REJECTED', label: '거절', color: 'bg-gray-100 text-gray-800' },
+        { value: 'ACTION_TAKEN', label: '조치완료', color: 'bg-blue-100 text-blue-800' },
+      ],
+    },
     {
       key: 'createdAt',
       label: '신고일자',
@@ -25,24 +57,13 @@ export const userReportTableConfig: TableConfig<MockUserReport> = {
   ],
   filters: [
     {
-      key: 'reasonCode',
-      label: '신고 항목',
+      key: 'status',
+      label: '처리 상태',
       options: [
-        { value: '욕설, 비방, 괴롭힘', label: '욕설, 비방, 괴롭힘' },
-        { value: '사기, 허위 거래 시도', label: '사기, 허위 거래 시도' },
-        { value: '음란물 또는 불건전 행위', label: '음란물 또는 불건전 행위' },
-        { value: '스팸/광고성 메시지', label: '스팸/광고성 메시지' },
-        { value: '불쾌한 사용자 정보 내용', label: '불쾌한 사용자 정보 내용' },
-        { value: '만 14세 미만 유저', label: '만 14세 미만 유저' },
-        { value: '기타', label: '기타' },
-      ],
-    },
-    {
-      key: 'sort',
-      label: '정렬',
-      options: [
-        { value: '최신순', label: '최신순' },
-        { value: '오래된 순', label: '오래된 순' },
+        { value: '대기중', label: '대기중' },
+        { value: '검토완료', label: '검토완료' },
+        { value: '거절', label: '거절' },
+        { value: '조치완료', label: '조치완료' },
       ],
     },
   ],

--- a/src/features/admin/configs/userTableConfig.ts
+++ b/src/features/admin/configs/userTableConfig.ts
@@ -1,7 +1,19 @@
 import type { TableConfig } from '../types/adminTable'
-import type { MockUser } from '../mocks/mockUsers'
+import type { AdminUser } from '../types/adminApi'
 
-export const userTableConfig: TableConfig<MockUser> = {
+const USER_ROLE_EN_TO_KO: Record<string, string> = {
+  USER: '일반회원',
+  ADMIN: '관리자',
+}
+
+const USER_STATUS_EN_TO_KO: Record<string, string> = {
+  ACTIVE: '활성',
+  WITHDRAWN: '탈퇴',
+}
+
+export { USER_ROLE_EN_TO_KO, USER_STATUS_EN_TO_KO }
+
+export const userTableConfig: TableConfig<AdminUser> = {
   title: '사용자 관리',
   rowKey: 'id',
   searchable: true,
@@ -11,7 +23,6 @@ export const userTableConfig: TableConfig<MockUser> = {
     { key: 'email', label: '이메일', type: 'text', sortable: true },
     { key: 'nickname', label: '닉네임', type: 'text', sortable: true },
     { key: 'name', label: '이름', type: 'text', sortable: true },
-    { key: 'birthDate', label: '생년월일', type: 'date', sortable: true, width: '160px' },
     {
       key: 'role',
       label: '권한',
@@ -19,8 +30,8 @@ export const userTableConfig: TableConfig<MockUser> = {
       sortable: true,
       width: '100px',
       badgeOptions: [
-        { value: '일반회원', label: '일반회원', color: 'bg-gray-100 text-gray-800' },
-        { value: '관리자', label: '관리자', color: 'bg-purple-100 text-purple-800' },
+        { value: 'USER', label: '일반회원', color: 'bg-gray-100 text-gray-800' },
+        { value: 'ADMIN', label: '관리자', color: 'bg-purple-100 text-purple-800' },
       ],
     },
     {
@@ -30,30 +41,17 @@ export const userTableConfig: TableConfig<MockUser> = {
       sortable: true,
       width: '100px',
       badgeOptions: [
-        { value: '활성', label: '활성', color: 'bg-green-100 text-green-800' },
-        { value: '비활성', label: '비활성', color: 'bg-gray-100 text-gray-800' },
-        { value: '탈퇴요청', label: '탈퇴요청', color: 'bg-yellow-100 text-yellow-800' },
+        { value: 'ACTIVE', label: '활성', color: 'bg-green-100 text-green-800' },
+        { value: 'WITHDRAWN', label: '탈퇴', color: 'bg-gray-100 text-gray-800' },
       ],
     },
     {
-      key: 'joinedAt',
+      key: 'createdAt',
       label: '가입일',
       type: 'date',
       sortable: true,
       width: '120px',
       format: (v) => {
-        const d = new Date(v as string)
-        return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
-      },
-    },
-    {
-      key: 'withdrawalRequestedAt',
-      label: '탈퇴요청일',
-      type: 'date',
-      sortable: true,
-      width: '120px',
-      format: (v) => {
-        if (!v) return '-'
         const d = new Date(v as string)
         return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
       },
@@ -65,8 +63,7 @@ export const userTableConfig: TableConfig<MockUser> = {
       label: '상태',
       options: [
         { value: '활성', label: '활성' },
-        { value: '비활성', label: '비활성' },
-        { value: '탈퇴요청', label: '탈퇴요청' },
+        { value: '탈퇴', label: '탈퇴' },
       ],
     },
     {

--- a/src/features/admin/configs/withdrawalTableConfig.ts
+++ b/src/features/admin/configs/withdrawalTableConfig.ts
@@ -1,7 +1,17 @@
 import type { TableConfig } from '../types/adminTable'
-import type { MockWithdrawal } from '../mocks/mockWithdrawals'
+import type { AdminWithdrawal } from '../types/adminApi'
 
-export const withdrawalTableConfig: TableConfig<MockWithdrawal> = {
+const WITHDRAWAL_REASON_EN_TO_KO: Record<string, string> = {
+  SERVICE_DISSATISFACTION: '서비스 불만족',
+  PRIVACY_CONCERN: '개인정보 우려',
+  LOW_USAGE: '사용 빈도 낮음',
+  COMPETITOR: '경쟁 서비스 이용',
+  OTHER: '기타',
+}
+
+export { WITHDRAWAL_REASON_EN_TO_KO }
+
+export const withdrawalTableConfig: TableConfig<AdminWithdrawal> = {
   title: '탈퇴 관리',
   rowKey: 'id',
   searchable: true,
@@ -18,13 +28,26 @@ export const withdrawalTableConfig: TableConfig<MockWithdrawal> = {
       sortable: true,
       width: '120px',
       format: (v) => {
+        if (!v) return '-'
         const d = new Date(v as string)
         return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
       },
     },
-    { key: 'reason', label: '탈퇴사유', type: 'text', sortable: true },
     {
-      key: 'withdrawnAt',
+      key: 'withdrawalReason',
+      label: '탈퇴사유',
+      type: 'badge',
+      sortable: true,
+      badgeOptions: [
+        { value: 'SERVICE_DISSATISFACTION', label: '서비스 불만족', color: 'bg-red-100 text-red-800' },
+        { value: 'PRIVACY_CONCERN', label: '개인정보 우려', color: 'bg-yellow-100 text-yellow-800' },
+        { value: 'LOW_USAGE', label: '사용 빈도 낮음', color: 'bg-gray-100 text-gray-800' },
+        { value: 'COMPETITOR', label: '경쟁 서비스 이용', color: 'bg-blue-100 text-blue-800' },
+        { value: 'OTHER', label: '기타', color: 'bg-gray-100 text-gray-800' },
+      ],
+    },
+    {
+      key: 'deletedAt',
       label: '탈퇴 일시',
       type: 'date',
       sortable: true,
@@ -37,7 +60,7 @@ export const withdrawalTableConfig: TableConfig<MockWithdrawal> = {
   ],
   filters: [
     {
-      key: 'reason',
+      key: 'withdrawalReason',
       label: '탈퇴사유',
       options: [
         { value: '서비스 불만족', label: '서비스 불만족' },

--- a/src/features/admin/mocks/mockCommunityReports.ts
+++ b/src/features/admin/mocks/mockCommunityReports.ts
@@ -1,116 +1,32 @@
 import type { AdminTableResponse, SortState, FilterState } from '../types/adminTable'
+import type { AdminReport } from '../types/adminApi'
 
-export interface MockCommunityReport {
-  id: number
-  boardType: string
-  reporterNickname: string
-  postTitle: string
-  authorNickname: string
-  reasonCode: string
-  postContent: string
-  detailReason: string | null
-  images: string[]
-  createdAt: string
-}
-
-const REASON_LABELS = [
-  '욕설, 비방, 혐오 표현',
-  '도배 게시물',
-  '음란물/불건전 콘텐츠',
-  '스팸/광고성 메시지',
-  '자해 또는 자살 의도를 포함',
-  '기타',
+const REASON_CODES = [
+  'ABUSE_OR_HATE', 'SPAM_OR_AD', 'INAPPROPRIATE_CONTENT',
+  'REPETITIVE_POST', 'SELF_HARM_OR_SUICIDE', 'ETC',
 ]
 
-const BOARD_TYPES = ['질문있어요', '정보공유']
-
-const REPORTER_NICKNAMES = [
-  '댕댕이맘', '냥이집사', '펫러버', '동물친구', '쿠들러',
-  '멍뭉이파파', '고양이왕국', '반려인생', '펫프렌즈', '해피독',
-]
-
-const AUTHOR_NICKNAMES = [
-  '나쁜작성자', '스팸봇', '도배충', '광고쟁이', '혐오발언자',
-  '불량유저', '욕쟁이작성자', '음란물작성자', '자해언급자', '기타신고자',
-]
-
-const POST_TITLES = [
-  '강아지 사료 추천해주세요',
-  '고양이 털 빠짐 심한데 어떻게 하나요',
-  '반려동물 병원 추천 부탁드립니다',
-  '강아지 산책 얼마나 해야 할까요',
-  '고양이 화장실 냄새 제거 방법',
-  '반려동물 보험 가입하신 분 계신가요',
-  '강아지 훈련 팁 공유합니다',
-  '고양이 간식 추천 목록',
-  '반려동물 이동장 구매 후기',
-  '강아지 발바닥 관리법 공유',
-  '고양이 스크래처 DIY 방법',
-  '반려동물 목욕 주기 질문',
-  '강아지 예방접종 일정 공유',
-  '고양이 중성화 수술 후기',
-  '반려동물 여행 팁 모음',
-]
-
-const POST_CONTENTS = [
-  '안녕하세요. 강아지 사료를 바꾸려고 하는데 추천해주실 분 계신가요?',
-  '저희 고양이가 요즘 털이 너무 많이 빠지는데 혹시 좋은 방법 있나요?',
-  '근처에 좋은 동물병원을 찾고 있습니다. 추천 부탁드립니다.',
-  '강아지 산책은 하루에 몇 번, 얼마나 해야 할까요?',
-  '고양이 화장실 냄새가 너무 심한데 효과적인 제거 방법을 알고 싶습니다.',
-  '반려동물 보험 가입을 고민 중인데 어떤 상품이 좋을까요?',
-  '강아지 훈련 시 효과적인 방법들을 공유해 드립니다.',
-  '제가 먹여본 고양이 간식 중에서 좋았던 것들을 정리해봤습니다.',
-  '이동장을 구매했는데 사용 후기를 공유합니다.',
-  '강아지 발바닥 관리하는 방법을 공유합니다.',
-]
-
-const DETAIL_REASONS = [
-  '욕설 및 비방 내용이 포함되어 있습니다.',
-  '동일한 게시물을 여러 번 반복 게시하고 있습니다.',
-  '불건전한 이미지가 첨부되어 있습니다.',
-  '광고성 링크가 포함되어 있습니다.',
-  '자해를 암시하는 내용이 있습니다.',
-  null,
-  null,
-  null,
-  '기타 사유로 신고합니다.',
-  '혐오 표현이 포함되어 있습니다.',
-]
-
-const LONG_DETAIL_REASONS: Record<number, string> = {
-  1: '욕설 및 비방 내용이 포함되어 있습니다.\n해당 게시글에는 다른 사용자를 향한 심한 욕설과 비방이 포함되어 있으며, 특정 사용자의 닉네임을 직접 거론하면서 인신공격을 하고 있습니다. 게시글 본문뿐만 아니라 댓글에서도 지속적으로 욕설을 사용하고 있어 다른 사용자들이 심각한 불쾌감을 느끼고 있습니다. 해당 작성자의 이전 게시글을 확인해보면 유사한 패턴이 반복되고 있으며, 커뮤니티 분위기를 심각하게 해치고 있습니다.',
-  3: '불건전한 이미지가 첨부되어 있습니다.\n해당 게시글에 첨부된 이미지들이 매우 불건전하고 선정적인 내용을 담고 있습니다. 반려동물 관련 커뮤니티에서 이러한 이미지가 게시되는 것은 전혀 적절하지 않으며, 미성년자 이용자들이 접할 수 있다는 점에서 더욱 심각한 문제입니다. 이미지 3장 모두 성인 콘텐츠에 해당하는 것으로 판단되며, 게시글의 즉각적인 삭제와 작성자에 대한 강력한 제재를 요청드립니다.',
-  5: '자해를 암시하는 내용이 있습니다.\n해당 게시글의 내용에 자해 및 자살을 암시하는 표현이 다수 포함되어 있어 매우 우려됩니다. 구체적인 방법을 언급하고 있으며, 다른 사용자들에게도 부정적인 영향을 미칠 수 있는 내용입니다. 반려동물 커뮤니티의 특성상 정서적으로 취약한 이용자들도 있을 수 있으므로, 해당 게시글의 즉각적인 비공개 처리와 함께 작성자에게 적절한 안내가 필요하다고 판단됩니다.',
-  7: '혐오 표현이 포함되어 있습니다.\n해당 게시글의 제목과 내용에 특정 인종, 성별, 지역을 비하하고 차별하는 혐오 표현이 다수 포함되어 있습니다. 반려동물과 전혀 관련 없는 정치적이고 사회적으로 민감한 주제를 다루면서 극단적인 혐오 발언을 하고 있으며, 댓글에서 이를 지적하는 다른 사용자들에게도 추가적인 혐오 표현을 사용하고 있습니다. 커뮤니티 가이드라인 위반으로 즉각적인 조치를 요청합니다.',
-  10: '광고성 링크가 포함되어 있습니다.\n해당 게시글에 외부 쇼핑몰 링크와 함께 특정 상품을 홍보하는 광고성 내용이 포함되어 있습니다. 게시글 제목은 정보 공유인 것처럼 위장하고 있으나, 실제 내용은 특정 업체의 상품을 홍보하기 위한 목적으로 작성된 것이 명백합니다. 해당 작성자의 이전 게시글들을 확인해보면 모두 유사한 패턴의 광고성 게시글이며, 조직적인 스팸 활동으로 의심됩니다.',
-}
+const STATUSES: AdminReport['status'][] = ['PENDING', 'REVIEWED', 'REJECTED', 'ACTION_TAKEN']
 
 function randomDate(start: Date, end: Date): string {
   const d = new Date(start.getTime() + Math.random() * (end.getTime() - start.getTime()))
   return d.toISOString()
 }
 
-function generateCommunityReports(count: number): MockCommunityReport[] {
-  return Array.from({ length: count }, (_, i) => {
-    const imageCount = i % 3 === 0 ? Math.floor(Math.random() * 3) + 1 : 0
-    const images = Array.from({ length: imageCount }, (__, j) =>
-      `https://picsum.photos/seed/creport${i + 1}-${j + 1}/200/200`
-    )
-
-    return {
-      id: i + 1,
-      boardType: BOARD_TYPES[i % BOARD_TYPES.length],
-      reporterNickname: `${REPORTER_NICKNAMES[i % REPORTER_NICKNAMES.length]}${i + 1}`,
-      postTitle: POST_TITLES[i % POST_TITLES.length],
-      authorNickname: `${AUTHOR_NICKNAMES[i % AUTHOR_NICKNAMES.length]}`,
-      reasonCode: REASON_LABELS[i % REASON_LABELS.length],
-      postContent: POST_CONTENTS[i % POST_CONTENTS.length],
-      detailReason: LONG_DETAIL_REASONS[i + 1] ?? DETAIL_REASONS[i % DETAIL_REASONS.length],
-      images,
-      createdAt: randomDate(new Date('2024-01-01'), new Date('2025-12-31')),
-    }
-  })
+function generateCommunityReports(count: number): AdminReport[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: i + 1,
+    reporterId: 100 + i,
+    targetType: 'COMMUNITY_POST' as const,
+    targetId: 500 + i,
+    reasonCodes: [REASON_CODES[i % REASON_CODES.length]],
+    detailReason: i % 3 === 0 ? '커뮤니티 게시글 신고 상세 사유입니다.' : null,
+    imageUrls: i % 4 === 0 ? [`https://picsum.photos/seed/creport${i + 1}/200/200`] : null,
+    status: STATUSES[i % STATUSES.length],
+    createdAt: randomDate(new Date('2024-01-01'), new Date('2025-12-31')),
+    reviewedAt: null,
+    rejectedReason: null,
+  }))
 }
 
 const communityReports = generateCommunityReports(25)
@@ -121,28 +37,26 @@ export function getMockCommunityReports(params: {
   sort?: SortState
   filters?: FilterState
   search?: string
-}): AdminTableResponse<MockCommunityReport> {
+}): AdminTableResponse<AdminReport> {
   let filtered = [...communityReports]
 
-  if (params.search) {
-    const q = params.search.toLowerCase()
-    filtered = filtered.filter(
-      (r) =>
-        r.postTitle.toLowerCase().includes(q) ||
-        r.authorNickname.toLowerCase().includes(q) ||
-        r.reporterNickname.toLowerCase().includes(q)
-    )
+  if (params.filters?.status) {
+    filtered = filtered.filter((r) => r.status === params.filters!.status)
   }
 
-  if (params.filters) {
-    if (params.filters.reasonCode) {
-      filtered = filtered.filter((r) => r.reasonCode === params.filters!.reasonCode)
-    }
-    if (params.filters.sort === '최신순') {
-      filtered.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
-    } else if (params.filters.sort === '오래된 순') {
-      filtered.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
-    }
+  if (params.sort?.direction) {
+    const { key, direction } = params.sort
+    filtered.sort((a, b) => {
+      const aVal = a[key as keyof AdminReport]
+      const bVal = b[key as keyof AdminReport]
+      if (typeof aVal === 'string' && typeof bVal === 'string') {
+        return direction === 'asc' ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal)
+      }
+      if (typeof aVal === 'number' && typeof bVal === 'number') {
+        return direction === 'asc' ? aVal - bVal : bVal - aVal
+      }
+      return 0
+    })
   }
 
   const total = filtered.length

--- a/src/features/admin/mocks/mockMemberStats.ts
+++ b/src/features/admin/mocks/mockMemberStats.ts
@@ -1,21 +1,6 @@
-export interface MonthlyMemberStat {
-  month: string
-  signups: number
-  withdrawals: number
-}
+import type { MemberTrendStat, WithdrawalReasonStat } from '../types/adminApi'
 
-export interface WithdrawalReasonStat {
-  reason: string
-  count: number
-}
-
-export const mockWithdrawalReasons: WithdrawalReasonStat[] = [
-  { reason: 'SERVICE_DISSATISFACTION', count: 8 },
-  { reason: 'PRIVACY_CONCERN', count: 6 },
-  { reason: 'LOW_USAGE', count: 7 },
-  { reason: 'COMPETITOR', count: 5 },
-  { reason: 'OTHER', count: 4 },
-]
+export type { MemberTrendStat, WithdrawalReasonStat }
 
 export interface MonthlyWithdrawalReasonStat {
   month: string
@@ -25,6 +10,14 @@ export interface MonthlyWithdrawalReasonStat {
   COMPETITOR: number
   OTHER: number
 }
+
+export const mockWithdrawalReasons: WithdrawalReasonStat[] = [
+  { reason: 'SERVICE_DISSATISFACTION', count: 8 },
+  { reason: 'PRIVACY_CONCERN', count: 6 },
+  { reason: 'LOW_USAGE', count: 7 },
+  { reason: 'COMPETITOR', count: 5 },
+  { reason: 'OTHER', count: 4 },
+]
 
 export const mockMonthlyWithdrawalReasons: MonthlyWithdrawalReasonStat[] = [
   { month: '2025-04', SERVICE_DISSATISFACTION: 3, PRIVACY_CONCERN: 1, LOW_USAGE: 2, COMPETITOR: 1, OTHER: 1 },
@@ -41,17 +34,17 @@ export const mockMonthlyWithdrawalReasons: MonthlyWithdrawalReasonStat[] = [
   { month: '2026-03', SERVICE_DISSATISFACTION: 4, PRIVACY_CONCERN: 2, LOW_USAGE: 3, COMPETITOR: 2, OTHER: 2 },
 ]
 
-export const mockMemberStats: MonthlyMemberStat[] = [
-  { month: '2025-04', signups: 120, withdrawals: 8 },
-  { month: '2025-05', signups: 135, withdrawals: 12 },
-  { month: '2025-06', signups: 98, withdrawals: 6 },
-  { month: '2025-07', signups: 142, withdrawals: 15 },
-  { month: '2025-08', signups: 160, withdrawals: 10 },
-  { month: '2025-09', signups: 175, withdrawals: 18 },
-  { month: '2025-10', signups: 155, withdrawals: 14 },
-  { month: '2025-11', signups: 190, withdrawals: 20 },
-  { month: '2025-12', signups: 210, withdrawals: 22 },
-  { month: '2026-01', signups: 185, withdrawals: 16 },
-  { month: '2026-02', signups: 200, withdrawals: 19 },
-  { month: '2026-03', signups: 225, withdrawals: 13 },
+export const mockMemberStats: MemberTrendStat[] = [
+  { yearMonth: '2025-04', signupCount: 120, withdrawalCount: 8 },
+  { yearMonth: '2025-05', signupCount: 135, withdrawalCount: 12 },
+  { yearMonth: '2025-06', signupCount: 98, withdrawalCount: 6 },
+  { yearMonth: '2025-07', signupCount: 142, withdrawalCount: 15 },
+  { yearMonth: '2025-08', signupCount: 160, withdrawalCount: 10 },
+  { yearMonth: '2025-09', signupCount: 175, withdrawalCount: 18 },
+  { yearMonth: '2025-10', signupCount: 155, withdrawalCount: 14 },
+  { yearMonth: '2025-11', signupCount: 190, withdrawalCount: 20 },
+  { yearMonth: '2025-12', signupCount: 210, withdrawalCount: 22 },
+  { yearMonth: '2026-01', signupCount: 185, withdrawalCount: 16 },
+  { yearMonth: '2026-02', signupCount: 200, withdrawalCount: 19 },
+  { yearMonth: '2026-03', signupCount: 225, withdrawalCount: 13 },
 ]

--- a/src/features/admin/mocks/mockProductRequestReports.ts
+++ b/src/features/admin/mocks/mockProductRequestReports.ts
@@ -1,89 +1,33 @@
 import type { AdminTableResponse, SortState, FilterState } from '../types/adminTable'
+import type { AdminReport } from '../types/adminApi'
 
-export interface MockProductRequestReport {
-  id: number
-  reporterNickname: string
-  image: string
-  productName: string
-  requesterNickname: string
-  reasonCode: string
-  detailReason: string | null
-  images: string[]
-  createdAt: string
-}
-
-const REASON_LABELS = [
-  '욕설, 비방, 괴롭힘',
-  '사기, 허위 거래 시도',
-  '음란물 또는 불건전 행위',
-  '스팸/광고성 메시지',
-  '불쾌한 사용자 정보 내용',
-  '만 14세 미만 유저',
-  '기타',
+const REASON_CODES = [
+  'FALSE_OR_SCAM', 'ILLEGAL_ITEM', 'INAPPROPRIATE_IMAGE',
+  'DUPLICATE_POST', 'SPAM_OR_AD', 'PROXY_PAYMENT_OR_TRADE',
+  'PROFESSIONAL_SELLER', 'ETC',
 ]
 
-const REPORTER_NICKNAMES = [
-  '댕댕이맘', '냥이집사', '펫러버', '동물친구', '쿠들러',
-  '멍뭉이파파', '고양이왕국', '반려인생', '펫프렌즈', '해피독',
-]
-
-const REQUESTER_NICKNAMES = [
-  '의심요청자', '허위요청자', '스팸요청자', '불량요청자', '사기요청자',
-  '욕쟁이요청자', '광고봇요청자', '음란요청자', '미성년요청자', '나쁜요청자',
-]
-
-const PRODUCT_NAMES = [
-  '강아지 사료 10kg', '고양이 캣타워', '반려동물 이동장', '강아지 간식 세트',
-  '고양이 장난감 세트', '반려동물 목욕용품', '강아지 옷 겨울용', '고양이 모래 10L',
-  '반려동물 자동급식기', '강아지 리드줄', '고양이 스크래처', '반려동물 건강검진 쿠폰',
-  '강아지 훈련용 간식', '고양이 습식사료', '반려동물 침대',
-]
-
-const DETAIL_REASONS = [
-  '요청 내용에 부적절한 언어가 포함되어 있습니다.',
-  '허위로 상품을 요청하는 것으로 의심됩니다.',
-  '요청 이미지가 불건전합니다.',
-  '동일한 요청을 반복적으로 도배하고 있습니다.',
-  '요청자의 프로필 정보가 불쾌합니다.',
-  null,
-  null,
-  null,
-  '만 14세 미만인 것으로 의심됩니다.',
-  '기타 사유로 신고합니다.',
-]
-
-const LONG_DETAIL_REASONS: Record<number, string> = {
-  1: '요청 내용에 부적절한 언어가 포함되어 있습니다.\n해당 요청자는 상품 요청 게시글에서 반복적으로 부적절한 언어와 비속어를 사용하고 있습니다. 요청 내용 자체도 정상적인 거래 목적이 아닌 다른 사용자들을 자극하고 분란을 일으키기 위한 목적으로 보이며, 댓글에서도 다른 사용자들에게 욕설과 비방을 일삼고 있습니다. 해당 요청자의 최근 활동 이력을 확인해보면 유사한 패턴이 반복되고 있어 강력한 제재가 필요합니다.',
-  3: '요청 이미지가 불건전합니다.\n해당 상품 요청 게시글에 첨부된 이미지가 매우 선정적이고 불건전한 내용을 포함하고 있습니다. 반려동물 용품 요청과 전혀 관련 없는 부적절한 이미지를 업로드하여 다른 사용자들에게 불쾌감을 주고 있습니다. 특히 미성년자가 이용할 수 있는 플랫폼에서 이러한 콘텐츠가 노출되는 것은 심각한 문제이므로 즉각적인 게시글 삭제와 계정 제재를 요청합니다.',
-  5: '요청자의 프로필 정보가 불쾌합니다.\n해당 요청자의 프로필에 인종차별적이고 혐오적인 내용이 포함되어 있으며, 자기소개란에 다른 반려동물 종을 비하하는 표현을 사용하고 있습니다. 또한 요청 게시글의 내용에서도 특정 지역 출신 사용자들을 차별하는 발언을 하고 있어 커뮤니티의 건전한 문화를 심각하게 훼손하고 있습니다. 이용약관 및 커뮤니티 가이드라인 위반으로 적절한 조치를 부탁드립니다.',
-  7: '만 14세 미만인 것으로 의심됩니다.\n해당 요청자와 채팅으로 대화를 나누다가 본인이 초등학교 6학년이라고 말했습니다. 만 14세 미만의 미성년자가 보호자 동의 없이 서비스를 이용하고 상품 요청 거래를 시도하는 것은 관련 법률에 위반됩니다. 대화 내역을 캡처하여 첨부하오니 확인 부탁드리며, 미성년자 보호 차원에서 해당 계정에 대한 연령 확인 절차를 진행해주시기 바랍니다.',
-  10: '동일한 요청을 반복적으로 도배하고 있습니다.\n해당 요청자가 동일한 상품 요청 게시글을 하루에 20건 이상 반복적으로 등록하고 있으며, 제목과 내용을 미세하게 변경하여 필터를 우회하고 있습니다. 이러한 도배 행위로 인해 다른 정상적인 요청 게시글이 묻히고 있으며, 여러 사용자들이 불편을 호소하고 있습니다. 해당 요청자의 게시 이력을 확인하시면 패턴이 명확하게 드러날 것이며, 반복적인 도배 행위에 대한 제재를 요청드립니다.',
-}
+const STATUSES: AdminReport['status'][] = ['PENDING', 'REVIEWED', 'REJECTED', 'ACTION_TAKEN']
 
 function randomDate(start: Date, end: Date): string {
   const d = new Date(start.getTime() + Math.random() * (end.getTime() - start.getTime()))
   return d.toISOString()
 }
 
-function generateProductRequestReports(count: number): MockProductRequestReport[] {
-  return Array.from({ length: count }, (_, i) => {
-    const imageCount = i % 3 === 0 ? Math.floor(Math.random() * 3) + 1 : 0
-    const images = Array.from({ length: imageCount }, (__, j) =>
-      `https://picsum.photos/seed/prreport${i + 1}-${j + 1}/200/200`
-    )
-
-    return {
-      id: i + 1,
-      reporterNickname: `${REPORTER_NICKNAMES[i % REPORTER_NICKNAMES.length]}${i + 1}`,
-      image: `https://picsum.photos/seed/prproduct${i + 1}/100/100`,
-      productName: PRODUCT_NAMES[i % PRODUCT_NAMES.length],
-      requesterNickname: `${REQUESTER_NICKNAMES[i % REQUESTER_NICKNAMES.length]}`,
-      reasonCode: REASON_LABELS[i % REASON_LABELS.length],
-      detailReason: LONG_DETAIL_REASONS[i + 1] ?? DETAIL_REASONS[i % DETAIL_REASONS.length],
-      images,
-      createdAt: randomDate(new Date('2024-01-01'), new Date('2025-12-31')),
-    }
-  })
+function generateProductRequestReports(count: number): AdminReport[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: i + 1,
+    reporterId: 100 + i,
+    targetType: 'PRODUCT' as const,
+    targetId: 400 + i,
+    reasonCodes: [REASON_CODES[i % REASON_CODES.length]],
+    detailReason: i % 3 === 0 ? '판매요청 상품 신고 상세 사유입니다.' : null,
+    imageUrls: i % 4 === 0 ? [`https://picsum.photos/seed/prreport${i + 1}/200/200`] : null,
+    status: STATUSES[i % STATUSES.length],
+    createdAt: randomDate(new Date('2024-01-01'), new Date('2025-12-31')),
+    reviewedAt: null,
+    rejectedReason: null,
+  }))
 }
 
 const productRequestReports = generateProductRequestReports(25)
@@ -94,28 +38,26 @@ export function getMockProductRequestReports(params: {
   sort?: SortState
   filters?: FilterState
   search?: string
-}): AdminTableResponse<MockProductRequestReport> {
+}): AdminTableResponse<AdminReport> {
   let filtered = [...productRequestReports]
 
-  if (params.search) {
-    const q = params.search.toLowerCase()
-    filtered = filtered.filter(
-      (r) =>
-        r.productName.toLowerCase().includes(q) ||
-        r.requesterNickname.toLowerCase().includes(q) ||
-        r.reporterNickname.toLowerCase().includes(q)
-    )
+  if (params.filters?.status) {
+    filtered = filtered.filter((r) => r.status === params.filters!.status)
   }
 
-  if (params.filters) {
-    if (params.filters.reasonCode) {
-      filtered = filtered.filter((r) => r.reasonCode === params.filters!.reasonCode)
-    }
-    if (params.filters.sort === '최신순') {
-      filtered.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
-    } else if (params.filters.sort === '오래된 순') {
-      filtered.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
-    }
+  if (params.sort?.direction) {
+    const { key, direction } = params.sort
+    filtered.sort((a, b) => {
+      const aVal = a[key as keyof AdminReport]
+      const bVal = b[key as keyof AdminReport]
+      if (typeof aVal === 'string' && typeof bVal === 'string') {
+        return direction === 'asc' ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal)
+      }
+      if (typeof aVal === 'number' && typeof bVal === 'number') {
+        return direction === 'asc' ? aVal - bVal : bVal - aVal
+      }
+      return 0
+    })
   }
 
   const total = filtered.length

--- a/src/features/admin/mocks/mockProductSellReports.ts
+++ b/src/features/admin/mocks/mockProductSellReports.ts
@@ -1,89 +1,33 @@
 import type { AdminTableResponse, SortState, FilterState } from '../types/adminTable'
+import type { AdminReport } from '../types/adminApi'
 
-export interface MockProductSellReport {
-  id: number
-  reporterNickname: string
-  image: string
-  productName: string
-  sellerNickname: string
-  reasonCode: string
-  detailReason: string | null
-  images: string[]
-  createdAt: string
-}
-
-const REASON_LABELS = [
-  '욕설, 비방, 괴롭힘',
-  '사기, 허위 거래 시도',
-  '음란물 또는 불건전 행위',
-  '스팸/광고성 메시지',
-  '불쾌한 사용자 정보 내용',
-  '만 14세 미만 유저',
-  '기타',
+const REASON_CODES = [
+  'FALSE_OR_SCAM', 'ILLEGAL_ITEM', 'INAPPROPRIATE_IMAGE',
+  'DUPLICATE_POST', 'SPAM_OR_AD', 'PROXY_PAYMENT_OR_TRADE',
+  'PROFESSIONAL_SELLER', 'ETC',
 ]
 
-const REPORTER_NICKNAMES = [
-  '댕댕이맘', '냥이집사', '펫러버', '동물친구', '쿠들러',
-  '멍뭉이파파', '고양이왕국', '반려인생', '펫프렌즈', '해피독',
-]
-
-const SELLER_NICKNAMES = [
-  '사기판매자', '허위상품판매', '불량셀러', '스팸셀러', '욕쟁이셀러',
-  '광고봇판매자', '의심판매자', '음란물판매', '허위거래자', '나쁜판매자',
-]
-
-const PRODUCT_NAMES = [
-  '강아지 사료 10kg', '고양이 캣타워', '반려동물 이동장', '강아지 간식 세트',
-  '고양이 장난감 세트', '반려동물 목욕용품', '강아지 옷 겨울용', '고양이 모래 10L',
-  '반려동물 자동급식기', '강아지 리드줄', '고양이 스크래처', '반려동물 건강검진 쿠폰',
-  '강아지 훈련용 간식', '고양이 습식사료', '반려동물 침대',
-]
-
-const DETAIL_REASONS = [
-  '상품 설명과 실제 상품이 완전히 다릅니다.',
-  '돈을 보냈는데 상품을 받지 못했습니다.',
-  '상품 이미지가 불건전합니다.',
-  '동일한 상품을 여러 번 도배하고 있습니다.',
-  '상품 설명에 부적절한 내용이 포함되어 있습니다.',
-  null,
-  null,
-  null,
-  '가격을 허위로 표기한 것 같습니다.',
-  '판매자가 연락을 받지 않습니다.',
-]
-
-const LONG_DETAIL_REASONS: Record<number, string> = {
-  1: '상품 설명과 실제 상품이 완전히 다릅니다.\n해당 상품의 설명에는 "새 상품, 미개봉"이라고 기재되어 있었으나, 실제로 수령한 상품은 포장이 뜯겨져 있었고 사용 흔적이 뚜렷하게 남아있었습니다. 상품 사진도 인터넷에서 가져온 것으로 보이며, 실제 상품과 전혀 일치하지 않습니다. 판매자에게 문의했으나 답변을 회피하고 있으며, 환불도 거부하고 있는 상황입니다. 허위 상품 등록에 대한 제재를 요청합니다.',
-  3: '상품 이미지가 불건전합니다.\n해당 판매 게시글에 첨부된 상품 이미지 중 일부가 매우 불건전하고 선정적인 내용을 포함하고 있습니다. 반려동물 용품 거래 플랫폼에서 이러한 이미지가 노출되는 것은 부적절하며, 특히 미성년자 이용자가 접근할 수 있는 환경에서 심각한 문제가 됩니다. 해당 게시글의 이미지를 즉시 확인하시고 적절한 조치를 취해주시기 바랍니다.',
-  5: '상품 설명에 부적절한 내용이 포함되어 있습니다.\n해당 상품 게시글의 설명란에 반려동물과 무관한 부적절하고 불쾌한 내용이 다수 포함되어 있습니다. 상품명은 정상적인 반려동물 용품으로 되어 있으나, 상세 설명을 읽어보면 혐오 표현과 차별적 발언이 포함되어 있어 이용자들에게 불쾌감을 주고 있습니다. 커뮤니티 가이드라인을 명백히 위반하고 있으므로 게시글 삭제 및 판매자 제재를 요청드립니다.',
-  7: '만 14세 미만 판매자로 의심됩니다.\n해당 판매자와 거래를 진행하면서 채팅을 나눴는데, 대화 중 본인이 중학교 1학년이라고 밝혔습니다. 만 14세 미만으로 추정되며, 보호자의 동의 없이 고가의 반려동물 용품을 판매하고 있는 것으로 보입니다. 미성년자 보호를 위해 해당 계정의 나이 확인 및 적절한 조치가 필요하다고 판단됩니다. 관련 대화 스크린샷을 첨부합니다.',
-  10: '입금 후 상품 미발송 사기 의심 거래입니다.\n해당 판매자에게 반려동물 자동급식기를 구매하고 입금까지 완료했으나, 이후 일주일이 넘도록 상품을 발송하지 않고 있습니다. 채팅으로 여러 차례 배송 일정을 문의했지만 매번 다른 핑계를 대며 발송을 미루고 있으며, 최근에는 메시지 읽기조차 하지 않고 있습니다. 다른 구매자 후기에서도 유사한 패턴이 확인되어 사기 거래로 의심됩니다.',
-}
+const STATUSES: AdminReport['status'][] = ['PENDING', 'REVIEWED', 'REJECTED', 'ACTION_TAKEN']
 
 function randomDate(start: Date, end: Date): string {
   const d = new Date(start.getTime() + Math.random() * (end.getTime() - start.getTime()))
   return d.toISOString()
 }
 
-function generateProductSellReports(count: number): MockProductSellReport[] {
-  return Array.from({ length: count }, (_, i) => {
-    const imageCount = i % 3 === 0 ? Math.floor(Math.random() * 3) + 1 : 0
-    const images = Array.from({ length: imageCount }, (__, j) =>
-      `https://picsum.photos/seed/preport${i + 1}-${j + 1}/200/200`
-    )
-
-    return {
-      id: i + 1,
-      reporterNickname: `${REPORTER_NICKNAMES[i % REPORTER_NICKNAMES.length]}${i + 1}`,
-      image: `https://picsum.photos/seed/psell${i + 1}/100/100`,
-      productName: PRODUCT_NAMES[i % PRODUCT_NAMES.length],
-      sellerNickname: `${SELLER_NICKNAMES[i % SELLER_NICKNAMES.length]}`,
-      reasonCode: REASON_LABELS[i % REASON_LABELS.length],
-      detailReason: LONG_DETAIL_REASONS[i + 1] ?? DETAIL_REASONS[i % DETAIL_REASONS.length],
-      images,
-      createdAt: randomDate(new Date('2024-01-01'), new Date('2025-12-31')),
-    }
-  })
+function generateProductSellReports(count: number): AdminReport[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: i + 1,
+    reporterId: 100 + i,
+    targetType: 'PRODUCT' as const,
+    targetId: 300 + i,
+    reasonCodes: [REASON_CODES[i % REASON_CODES.length]],
+    detailReason: i % 3 === 0 ? '상품 신고 상세 사유입니다.' : null,
+    imageUrls: i % 4 === 0 ? [`https://picsum.photos/seed/preport${i + 1}/200/200`] : null,
+    status: STATUSES[i % STATUSES.length],
+    createdAt: randomDate(new Date('2024-01-01'), new Date('2025-12-31')),
+    reviewedAt: null,
+    rejectedReason: null,
+  }))
 }
 
 const productSellReports = generateProductSellReports(25)
@@ -94,28 +38,26 @@ export function getMockProductSellReports(params: {
   sort?: SortState
   filters?: FilterState
   search?: string
-}): AdminTableResponse<MockProductSellReport> {
+}): AdminTableResponse<AdminReport> {
   let filtered = [...productSellReports]
 
-  if (params.search) {
-    const q = params.search.toLowerCase()
-    filtered = filtered.filter(
-      (r) =>
-        r.productName.toLowerCase().includes(q) ||
-        r.sellerNickname.toLowerCase().includes(q) ||
-        r.reporterNickname.toLowerCase().includes(q)
-    )
+  if (params.filters?.status) {
+    filtered = filtered.filter((r) => r.status === params.filters!.status)
   }
 
-  if (params.filters) {
-    if (params.filters.reasonCode) {
-      filtered = filtered.filter((r) => r.reasonCode === params.filters!.reasonCode)
-    }
-    if (params.filters.sort === '최신순') {
-      filtered.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
-    } else if (params.filters.sort === '오래된 순') {
-      filtered.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
-    }
+  if (params.sort?.direction) {
+    const { key, direction } = params.sort
+    filtered.sort((a, b) => {
+      const aVal = a[key as keyof AdminReport]
+      const bVal = b[key as keyof AdminReport]
+      if (typeof aVal === 'string' && typeof bVal === 'string') {
+        return direction === 'asc' ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal)
+      }
+      if (typeof aVal === 'number' && typeof bVal === 'number') {
+        return direction === 'asc' ? aVal - bVal : bVal - aVal
+      }
+      return 0
+    })
   }
 
   const total = filtered.length

--- a/src/features/admin/mocks/mockUserReports.ts
+++ b/src/features/admin/mocks/mockUserReports.ts
@@ -1,78 +1,32 @@
 import type { AdminTableResponse, SortState, FilterState } from '../types/adminTable'
+import type { AdminReport } from '../types/adminApi'
 
-export interface MockUserReport {
-  id: number
-  reporterNickname: string
-  targetNickname: string
-  reasonCode: string
-  detailReason: string | null
-  images: string[]
-  createdAt: string
-}
-
-const REASON_LABELS = [
-  '욕설, 비방, 괴롭힘',
-  '사기, 허위 거래 시도',
-  '음란물 또는 불건전 행위',
-  '스팸/광고성 메시지',
-  '불쾌한 사용자 정보 내용',
-  '만 14세 미만 유저',
-  '기타',
+const REASON_CODES = [
+  'ABUSE_OR_HATE', 'SPAM_OR_AD', 'INAPPROPRIATE_CONTENT',
+  'REPETITIVE_POST', 'SELF_HARM_OR_SUICIDE', 'ETC',
 ]
 
-const REPORTER_NICKNAMES = [
-  '댕댕이맘', '냥이집사', '펫러버', '동물친구', '쿠들러',
-  '멍뭉이파파', '고양이왕국', '반려인생', '펫프렌즈', '해피독',
-]
-
-const TARGET_NICKNAMES = [
-  '나쁜유저1', '스팸봇99', '사기꾼주의', '불량회원', '욕쟁이유저',
-  '광고쟁이', '미성년자의심', '음란물게시자', '허위판매자', '괴롭힘유저',
-]
-
-const DETAIL_REASONS = [
-  '채팅에서 심한 욕설을 반복적으로 사용했습니다.',
-  '물건을 보내지 않고 돈만 받아갔습니다.',
-  '프로필 사진이 매우 불건전합니다.',
-  '같은 메시지를 하루에 수십 번 보냅니다.',
-  '사용자 소개에 부적절한 내용이 있습니다.',
-  '대화 중 나이를 물어봤더니 13살이라고 했습니다.',
-  null,
-  null,
-  null,
-  '거래 후 연락이 두절되었습니다.',
-]
-
-const LONG_DETAIL_REASONS: Record<number, string> = {
-  1: '채팅에서 심한 욕설과 비방을 했습니다.\n해당 유저는 채팅방에서 반복적으로 심한 욕설과 비방을 하고 있으며, 다른 사용자들에게 인신공격성 발언을 지속적으로 하고 있습니다. 특히 거래 과정에서 의견이 맞지 않으면 극단적인 표현을 사용하며, 여러 사용자가 동일한 피해를 호소하고 있는 상황입니다. 해당 유저의 채팅 내역을 확인해주시면 반복적인 패턴을 확인하실 수 있을 것입니다. 빠른 조치를 부탁드립니다.',
-  3: '프로필에 불건전한 콘텐츠가 포함되어 있습니다.\n해당 유저의 프로필 사진과 소개글에 매우 불건전하고 선정적인 이미지와 내용이 포함되어 있습니다. 반려동물 커뮤니티의 특성상 미성년자 이용자도 많은데, 이러한 콘텐츠가 노출되는 것은 매우 부적절합니다. 프로필 사진은 성인 콘텐츠에 해당하며, 소개글에도 부적절한 표현이 다수 포함되어 있어 즉각적인 제재가 필요하다고 판단됩니다.',
-  5: '사용자 프로필에 차별적 내용이 포함되어 있습니다.\n해당 유저의 자기소개 및 프로필 정보에 다른 사용자를 비하하고 차별하는 내용이 포함되어 있습니다. 특정 견종이나 반려동물을 키우는 사람들을 비하하는 표현을 사용하고 있으며, 커뮤니티의 건전한 문화를 해치고 있습니다. 여러 사용자들이 해당 프로필을 보고 불쾌함을 느끼고 있으며, 커뮤니티 이용 규칙에 명백히 위반되는 내용입니다.',
-  7: '만 14세 미만 유저로 의심됩니다.\n해당 유저와 채팅을 나누던 중 본인이 만 13세라고 밝혔으며, 부모님의 동의 없이 거래를 시도하고 있었습니다. 개인정보 보호 및 미성년자 보호 관련 법률에 따라 만 14세 미만의 유저는 서비스 이용이 제한되어야 합니다. 대화 내역에서 나이를 확인할 수 있으며, 해당 유저의 다른 활동 내역도 함께 검토해주시기 바랍니다.',
-  10: '입금 후 연락이 두절된 사기 의심 거래입니다.\n해당 유저와 반려동물 용품 거래를 진행했는데, 입금 후 연락이 완전히 두절되었습니다. 여러 차례 메시지를 보냈으나 읽지도 않고 있으며, 프로필도 비공개로 전환한 상태입니다. 다른 사용자들의 후기를 확인해보니 유사한 피해 사례가 다수 존재하는 것으로 보입니다. 사기 의심 거래로 판단되어 빠른 확인과 계정 제재를 요청드립니다.',
-}
+const STATUSES: AdminReport['status'][] = ['PENDING', 'REVIEWED', 'REJECTED', 'ACTION_TAKEN']
 
 function randomDate(start: Date, end: Date): string {
   const d = new Date(start.getTime() + Math.random() * (end.getTime() - start.getTime()))
   return d.toISOString()
 }
 
-function generateUserReports(count: number): MockUserReport[] {
-  return Array.from({ length: count }, (_, i) => {
-    const imageCount = i % 3 === 0 ? Math.floor(Math.random() * 3) + 1 : 0
-    const images = Array.from({ length: imageCount }, (__, j) =>
-      `https://picsum.photos/seed/ureport${i + 1}-${j + 1}/200/200`
-    )
-
-    return {
-      id: i + 1,
-      reporterNickname: `${REPORTER_NICKNAMES[i % REPORTER_NICKNAMES.length]}${i + 1}`,
-      targetNickname: `${TARGET_NICKNAMES[i % TARGET_NICKNAMES.length]}`,
-      reasonCode: REASON_LABELS[i % REASON_LABELS.length],
-      detailReason: LONG_DETAIL_REASONS[i + 1] ?? DETAIL_REASONS[i % DETAIL_REASONS.length],
-      images,
-      createdAt: randomDate(new Date('2024-01-01'), new Date('2025-12-31')),
-    }
-  })
+function generateUserReports(count: number): AdminReport[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: i + 1,
+    reporterId: 100 + i,
+    targetType: 'USER' as const,
+    targetId: 200 + i,
+    reasonCodes: [REASON_CODES[i % REASON_CODES.length]],
+    detailReason: i % 3 === 0 ? '신고 상세 사유입니다.' : null,
+    imageUrls: i % 4 === 0 ? [`https://picsum.photos/seed/ureport${i + 1}/200/200`] : null,
+    status: STATUSES[i % STATUSES.length],
+    createdAt: randomDate(new Date('2024-01-01'), new Date('2025-12-31')),
+    reviewedAt: null,
+    rejectedReason: null,
+  }))
 }
 
 const userReports = generateUserReports(25)
@@ -83,27 +37,26 @@ export function getMockUserReports(params: {
   sort?: SortState
   filters?: FilterState
   search?: string
-}): AdminTableResponse<MockUserReport> {
+}): AdminTableResponse<AdminReport> {
   let filtered = [...userReports]
 
-  if (params.search) {
-    const q = params.search.toLowerCase()
-    filtered = filtered.filter(
-      (r) =>
-        r.reporterNickname.toLowerCase().includes(q) ||
-        r.targetNickname.toLowerCase().includes(q)
-    )
+  if (params.filters?.status) {
+    filtered = filtered.filter((r) => r.status === params.filters!.status)
   }
 
-  if (params.filters) {
-    if (params.filters.reasonCode) {
-      filtered = filtered.filter((r) => r.reasonCode === params.filters!.reasonCode)
-    }
-    if (params.filters.sort === '최신순') {
-      filtered.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
-    } else if (params.filters.sort === '오래된 순') {
-      filtered.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
-    }
+  if (params.sort?.direction) {
+    const { key, direction } = params.sort
+    filtered.sort((a, b) => {
+      const aVal = a[key as keyof AdminReport]
+      const bVal = b[key as keyof AdminReport]
+      if (typeof aVal === 'string' && typeof bVal === 'string') {
+        return direction === 'asc' ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal)
+      }
+      if (typeof aVal === 'number' && typeof bVal === 'number') {
+        return direction === 'asc' ? aVal - bVal : bVal - aVal
+      }
+      return 0
+    })
   }
 
   const total = filtered.length

--- a/src/features/admin/mocks/mockUsers.ts
+++ b/src/features/admin/mocks/mockUsers.ts
@@ -1,22 +1,7 @@
 import type { AdminTableResponse, SortState, FilterState } from '../types/adminTable'
+import type { AdminUser } from '../types/adminApi'
 import { CITIES, PROVINCES } from '@/constants/cities'
 
-export interface MockUser {
-  id: number
-  name: string
-  nickname: string
-  email: string
-  joinedAt: string
-  birthDate: string
-  addressSido: string
-  addressGugun: string
-  profileImageUrl: string | null
-  role: string
-  status: string
-  withdrawalRequestedAt: string | null
-}
-
-const USER_STATUSES = ['활성', '비활성', '탈퇴요청']
 const NICKNAMES = [
   '댕댕이맘', '냥이집사', '펫러버', '동물친구', '쿠들러',
   '멍뭉이파파', '고양이왕국', '반려인생', '펫프렌즈', '해피독',
@@ -27,7 +12,6 @@ const NAMES = [
   '강하은', '조유준', '윤서진', '임지아', '한민재',
   '오예린', '신동현', '황수빈', '배준서', '류하윤',
 ]
-const ROLES = ['일반회원', '관리자']
 
 function randomAddress(): { addressSido: string; addressGugun: string } {
   const sido = PROVINCES[Math.floor(Math.random() * PROVINCES.length)]
@@ -41,21 +25,19 @@ function randomDate(start: Date, end: Date): string {
   return d.toISOString()
 }
 
-function generateUsers(count: number): MockUser[] {
+function generateUsers(count: number): AdminUser[] {
   return Array.from({ length: count }, (_, i) => {
-    const status = USER_STATUSES[Math.floor(Math.random() * USER_STATUSES.length)]
+    const status: AdminUser['status'] = Math.random() > 0.15 ? 'ACTIVE' : 'WITHDRAWN'
     return {
       id: i + 1,
       name: NAMES[i % NAMES.length],
       nickname: `${NICKNAMES[i % NICKNAMES.length]}${i + 1}`,
       email: `user${i + 1}@example.com`,
-      joinedAt: randomDate(new Date('2023-01-01'), new Date('2025-12-31')),
+      createdAt: randomDate(new Date('2023-01-01'), new Date('2025-12-31')),
       birthDate: randomDate(new Date('1980-01-01'), new Date('2005-12-31')),
       ...randomAddress(),
-      profileImageUrl: [1, 3, 5, 7, 10].includes(i + 1) ? `https://i.pravatar.cc/150?img=${i + 1}` : null,
-      role: ROLES[Math.floor(Math.random() * ROLES.length)],
+      role: Math.random() > 0.9 ? 'ADMIN' : 'USER',
       status,
-      withdrawalRequestedAt: status !== '활성' ? randomDate(new Date('2025-01-01'), new Date('2025-12-31')) : null,
     }
   })
 }
@@ -68,7 +50,7 @@ export function getMockUsers(params: {
   sort?: SortState
   filters?: FilterState
   search?: string
-}): AdminTableResponse<MockUser> {
+}): AdminTableResponse<AdminUser> {
   let filtered = [...users]
 
   if (params.search) {
@@ -89,8 +71,8 @@ export function getMockUsers(params: {
   if (params.sort?.direction) {
     const { key, direction } = params.sort
     filtered.sort((a, b) => {
-      const aVal = a[key as keyof MockUser]
-      const bVal = b[key as keyof MockUser]
+      const aVal = a[key as keyof AdminUser]
+      const bVal = b[key as keyof AdminUser]
       if (typeof aVal === 'string' && typeof bVal === 'string') {
         return direction === 'asc' ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal)
       }

--- a/src/features/admin/mocks/mockWithdrawals.ts
+++ b/src/features/admin/mocks/mockWithdrawals.ts
@@ -1,59 +1,29 @@
 import type { AdminTableResponse, SortState, FilterState } from '../types/adminTable'
-
-export interface MockWithdrawal {
-  id: number
-  name: string
-  nickname: string
-  email: string
-  birthDate: string
-  withdrawnAt: string
-  reason: string
-  status: '처리완료' | '처리중' | '보류'
-}
+import type { AdminWithdrawal } from '../types/adminApi'
 
 const NAMES = [
   '김민수', '이서연', '박지호', '최수아', '정도윤',
   '강하은', '조유준', '윤서진', '임지아', '한민재',
   '오예린', '신동현', '황수빈', '배준서', '류하윤',
 ]
-const BIRTH_DATES = [
-  '1990-03-15', '1988-07-22', '1995-01-10', '1992-11-05', '1987-06-28',
-  '1993-09-14', '1991-04-03', '1989-12-19', '1996-02-25', '1994-08-07',
-  '1990-05-30', '1988-10-12', '1995-07-08', '1992-03-21', '1987-11-16',
+
+const WITHDRAWAL_REASONS = [
+  'SERVICE_DISSATISFACTION', 'PRIVACY_CONCERN', 'LOW_USAGE', 'COMPETITOR', 'OTHER',
 ]
 
-const withdrawals: MockWithdrawal[] = [
-  { id: 1, name: NAMES[0], nickname: '사용자01', email: 'user01@example.com', birthDate: BIRTH_DATES[0], withdrawnAt: '2026-03-01', reason: '서비스 불만족', status: '처리완료' },
-  { id: 2, name: NAMES[1], nickname: '사용자02', email: 'user02@example.com', birthDate: BIRTH_DATES[1], withdrawnAt: '2026-03-01', reason: '개인정보 우려', status: '처리완료' },
-  { id: 3, name: NAMES[2], nickname: '사용자03', email: 'user03@example.com', birthDate: BIRTH_DATES[2], withdrawnAt: '2026-02-28', reason: '경쟁 서비스 이용', status: '처리완료' },
-  { id: 4, name: NAMES[3], nickname: '사용자04', email: 'user04@example.com', birthDate: BIRTH_DATES[3], withdrawnAt: '2026-02-27', reason: '서비스 불만족', status: '처리중' },
-  { id: 5, name: NAMES[4], nickname: '사용자05', email: 'user05@example.com', birthDate: BIRTH_DATES[4], withdrawnAt: '2026-02-26', reason: '개인정보 우려', status: '처리완료' },
-  { id: 6, name: NAMES[5], nickname: '사용자06', email: 'user06@example.com', birthDate: BIRTH_DATES[5], withdrawnAt: '2026-02-25', reason: '사용 빈도 낮음', status: '보류' },
-  { id: 7, name: NAMES[6], nickname: '사용자07', email: 'user07@example.com', birthDate: BIRTH_DATES[6], withdrawnAt: '2026-02-24', reason: '개인정보 우려', status: '처리완료' },
-  { id: 8, name: NAMES[7], nickname: '사용자08', email: 'user08@example.com', birthDate: BIRTH_DATES[7], withdrawnAt: '2026-02-23', reason: '서비스 불만족', status: '처리완료' },
-  { id: 9, name: NAMES[8], nickname: '사용자09', email: 'user09@example.com', birthDate: BIRTH_DATES[8], withdrawnAt: '2026-02-22', reason: '경쟁 서비스 이용', status: '처리중' },
-  { id: 10, name: NAMES[9], nickname: '사용자10', email: 'user10@example.com', birthDate: BIRTH_DATES[9], withdrawnAt: '2026-02-21', reason: '개인정보 우려', status: '처리완료' },
-  { id: 11, name: NAMES[10], nickname: '사용자11', email: 'user11@example.com', birthDate: BIRTH_DATES[10], withdrawnAt: '2026-02-20', reason: '사용 빈도 낮음', status: '처리완료' },
-  { id: 12, name: NAMES[11], nickname: '사용자12', email: 'user12@example.com', birthDate: BIRTH_DATES[11], withdrawnAt: '2026-02-19', reason: '서비스 불만족', status: '보류' },
-  { id: 13, name: NAMES[12], nickname: '사용자13', email: 'user13@example.com', birthDate: BIRTH_DATES[12], withdrawnAt: '2026-02-18', reason: '개인정보 우려', status: '처리완료' },
-  { id: 14, name: NAMES[13], nickname: '사용자14', email: 'user14@example.com', birthDate: BIRTH_DATES[13], withdrawnAt: '2026-02-17', reason: '경쟁 서비스 이용', status: '처리중' },
-  { id: 15, name: NAMES[14], nickname: '사용자15', email: 'user15@example.com', birthDate: BIRTH_DATES[14], withdrawnAt: '2026-02-16', reason: '서비스 불만족', status: '처리완료' },
-  { id: 16, name: NAMES[0], nickname: '사용자16', email: 'user16@example.com', birthDate: BIRTH_DATES[0], withdrawnAt: '2026-02-15', reason: '개인정보 우려', status: '처리완료' },
-  { id: 17, name: NAMES[1], nickname: '사용자17', email: 'user17@example.com', birthDate: BIRTH_DATES[1], withdrawnAt: '2026-02-14', reason: '사용 빈도 낮음', status: '보류' },
-  { id: 18, name: NAMES[2], nickname: '사용자18', email: 'user18@example.com', birthDate: BIRTH_DATES[2], withdrawnAt: '2026-02-13', reason: '서비스 불만족', status: '처리완료' },
-  { id: 19, name: NAMES[3], nickname: '사용자19', email: 'user19@example.com', birthDate: BIRTH_DATES[3], withdrawnAt: '2026-02-12', reason: '개인정보 우려', status: '처리중' },
-  { id: 20, name: NAMES[4], nickname: '사용자20', email: 'user20@example.com', birthDate: BIRTH_DATES[4], withdrawnAt: '2026-02-11', reason: '경쟁 서비스 이용', status: '처리완료' },
-  { id: 21, name: NAMES[5], nickname: '사용자21', email: 'user21@example.com', birthDate: BIRTH_DATES[5], withdrawnAt: '2026-02-10', reason: '서비스 불만족', status: '처리완료' },
-  { id: 22, name: NAMES[6], nickname: '사용자22', email: 'user22@example.com', birthDate: BIRTH_DATES[6], withdrawnAt: '2026-02-09', reason: '개인정보 우려', status: '보류' },
-  { id: 23, name: NAMES[7], nickname: '사용자23', email: 'user23@example.com', birthDate: BIRTH_DATES[7], withdrawnAt: '2026-02-08', reason: '사용 빈도 낮음', status: '처리완료' },
-  { id: 24, name: NAMES[8], nickname: '사용자24', email: 'user24@example.com', birthDate: BIRTH_DATES[8], withdrawnAt: '2026-02-07', reason: '서비스 불만족', status: '처리중' },
-  { id: 25, name: NAMES[9], nickname: '사용자25', email: 'user25@example.com', birthDate: BIRTH_DATES[9], withdrawnAt: '2026-02-06', reason: '개인정보 우려', status: '처리완료' },
-  { id: 26, name: NAMES[10], nickname: '사용자26', email: 'user26@example.com', birthDate: BIRTH_DATES[10], withdrawnAt: '2026-02-05', reason: '경쟁 서비스 이용', status: '처리완료' },
-  { id: 27, name: NAMES[11], nickname: '사용자27', email: 'user27@example.com', birthDate: BIRTH_DATES[11], withdrawnAt: '2026-02-04', reason: '서비스 불만족', status: '보류' },
-  { id: 28, name: NAMES[12], nickname: '사용자28', email: 'user28@example.com', birthDate: BIRTH_DATES[12], withdrawnAt: '2026-02-03', reason: '개인정보 우려', status: '처리완료' },
-  { id: 29, name: NAMES[13], nickname: '사용자29', email: 'user29@example.com', birthDate: BIRTH_DATES[13], withdrawnAt: '2026-02-02', reason: '사용 빈도 낮음', status: '처리중' },
-  { id: 30, name: NAMES[14], nickname: '사용자30', email: 'user30@example.com', birthDate: BIRTH_DATES[14], withdrawnAt: '2026-02-01', reason: '서비스 불만족', status: '처리완료' },
-]
+const withdrawals: AdminWithdrawal[] = Array.from({ length: 30 }, (_, i) => ({
+  id: i + 1,
+  name: NAMES[i % NAMES.length],
+  nickname: `사용자${String(i + 1).padStart(2, '0')}`,
+  email: `user${String(i + 1).padStart(2, '0')}@example.com`,
+  role: 'USER',
+  addressSido: null,
+  addressGugun: null,
+  birthDate: `199${i % 10}-0${(i % 9) + 1}-${String((i % 28) + 1).padStart(2, '0')}`,
+  withdrawalReason: WITHDRAWAL_REASONS[i % WITHDRAWAL_REASONS.length],
+  withdrawalDetailReason: i % 3 === 0 ? '서비스가 기대에 미치지 못했습니다.' : null,
+  deletedAt: `2026-03-${String(Math.max(1, 30 - i)).padStart(2, '0')}T00:00:00`,
+}))
 
 export function getMockWithdrawals(params: {
   page: number
@@ -61,7 +31,7 @@ export function getMockWithdrawals(params: {
   sort?: SortState
   filters?: FilterState
   search?: string
-}): AdminTableResponse<MockWithdrawal> {
+}): AdminTableResponse<AdminWithdrawal> {
   let filtered = [...withdrawals]
 
   if (params.search) {
@@ -74,7 +44,7 @@ export function getMockWithdrawals(params: {
   if (params.filters) {
     for (const [key, value] of Object.entries(params.filters)) {
       if (value) {
-        filtered = filtered.filter((w) => String(w[key as keyof MockWithdrawal]) === value)
+        filtered = filtered.filter((w) => String(w[key as keyof AdminWithdrawal]) === value)
       }
     }
   }
@@ -82,8 +52,8 @@ export function getMockWithdrawals(params: {
   if (params.sort?.direction) {
     const { key, direction } = params.sort
     filtered.sort((a, b) => {
-      const aVal = String(a[key as keyof MockWithdrawal])
-      const bVal = String(b[key as keyof MockWithdrawal])
+      const aVal = String(a[key as keyof AdminWithdrawal])
+      const bVal = String(b[key as keyof AdminWithdrawal])
       return direction === 'asc' ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal)
     })
   }

--- a/src/features/admin/types/adminApi.ts
+++ b/src/features/admin/types/adminApi.ts
@@ -1,0 +1,102 @@
+/** GET /api/admin/users 응답 아이템 */
+export interface AdminUser {
+  id: number
+  email: string
+  name: string
+  nickname: string
+  birthDate: string | null
+  addressSido: string | null
+  addressGugun: string | null
+  role: 'USER' | 'ADMIN'
+  createdAt: string
+  status: 'ACTIVE' | 'WITHDRAWN'
+}
+
+/** GET /api/admin/withdrawals 응답 아이템 */
+export interface AdminWithdrawal {
+  id: number
+  email: string
+  nickname: string
+  name: string
+  role: string
+  addressSido: string | null
+  addressGugun: string | null
+  birthDate: string | null
+  withdrawalReason: string
+  withdrawalDetailReason: string | null
+  deletedAt: string
+}
+
+/** GET /api/admin/withdrawals/{userId} 상세 응답 */
+export interface AdminWithdrawalDetail extends AdminWithdrawal {
+  createdAt: string
+  profileImageUrl: string | null
+}
+
+/** GET /api/admin/products 응답 아이템 */
+export interface AdminProduct {
+  id: number
+  title: string
+  price: number
+  productType: string
+  category: string
+  productStatus: string
+  tradeStatus: string | null
+  sellerNickname: string
+  createdAt: string
+  updatedAt: string
+}
+
+/** GET /api/admin/reports 응답 아이템 */
+export interface AdminReport {
+  id: number
+  reporterId: number
+  targetType: 'USER' | 'PRODUCT' | 'COMMUNITY_POST'
+  targetId: number
+  reasonCodes: string[]
+  detailReason: string | null
+  imageUrls: string[] | null
+  status: 'PENDING' | 'REVIEWED' | 'REJECTED' | 'ACTION_TAKEN'
+  createdAt: string
+  reviewedAt: string | null
+  rejectedReason: string | null
+}
+
+/** GET /api/admin/statistics/trends 응답 아이템 */
+export interface MemberTrendStat {
+  yearMonth: string
+  signupCount: number
+  withdrawalCount: number
+}
+
+/** GET /api/admin/statistics/withdrawal-reasons 응답 아이템 */
+export interface WithdrawalReasonStat {
+  reason: string
+  count: number
+}
+
+/** GET /api/admin/statistics/summary 응답 */
+export interface DashboardSummary {
+  totalUserCount: number
+  activeUserCount: number
+  withdrawnUserCount: number
+  totalProductCount: number
+  activeProductCount: number
+}
+
+/** 공통 Spring Boot Page 응답 래퍼 */
+export interface ApiResponse<T> {
+  code: string
+  message: string
+  data: T
+}
+
+export interface PageResponse<T> {
+  content: T[]
+  page: number
+  size: number
+  totalElements: number
+  totalPages: number
+  hasNext: boolean
+  hasPrevious?: boolean
+}

--- a/src/lib/api/admin.ts
+++ b/src/lib/api/admin.ts
@@ -3,13 +3,18 @@ import { useUserStore } from '@/store/userStore'
 import type { AdminTableResponse, SortState, FilterState } from '@/features/admin/types/adminTable'
 import type { Product, ProductResponse, ProductDetailItem, ProductDetailItemResponse } from '@/types/product'
 import type { CommunityItem, CommunityResponse, CommunityDetailItem, CommunityDetailItemResponse } from '@/types/community'
-import type { MockUser } from '@/features/admin/mocks/mockUsers'
-import type { MockWithdrawal } from '@/features/admin/mocks/mockWithdrawals'
-import type { MonthlyMemberStat, WithdrawalReasonStat, MonthlyWithdrawalReasonStat } from '@/features/admin/mocks/mockMemberStats'
-import type { MockUserReport } from '@/features/admin/mocks/mockUserReports'
-import type { MockProductSellReport } from '@/features/admin/mocks/mockProductSellReports'
-import type { MockProductRequestReport } from '@/features/admin/mocks/mockProductRequestReports'
-import type { MockCommunityReport } from '@/features/admin/mocks/mockCommunityReports'
+import type {
+  AdminUser,
+  AdminWithdrawal,
+  AdminWithdrawalDetail,
+  AdminProduct,
+  AdminReport,
+  MemberTrendStat,
+  WithdrawalReasonStat,
+  DashboardSummary,
+  ApiResponse,
+  PageResponse,
+} from '@/features/admin/types/adminApi'
 
 interface FetchParams {
   page: number
@@ -19,14 +24,12 @@ interface FetchParams {
   search?: string
 }
 
-/** 로그인 상태이고 실제 API가 존재할 때만 호출, 아니면 목 데이터 사용 */
 function hasAuth(): boolean {
   return !!useUserStore.getState().accessToken
 }
 
 // ========== 응답 변환 ==========
 
-/** Spring Boot Page 응답 → AdminTableResponse 변환 */
 function toAdminTableResponse<T>(
   data: { content: T[]; totalElements: number; page: number; size: number },
   page: number,
@@ -71,13 +74,38 @@ const BOARD_TYPE_KO_TO_EN: Record<string, string> = {
   '정보공유': 'INFO',
 }
 
+const USER_ROLE_KO_TO_EN: Record<string, string> = {
+  '일반회원': 'USER',
+  '관리자': 'ADMIN',
+}
+
+const USER_STATUS_KO_TO_EN: Record<string, string> = {
+  '활성': 'ACTIVE',
+  '탈퇴': 'WITHDRAWN',
+}
+
+const WITHDRAWAL_REASON_KO_TO_EN: Record<string, string> = {
+  '서비스 불만족': 'SERVICE_DISSATISFACTION',
+  '개인정보 우려': 'PRIVACY_CONCERN',
+  '사용 빈도 낮음': 'LOW_USAGE',
+  '경쟁 서비스 이용': 'COMPETITOR',
+  '기타': 'OTHER',
+}
+
+const REPORT_STATUS_KO_TO_EN: Record<string, string> = {
+  '대기중': 'PENDING',
+  '검토완료': 'REVIEWED',
+  '거절': 'REJECTED',
+  '조치완료': 'ACTION_TAKEN',
+}
+
 // ========== 상품 API ==========
 
-export async function fetchAdminProducts(params: FetchParams): Promise<AdminTableResponse<Product>> {
+export async function fetchAdminProducts(params: FetchParams): Promise<AdminTableResponse<AdminProduct>> {
   if (hasAuth()) {
     try {
       const searchParams = new URLSearchParams({
-        page: String(params.page - 1), // Spring은 0-based
+        page: String(params.page - 1),
         size: String(params.pageSize),
       })
 
@@ -87,25 +115,22 @@ export async function fetchAdminProducts(params: FetchParams): Promise<AdminTabl
       if (params.filters?.productType) {
         searchParams.set('productType', PRODUCT_TYPE_KO_TO_EN[params.filters.productType] || params.filters.productType)
       }
-      if (params.filters?.tradeStatus) {
-        // tradeStatus는 검색 API에서 직접 지원하지 않을 수 있음
-      }
       if (params.filters?.category) {
-        searchParams.set('categories', CATEGORY_KO_TO_EN[params.filters.category] || params.filters.category)
-      }
-      if (params.sort?.direction) {
-        searchParams.set('sortBy', params.sort.key)
-        searchParams.set('sortOrder', params.sort.direction === 'asc' ? 'ASC' : 'DESC')
+        searchParams.set('category', CATEGORY_KO_TO_EN[params.filters.category] || params.filters.category)
       }
 
-      const { data } = await api.get<ProductResponse>(`/products/search?${searchParams.toString()}`)
+      const { data } = await api.get<ApiResponse<PageResponse<AdminProduct>>>(`/admin/products?${searchParams.toString()}`)
       return toAdminTableResponse(data.data, params.page, params.pageSize)
     } catch {
-      // API 실패 시 목 데이터 fallback
+      // fallback
     }
   }
   const { getMockProducts } = await import('@/features/admin/mocks/mockProducts')
-  return getMockProducts(params) as unknown as AdminTableResponse<Product>
+  const filters: Record<string, string> = {}
+  if (params.filters?.productType) filters.productType = PRODUCT_TYPE_KO_TO_EN[params.filters.productType] || params.filters.productType
+  if (params.filters?.tradeStatus) filters.tradeStatus = TRADE_STATUS_KO_TO_EN[params.filters.tradeStatus] || params.filters.tradeStatus
+  if (params.filters?.category) filters.category = CATEGORY_KO_TO_EN[params.filters.category] || params.filters.category
+  return getMockProducts({ ...params, filters: Object.keys(filters).length ? filters : undefined }) as unknown as AdminTableResponse<AdminProduct>
 }
 
 export async function fetchAdminProductDetail(id: number): Promise<ProductDetailItem | null> {
@@ -141,11 +166,13 @@ export async function fetchAdminCommunityPosts(params: FetchParams): Promise<Adm
       const { data } = await api.get<CommunityResponse>(`/community/posts?${searchParams.toString()}`)
       return toAdminTableResponse(data.data, params.page, params.pageSize)
     } catch {
-      // API 실패 시 목 데이터 fallback
+      // fallback
     }
   }
   const { getMockCommunityPosts } = await import('@/features/admin/mocks/mockCommunityPosts')
-  return getMockCommunityPosts(params) as unknown as AdminTableResponse<CommunityItem>
+  const communityFilters: Record<string, string> = {}
+  if (params.filters?.boardType) communityFilters.boardType = BOARD_TYPE_KO_TO_EN[params.filters.boardType] || params.filters.boardType
+  return getMockCommunityPosts({ ...params, filters: Object.keys(communityFilters).length ? communityFilters : undefined }) as unknown as AdminTableResponse<CommunityItem>
 }
 
 export async function fetchAdminCommunityDetail(id: number): Promise<CommunityDetailItem | null> {
@@ -157,75 +184,192 @@ export async function fetchAdminCommunityDetail(id: number): Promise<CommunityDe
   }
 }
 
-// ========== 이하 아직 실제 API 없는 도메인 (mock 유지) ==========
+// ========== 회원 관리 API ==========
 
-// 사용자 목록 조회
-export async function fetchAdminUsers(params: FetchParams): Promise<AdminTableResponse<MockUser>> {
+export async function fetchAdminUsers(params: FetchParams): Promise<AdminTableResponse<AdminUser>> {
+  if (hasAuth()) {
+    try {
+      const searchParams = new URLSearchParams({
+        page: String(params.page - 1),
+        size: String(params.pageSize),
+      })
+
+      if (params.search) {
+        searchParams.set('keyword', params.search)
+      }
+      if (params.filters?.status) {
+        searchParams.set('status', USER_STATUS_KO_TO_EN[params.filters.status] || params.filters.status)
+      }
+      if (params.filters?.role) {
+        searchParams.set('role', USER_ROLE_KO_TO_EN[params.filters.role] || params.filters.role)
+      }
+
+      const { data } = await api.get<ApiResponse<PageResponse<AdminUser>>>(`/admin/users?${searchParams.toString()}`)
+      return toAdminTableResponse(data.data, params.page, params.pageSize)
+    } catch {
+      // fallback
+    }
+  }
   const { getMockUsers } = await import('@/features/admin/mocks/mockUsers')
-  return getMockUsers(params)
+  const filters: Record<string, string> = {}
+  if (params.filters?.status) filters.status = USER_STATUS_KO_TO_EN[params.filters.status] || params.filters.status
+  if (params.filters?.role) filters.role = USER_ROLE_KO_TO_EN[params.filters.role] || params.filters.role
+  return getMockUsers({ ...params, filters: Object.keys(filters).length ? filters : undefined }) as unknown as AdminTableResponse<AdminUser>
 }
 
-// 탈퇴 회원 목록 조회
-export async function fetchAdminWithdrawals(params: FetchParams): Promise<AdminTableResponse<MockWithdrawal>> {
+export async function grantAdminRole(userId: number): Promise<void> {
+  await api.patch(`/admin/users/${userId}/role`)
+}
+
+// ========== 탈퇴 회원 API ==========
+
+export async function fetchAdminWithdrawals(params: FetchParams): Promise<AdminTableResponse<AdminWithdrawal>> {
+  if (hasAuth()) {
+    try {
+      const searchParams = new URLSearchParams({
+        page: String(params.page - 1),
+        size: String(params.pageSize),
+      })
+
+      if (params.search) {
+        searchParams.set('keyword', params.search)
+      }
+
+      const { data } = await api.get<ApiResponse<PageResponse<AdminWithdrawal>>>(`/admin/withdrawals?${searchParams.toString()}`)
+      return toAdminTableResponse(data.data, params.page, params.pageSize)
+    } catch {
+      // fallback
+    }
+  }
   const { getMockWithdrawals } = await import('@/features/admin/mocks/mockWithdrawals')
-  return getMockWithdrawals(params)
+  const filters: Record<string, string> = {}
+  if (params.filters?.withdrawalReason) filters.withdrawalReason = WITHDRAWAL_REASON_KO_TO_EN[params.filters.withdrawalReason] || params.filters.withdrawalReason
+  return getMockWithdrawals({ ...params, filters: Object.keys(filters).length ? filters : undefined }) as unknown as AdminTableResponse<AdminWithdrawal>
 }
 
-// 월별 가입/탈퇴 추세 데이터
-export async function fetchMemberStats(): Promise<MonthlyMemberStat[]> {
+export async function fetchAdminWithdrawalDetail(userId: number): Promise<AdminWithdrawalDetail | null> {
+  try {
+    const { data } = await api.get<ApiResponse<AdminWithdrawalDetail>>(`/admin/withdrawals/${userId}`)
+    return data.data
+  } catch {
+    return null
+  }
+}
+
+export async function restoreWithdrawnUser(userId: number): Promise<void> {
+  await api.post(`/admin/withdrawals/${userId}/restore`)
+}
+
+// ========== 신고 관리 API ==========
+
+export async function fetchAdminReports(
+  params: FetchParams,
+  targetType?: 'USER' | 'PRODUCT' | 'COMMUNITY_POST',
+): Promise<AdminTableResponse<AdminReport>> {
+  if (hasAuth()) {
+    try {
+      const searchParams = new URLSearchParams({
+        page: String(params.page - 1),
+        size: String(params.pageSize),
+      })
+
+      if (targetType) {
+        searchParams.set('targetType', targetType)
+      }
+      if (params.filters?.status) {
+        searchParams.set('status', REPORT_STATUS_KO_TO_EN[params.filters.status] || params.filters.status)
+      }
+
+      const { data } = await api.get<ApiResponse<PageResponse<AdminReport> & { total: number }>>(`/admin/reports?${searchParams.toString()}`)
+      return toAdminTableResponse(
+        { ...data.data, totalElements: data.data.totalElements ?? data.data.total },
+        params.page,
+        params.pageSize,
+      )
+    } catch {
+      // fallback
+    }
+  }
+  // Mock fallback: 각 targetType에 맞는 mock import
+  if (targetType === 'USER') {
+    const { getMockUserReports } = await import('@/features/admin/mocks/mockUserReports')
+    return getMockUserReports(params) as unknown as AdminTableResponse<AdminReport>
+  }
+  if (targetType === 'PRODUCT') {
+    const { getMockProductSellReports } = await import('@/features/admin/mocks/mockProductSellReports')
+    return getMockProductSellReports(params) as unknown as AdminTableResponse<AdminReport>
+  }
+  if (targetType === 'COMMUNITY_POST') {
+    const { getMockCommunityReports } = await import('@/features/admin/mocks/mockCommunityReports')
+    return getMockCommunityReports(params) as unknown as AdminTableResponse<AdminReport>
+  }
+  return { data: [], total: 0, page: params.page, pageSize: params.pageSize }
+}
+
+// 개별 신고 탭용 래퍼
+export async function fetchAdminUserReports(params: FetchParams): Promise<AdminTableResponse<AdminReport>> {
+  return fetchAdminReports(params, 'USER')
+}
+
+export async function fetchAdminProductReports(params: FetchParams): Promise<AdminTableResponse<AdminReport>> {
+  return fetchAdminReports(params, 'PRODUCT')
+}
+
+export async function fetchAdminCommunityReports(params: FetchParams): Promise<AdminTableResponse<AdminReport>> {
+  return fetchAdminReports(params, 'COMMUNITY_POST')
+}
+
+export async function reviewReport(
+  reportId: number,
+  body: { status: string; rejectedReason?: string; actionNote?: string },
+): Promise<void> {
+  await api.patch(`/admin/reports/${reportId}/review`, body)
+}
+
+// ========== 통계 API ==========
+
+export async function fetchMemberStats(): Promise<MemberTrendStat[]> {
+  if (hasAuth()) {
+    try {
+      const { data } = await api.get<ApiResponse<MemberTrendStat[]>>('/admin/statistics/trends')
+      return data.data
+    } catch {
+      // fallback
+    }
+  }
   const { mockMemberStats } = await import('@/features/admin/mocks/mockMemberStats')
   return mockMemberStats
 }
 
-// 탈퇴 사유별 통계
 export async function fetchWithdrawalReasons(): Promise<WithdrawalReasonStat[]> {
+  if (hasAuth()) {
+    try {
+      const { data } = await api.get<ApiResponse<WithdrawalReasonStat[]>>('/admin/statistics/withdrawal-reasons')
+      return data.data
+    } catch {
+      // fallback
+    }
+  }
   const { mockWithdrawalReasons } = await import('@/features/admin/mocks/mockMemberStats')
   return mockWithdrawalReasons
 }
 
-// 탈퇴 사유별 월별 추세
-export async function fetchMonthlyWithdrawalReasons(): Promise<MonthlyWithdrawalReasonStat[]> {
-  const { mockMonthlyWithdrawalReasons } = await import('@/features/admin/mocks/mockMemberStats')
-  return mockMonthlyWithdrawalReasons
-}
+// ========== 대시보드 API ==========
 
-// 유저신고 목록 조회
-export async function fetchAdminUserReports(params: FetchParams): Promise<AdminTableResponse<MockUserReport>> {
-  const { getMockUserReports } = await import('@/features/admin/mocks/mockUserReports')
-  return getMockUserReports(params)
-}
-
-// 판매상품 신고 목록 조회
-export async function fetchAdminProductSellReports(params: FetchParams): Promise<AdminTableResponse<MockProductSellReport>> {
-  const { getMockProductSellReports } = await import('@/features/admin/mocks/mockProductSellReports')
-  return getMockProductSellReports(params)
-}
-
-// 판매요청 상품 신고 목록 조회
-export async function fetchAdminProductRequestReports(params: FetchParams): Promise<AdminTableResponse<MockProductRequestReport>> {
-  const { getMockProductRequestReports } = await import('@/features/admin/mocks/mockProductRequestReports')
-  return getMockProductRequestReports(params)
-}
-
-// 커뮤니티 신고 목록 조회
-export async function fetchAdminCommunityReports(params: FetchParams): Promise<AdminTableResponse<MockCommunityReport>> {
-  const { getMockCommunityReports } = await import('@/features/admin/mocks/mockCommunityReports')
-  return getMockCommunityReports(params)
-}
-
-// 대시보드 통계
-export interface DashboardStats {
-  totalProducts: number
-  totalUsers: number
-  totalTransactions: number
-  totalRevenue: number
-}
-
-export async function fetchDashboardStats(): Promise<DashboardStats> {
+export async function fetchDashboardStats(): Promise<DashboardSummary> {
+  if (hasAuth()) {
+    try {
+      const { data } = await api.get<ApiResponse<DashboardSummary>>('/admin/statistics/summary')
+      return data.data
+    } catch {
+      // fallback
+    }
+  }
   return {
-    totalProducts: 50,
-    totalUsers: 30,
-    totalTransactions: 40,
-    totalRevenue: 4_850_000,
+    totalUserCount: 50,
+    activeUserCount: 45,
+    withdrawnUserCount: 5,
+    totalProductCount: 120,
+    activeProductCount: 100,
   }
 }


### PR DESCRIPTION
## 📌 개요

- 어드민 페이지의 나머지 도메인(회원, 탈퇴회원, 신고, 통계, 대시보드)을 실제 백엔드 API와 연동
- 인증 없을 시 mock 데이터 fallback 유지

## 🔧 작업 내용

- [x] `adminApi.ts` 타입 정의 (AdminUser, AdminWithdrawal, AdminProduct, AdminReport, MemberTrendStat, WithdrawalReasonStat, DashboardSummary)
- [x] `admin.ts` API 레이어 전면 리팩토링 (회원/탈퇴/신고/통계/대시보드 실제 API 호출)
- [x] 통합 신고 API 연동 (`GET /admin/reports` + targetType 필터)
- [x] 컴포넌트 16개 Mock 타입 → 실제 API 타입 전환
- [x] 테이블 설정 8개 실제 API 필드명으로 업데이트
- [x] Mock 7개 실제 API 타입과 동일한 필드명으로 리팩토링
- [x] 대시보드 DashboardSummary 타입 적용 (회원수/상품수 기반)
- [x] 회원 통계 차트 MemberTrendStat 타입 적용 (yearMonth/signupCount/withdrawalCount)

## 📎 관련 이슈

Closes #415

## 💬 리뷰어 참고 사항

- 신고 API는 단일 엔드포인트(`/admin/reports`)에 `targetType` 파라미터로 USER/PRODUCT/COMMUNITY_POST를 구분합니다
- 월별 탈퇴사유 추세(`WithdrawalReasonTrendChart`)는 백엔드 API가 없어 mock 유지
- 한글 필터값 → 영문 enum 변환 매핑이 각 도메인별로 적용되어 있습니다