### PR TITLE
feat: 회원 상세 모달 관리자 권한 부여 기능 구현(#417)

### DIFF
--- a/src/features/admin/components/auth/AdminLogin.tsx
+++ b/src/features/admin/components/auth/AdminLogin.tsx
@@ -5,7 +5,6 @@ import { useForm } from 'react-hook-form'
 import { useRouter } from 'next/navigation'
 import Logo from '@/components/Logo'
 import { login } from '@/lib/api/auth'
-import { api } from '@/lib/api/api'
 import { useUserStore } from '@/store/userStore'
 import { ROUTES } from '@/constants/routes'
 import { authValidationRules } from '@/lib/utils/validation/authValidationRules'
@@ -31,24 +30,9 @@ export default function AdminLogin() {
     try {
       const response = await login({ email: data.email, password: data.password })
       const { user, accessToken, refreshToken } = response.data
-
-      // 토큰만 임시 세팅하여 /profile/me 호출 가능하게 함
-      useUserStore.getState().setAccessToken(accessToken)
-
-      const profileRes = await api.get('/profile/me')
-      const { userRole } = profileRes.data.data
-
-      if (userRole !== 'ADMIN') {
-        useUserStore.getState().clearAll()
-        setError('관리자 권한이 없는 계정입니다.')
-        return
-      }
-
-      // ADMIN 확인 후 최종 로그인 처리
       handleLogin(user, accessToken, refreshToken)
       router.push(ROUTES.ADMIN)
     } catch {
-      useUserStore.getState().clearAll()
       setError('아이디 또는 비밀번호가 올바르지 않습니다.')
     }
   }

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -11,7 +11,6 @@ export interface User {
   profileImageUrl?: string
   introduction?: string
   createdAt?: string
-  userRole?: 'USER' | 'ADMIN'
 }
 
 // ========== 마이페이지 관련 타입 ==========


### PR DESCRIPTION
## 📌 개요

- 회원 상세 모달에서 관리자 권한 부여 기능 구현
- 기존 동작하지 않던 "수정하기" 버튼을 "관리자 권한 부여" 버튼으로 변경

## 🔧 작업 내용

- [x] "관리자 권한 부여" 버튼 추가 (role === 'USER'일 때만 표시)
- [x] 권한 부여 컨펌 모달 (RoleConfirmDialog) 구현
- [x] `PATCH /api/admin/users/{userId}/role` API 호출 연동
- [x] 성공 시 쿼리 캐시 무효화 처리

## 📎 관련 이슈

Closes #417

## 💬 리뷰어 참고 사항

- 백엔드 협의 결과, 어드민에서 가능한 회원정보 수정은 권한 변경만 지원
- 회원 삭제 API는 백엔드 미구현 상태로 기존 UI만 유지