### PR TITLE
fix: AdminSidebar useEffect 내 setState 호출 에러 수정(#423)

### DIFF
--- a/src/features/admin/components/layout/AdminSidebar.tsx
+++ b/src/features/admin/components/layout/AdminSidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { LayoutDashboard, Package, Users, ChevronDown, ChevronRight, UserX, MessageSquare, Flag, ShieldAlert, AlertTriangle, FileWarning } from 'lucide-react'
 import { cn } from '@/lib/utils/cn'
 import { ROUTES } from '@/constants/routes'
@@ -45,19 +45,25 @@ const NAV_ITEMS: NavItem[] = [
   },
 ]
 
+function getActiveParentLabel(pathname: string): string | null {
+  const activeParent = NAV_ITEMS.find((item) =>
+    item.children?.some((child) => pathname === child.href),
+  )
+  return activeParent?.label ?? null
+}
+
 export default function AdminSidebar() {
   const pathname = usePathname()
-  const [openMenus, setOpenMenus] = useState<Set<string>>(new Set())
+  const [openMenus, setOpenMenus] = useState<Set<string>>(() => {
+    const label = getActiveParentLabel(pathname)
+    return label ? new Set([label]) : new Set()
+  })
 
-  // Auto-expand parent when child route is active
-  useEffect(() => {
-    const activeParent = NAV_ITEMS.find((item) =>
-      item.children?.some((child) => pathname === child.href),
-    )
-    if (activeParent) {
-      setOpenMenus((prev) => new Set(prev).add(activeParent.label))
-    }
-  }, [pathname])
+  // pathname 변경 시 해당 부모 메뉴 자동 열기
+  const activeLabel = getActiveParentLabel(pathname)
+  if (activeLabel && !openMenus.has(activeLabel)) {
+    setOpenMenus((prev) => new Set(prev).add(activeLabel))
+  }
 
   const toggleMenu = (label: string) => {
     setOpenMenus((prev) => {


### PR DESCRIPTION
## 📌 개요

- AdminSidebar에서 `useEffect` 내 동기적 `setState` 호출로 인한 React 경고 수정

## 🔧 작업 내용

- [x] `useEffect` 내 `setState` → 렌더 중 조건부 setState로 변경 (React 권장 패턴)
- [x] `useState` 초기화 함수로 초기 메뉴 상태 설정
- [x] 불필요한 `useEffect` import 제거

## 📎 관련 이슈

Closes #423

## 💬 리뷰어 참고 사항

- React 공식 문서 권장: effect 내 동기적 setState 대신 렌더 중 조건부 setState 사용
- https://react.dev/learn/you-might-not-need-an-effect