### PR TITLE
fix: 어드민 레이아웃 Zustand store rehydrate 누락 수정(#425)

### DIFF
--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -1,10 +1,11 @@
-
 import AdminSidebar from '@/features/admin/components/layout/AdminSidebar'
 import AdminHeader from '@/features/admin/components/layout/AdminHeader'
+import AdminStoreHydration from '@/features/admin/components/layout/AdminStoreHydration'
 
 export default function AdminLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex h-screen overflow-hidden">
+      <AdminStoreHydration />
       <AdminSidebar />
       <div className="flex flex-1 flex-col overflow-hidden">
         <AdminHeader />

--- a/src/features/admin/components/community/CommunityDetailModal.tsx
+++ b/src/features/admin/components/community/CommunityDetailModal.tsx
@@ -28,9 +28,7 @@ function Field({ label, value }: { label: string; value: string }) {
   return (
     <div>
       <p className="mb-1.5 text-sm font-medium text-gray-500">{label}</p>
-      <div className="rounded-lg border border-gray-200 bg-gray-50/50 px-3 py-2.5 text-sm text-gray-900">
-        {value}
-      </div>
+      <div className="rounded-lg border border-gray-200 bg-gray-50/50 px-3 py-2.5 text-sm text-gray-900">{value}</div>
     </div>
   )
 }
@@ -62,7 +60,7 @@ function DeleteConfirmDialog({
   return (
     <dialog
       ref={confirmRef}
-      className="m-auto w-full max-w-fit open:flex flex-col gap-4 rounded-xl bg-white p-6 shadow-2xl backdrop:bg-gray-900/50"
+      className="m-auto w-full max-w-fit flex-col gap-4 rounded-xl bg-white p-6 shadow-2xl backdrop:bg-gray-900/50 open:flex"
       onClick={(e) => {
         if (e.target === confirmRef.current) onCancel()
       }}
@@ -142,7 +140,7 @@ export default function CommunityDetailModal({ isOpen, postId, onClose }: Commun
   return (
     <dialog
       ref={dialogRef}
-      className="m-auto w-full max-w-[900px] open:flex flex-col rounded-xl bg-white p-0 shadow-xl backdrop:bg-gray-900/70"
+      className="m-auto w-full max-w-225 flex-col rounded-xl bg-white p-0 shadow-xl backdrop:bg-gray-900/70 open:flex"
       onClick={(e) => {
         if (e.target === dialogRef.current) dialogRef.current.close()
       }}
@@ -173,17 +171,18 @@ export default function CommunityDetailModal({ isOpen, postId, onClose }: Commun
               {/* Left Column: images + fields */}
               <div className="flex w-1/2 shrink-0 flex-col">
                 {/* Main image */}
-                <div className="mb-2 flex h-[260px] w-full items-center justify-center overflow-hidden rounded-lg border border-gray-200 bg-gray-100">
+                <div className="mb-2 flex h-65 w-full items-center justify-center overflow-hidden rounded-lg border border-gray-200 bg-gray-100">
                   {post.imageUrls?.[0] ? (
                     // eslint-disable-next-line @next/next/no-img-element
-                    <img
-                      src={post.imageUrls[0]}
-                      alt={post.title}
-                      className="h-full w-full object-cover"
-                    />
+                    <img src={post.imageUrls[0]} alt={post.title} className="h-full w-full object-cover" />
                   ) : (
                     <svg className="h-12 w-12 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M2.25 15.75l5.159-5.159a2.25 2.25 0 013.182 0l5.159 5.159m-1.5-1.5l1.409-1.409a2.25 2.25 0 013.182 0l2.909 2.909M3.75 21h16.5A2.25 2.25 0 0022.5 18.75V5.25A2.25 2.25 0 0020.25 3H3.75A2.25 2.25 0 001.5 5.25v13.5A2.25 2.25 0 003.75 21z" />
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={1.5}
+                        d="M2.25 15.75l5.159-5.159a2.25 2.25 0 013.182 0l5.159 5.159m-1.5-1.5l1.409-1.409a2.25 2.25 0 013.182 0l2.909 2.909M3.75 21h16.5A2.25 2.25 0 0022.5 18.75V5.25A2.25 2.25 0 0020.25 3H3.75A2.25 2.25 0 001.5 5.25v13.5A2.25 2.25 0 003.75 21z"
+                      />
                     </svg>
                   )}
                 </div>
@@ -195,18 +194,19 @@ export default function CommunityDetailModal({ isOpen, postId, onClose }: Commun
                     return (
                       <div
                         key={idx}
-                        className="flex h-[60px] w-[60px] items-center justify-center overflow-hidden rounded-md border border-gray-200 bg-gray-50"
+                        className="flex h-15 w-15 items-center justify-center overflow-hidden rounded-md border border-gray-200 bg-gray-50"
                       >
                         {src ? (
                           // eslint-disable-next-line @next/next/no-img-element
-                          <img
-                            src={src}
-                            alt={`서브이미지 ${idx + 1}`}
-                            className="h-full w-full object-cover"
-                          />
+                          <img src={src} alt={`서브이미지 ${idx + 1}`} className="h-full w-full object-cover" />
                         ) : (
                           <svg className="h-5 w-5 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M2.25 15.75l5.159-5.159a2.25 2.25 0 013.182 0l5.159 5.159m-1.5-1.5l1.409-1.409a2.25 2.25 0 013.182 0l2.909 2.909M3.75 21h16.5A2.25 2.25 0 0022.5 18.75V5.25A2.25 2.25 0 0020.25 3H3.75A2.25 2.25 0 001.5 5.25v13.5A2.25 2.25 0 003.75 21z" />
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={1.5}
+                              d="M2.25 15.75l5.159-5.159a2.25 2.25 0 013.182 0l5.159 5.159m-1.5-1.5l1.409-1.409a2.25 2.25 0 013.182 0l2.909 2.909M3.75 21h16.5A2.25 2.25 0 0022.5 18.75V5.25A2.25 2.25 0 0020.25 3H3.75A2.25 2.25 0 001.5 5.25v13.5A2.25 2.25 0 003.75 21z"
+                            />
                           </svg>
                         )}
                       </div>
@@ -233,7 +233,7 @@ export default function CommunityDetailModal({ isOpen, postId, onClose }: Commun
                 {/* 게시글 내용 */}
                 <div className="mb-4">
                   <p className="mb-1.5 text-sm font-medium text-gray-500">게시글 내용</p>
-                  <div className="max-h-[160px] overflow-y-auto whitespace-pre-line rounded-lg border border-gray-200 bg-gray-50/50 px-3 py-2.5 text-sm leading-relaxed text-gray-900">
+                  <div className="max-h-40 overflow-y-auto rounded-lg border border-gray-200 bg-gray-50/50 px-3 py-2.5 text-sm leading-relaxed whitespace-pre-line text-gray-900">
                     {post.content}
                   </div>
                 </div>
@@ -250,14 +250,10 @@ export default function CommunityDetailModal({ isOpen, postId, onClose }: Commun
 
                 {/* 댓글 목록 */}
                 <div className="flex-1">
-                  <p className="mb-1.5 text-sm font-medium text-gray-500">
-                    댓글 목록 ({comments.length})
-                  </p>
-                  <div className="max-h-[240px] overflow-y-auto rounded-lg border border-gray-200">
+                  <p className="mb-1.5 text-sm font-medium text-gray-500">댓글 목록 ({comments.length})</p>
+                  <div className="max-h-60 overflow-y-auto rounded-lg border border-gray-200">
                     {comments.length === 0 ? (
-                      <div className="flex items-center justify-center py-8 text-sm text-gray-400">
-                        댓글이 없습니다.
-                      </div>
+                      <div className="flex items-center justify-center py-8 text-sm text-gray-400">댓글이 없습니다.</div>
                     ) : (
                       <div className="divide-y divide-gray-100">
                         {comments.map((comment) => (
@@ -267,12 +263,8 @@ export default function CommunityDetailModal({ isOpen, postId, onClose }: Commun
                           >
                             <div className="min-w-0 flex-1">
                               <div className="flex items-center gap-2">
-                                <span className="text-sm font-semibold text-gray-900">
-                                  {comment.authorNickname}
-                                </span>
-                                <span className="text-xs text-gray-400">
-                                  {formatDateTime(comment.createdAt)}
-                                </span>
+                                <span className="text-sm font-semibold text-gray-900">{comment.authorNickname}</span>
+                                <span className="text-xs text-gray-400">{formatDateTime(comment.createdAt)}</span>
                               </div>
                               <p className="mt-0.5 text-sm text-gray-700">{comment.content}</p>
                             </div>

--- a/src/features/admin/components/layout/AdminStoreHydration.tsx
+++ b/src/features/admin/components/layout/AdminStoreHydration.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useUserStore } from '@/store/userStore'
+
+export default function AdminStoreHydration() {
+  useEffect(() => {
+    useUserStore.persist.rehydrate()
+  }, [])
+
+  return null
+}

--- a/src/features/admin/components/users/UserDetailModal.tsx
+++ b/src/features/admin/components/users/UserDetailModal.tsx
@@ -35,22 +35,12 @@ function Field({ label, value }: { label: string; value: string }) {
   return (
     <div>
       <p className="mb-1.5 text-sm font-medium text-gray-500">{label}</p>
-      <div className="rounded-lg border border-gray-200 bg-gray-50/50 px-3 py-2.5 text-sm text-gray-900">
-        {value}
-      </div>
+      <div className="rounded-lg border border-gray-200 bg-gray-50/50 px-3 py-2.5 text-sm text-gray-900">{value}</div>
     </div>
   )
 }
 
-function DeleteConfirmDialog({
-  isOpen,
-  onConfirm,
-  onCancel,
-}: {
-  isOpen: boolean
-  onConfirm: () => void
-  onCancel: () => void
-}) {
+function DeleteConfirmDialog({ isOpen, onConfirm, onCancel }: { isOpen: boolean; onConfirm: () => void; onCancel: () => void }) {
   const confirmRef = useRef<HTMLDialogElement>(null)
 
   useEffect(() => {
@@ -65,7 +55,7 @@ function DeleteConfirmDialog({
   return (
     <dialog
       ref={confirmRef}
-      className="m-auto w-full max-w-fit open:flex flex-col gap-4 rounded-xl bg-white p-6 shadow-2xl backdrop:bg-gray-900/50"
+      className="m-auto w-full max-w-fit flex-col gap-4 rounded-xl bg-white p-6 shadow-2xl backdrop:bg-gray-900/50 open:flex"
       onClick={(e) => {
         if (e.target === confirmRef.current) onCancel()
       }}
@@ -125,7 +115,7 @@ function RoleConfirmDialog({
   return (
     <dialog
       ref={confirmRef}
-      className="m-auto w-full max-w-fit open:flex flex-col gap-4 rounded-xl bg-white p-6 shadow-2xl backdrop:bg-gray-900/50"
+      className="m-auto w-full max-w-fit flex-col gap-4 rounded-xl bg-white p-6 shadow-2xl backdrop:bg-gray-900/50 open:flex"
       onClick={(e) => {
         if (e.target === confirmRef.current) onCancel()
       }}
@@ -204,7 +194,7 @@ export default function UserDetailModal({ isOpen, user, onClose }: UserDetailMod
   return (
     <dialog
       ref={dialogRef}
-      className="m-auto w-full max-w-[680px] open:flex flex-col rounded-xl bg-white p-0 shadow-xl backdrop:bg-gray-900/70"
+      className="m-auto w-full max-w-170 flex-col rounded-xl bg-white p-0 shadow-xl backdrop:bg-gray-900/70 open:flex"
       onClick={(e) => {
         if (e.target === dialogRef.current) dialogRef.current.close()
       }}

--- a/src/features/admin/configs/communityTableConfig.ts
+++ b/src/features/admin/configs/communityTableConfig.ts
@@ -14,7 +14,7 @@ export const communityTableConfig: TableConfig<CommunityItem> = {
   searchable: true,
   searchPlaceholder: '제목 검색...',
   columns: [
-    { key: 'id', label: '게시글 ID', type: 'number', sortable: true, width: '90px' },
+    { key: 'id', label: '게시글 ID', type: 'number', sortable: true, width: '110px' },
     {
       key: 'boardType',
       label: '유형',
@@ -33,7 +33,7 @@ export const communityTableConfig: TableConfig<CommunityItem> = {
       label: '댓글',
       type: 'number',
       sortable: true,
-      width: '70px',
+      width: '80px',
     },
     {
       key: 'createdAt',


### PR DESCRIPTION
## 📌 개요

- 어드민 레이아웃에서 Zustand persist store의 `rehydrate()`가 호출되지 않아 `accessToken`이 복원되지 않는 버그 수정
- `(main)` 레이아웃에만 있던 rehydrate 로직을 `(admin)` 레이아웃에도 추가

## 🔧 작업 내용

- [x] `AdminStoreHydration` 클라이언트 컴포넌트 생성 (localStorage → Zustand store 복원)
- [x] 어드민 레이아웃에 `AdminStoreHydration` 추가
- [x] 커뮤니티 테이블 `게시글 ID` 컬럼 width 90px → 110px, `댓글` 컬럼 70px → 80px 조정
- [x] `CommunityDetailModal`, `UserDetailModal` Tailwind arbitrary value → 유틸리티 클래스 변환 및 코드 포매팅

## 📎 관련 이슈

Closes #425

## 💬 리뷰어 참고 사항

- 원인: `hasAuth()`가 `false`를 반환하여 실제 API 호출 없이 mock 데이터로 폴백 → `undefined` 표시
- `AdminStoreHydration`은 `(main)` 레이아웃의 `ClientComponents`와 동일한 역할 (useEffect에서 rehydrate 호출)