### PR TITLE
feat: 어드민 헤더에 드롭다운 로그아웃 버튼 추가(#421)

### DIFF
--- a/src/features/admin/components/layout/AdminHeader.tsx
+++ b/src/features/admin/components/layout/AdminHeader.tsx
@@ -1,18 +1,66 @@
 'use client'
 
+import { useState, useRef, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { LogOut } from 'lucide-react'
 import { useUserStore } from '@/store/userStore'
+import { logout } from '@/lib/api/auth'
+import { ROUTES } from '@/constants/routes'
 
 export default function AdminHeader() {
   const user = useUserStore((s) => s.user)
+  const router = useRouter()
+  const [isOpen, setIsOpen] = useState(false)
+  const dropdownRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setIsOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
+  const handleLogout = async () => {
+    try {
+      await logout()
+    } catch {
+      // 로그아웃 API 실패해도 클라이언트 상태는 클리어
+    } finally {
+      useUserStore.getState().clearAll()
+      router.push(ROUTES.ADMIN_LOGIN)
+    }
+  }
 
   return (
     <header className="flex h-16 items-center justify-between border-b border-gray-200 bg-white px-6">
       <h1 className="text-sm font-medium text-gray-500">관리자 대시보드</h1>
-      <div className="flex items-center gap-3">
-        <span className="text-sm text-gray-600">{user?.nickname ?? '관리자'}</span>
-        <div className="flex h-8 w-8 items-center justify-center rounded-full bg-gray-200 text-xs font-medium text-gray-600">
-          {user?.nickname?.charAt(0) ?? 'A'}
-        </div>
+      <div ref={dropdownRef} className="relative">
+        <button
+          type="button"
+          onClick={() => setIsOpen((prev) => !prev)}
+          className="flex cursor-pointer items-center gap-3 rounded-lg px-2 py-1.5 transition-colors hover:bg-gray-100"
+        >
+          <span className="text-sm text-gray-600">{user?.nickname ?? '관리자'}</span>
+          <div className="flex h-8 w-8 items-center justify-center rounded-full bg-gray-200 text-xs font-medium text-gray-600">
+            {user?.nickname?.charAt(0) ?? 'A'}
+          </div>
+        </button>
+
+        {isOpen && (
+          <div className="absolute right-0 top-full mt-1 w-40 rounded-lg border border-gray-200 bg-white py-1 shadow-lg">
+            <button
+              type="button"
+              onClick={handleLogout}
+              className="flex w-full cursor-pointer items-center gap-2 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
+            >
+              <LogOut size={16} />
+              로그아웃
+            </button>
+          </div>
+        )}
       </div>
     </header>
   )


### PR DESCRIPTION
## 📌 개요

- 어드민 헤더 우측 닉네임+아바타 클릭 시 드롭다운 메뉴로 로그아웃 기능 제공

## 🔧 작업 내용

- [x] 닉네임+아바타 영역을 클릭 가능한 버튼으로 변경
- [x] 드롭다운 메뉴에 로그아웃 버튼 추가
- [x] 바깥 클릭 시 드롭다운 닫힘 처리
- [x] 로그아웃 시 API 호출 → 토큰 클리어 → 어드민 로그인 페이지로 리다이렉트

## 📎 관련 이슈

Closes #421

## 💬 리뷰어 참고 사항

- GitHub 스타일 드롭다운 UX 적용 (헤더 우측 프로필 클릭 → 드롭다운)
- 로그아웃 API 실패 시에도 클라이언트 상태는 반드시 클리어 처리