### PR TITLE
fix: 어드민 커뮤니티 상세 모달 대댓글 미표시 수정(#427)

### DIFF
--- a/src/features/admin/components/community/CommunityDetailModal.tsx
+++ b/src/features/admin/components/community/CommunityDetailModal.tsx
@@ -96,10 +96,40 @@ const BOARD_TYPE_COLORS: Record<string, string> = {
   INFO: 'bg-green-100 text-green-800',
 }
 
-async function fetchComments(postId: number): Promise<Comment[]> {
+async function fetchReplies(commentId: number): Promise<Comment[]> {
+  try {
+    const { data } = await api.get<CommentResponse>(`/community/comments/${commentId}/replies`)
+    return data.data.comments
+  } catch {
+    return []
+  }
+}
+
+async function fetchCommentsWithReplies(postId: number): Promise<Comment[]> {
   try {
     const { data } = await api.get<CommentResponse>(`/community/posts/${postId}/comments`)
-    return data.data.comments
+    const parentComments = data.data.comments
+
+    // hasChildren인 댓글의 대댓글을 병렬로 가져옴
+    const withChildren = parentComments.filter((c) => c.hasChildren)
+    const repliesMap = new Map<number, Comment[]>()
+
+    if (withChildren.length > 0) {
+      const repliesResults = await Promise.all(withChildren.map((c) => fetchReplies(c.id)))
+      withChildren.forEach((c, i) => repliesMap.set(c.id, repliesResults[i]))
+    }
+
+    // 부모 댓글 뒤에 대댓글을 삽입하여 평탄화
+    const result: Comment[] = []
+    for (const comment of parentComments) {
+      result.push(comment)
+      const replies = repliesMap.get(comment.id)
+      if (replies) {
+        result.push(...replies)
+      }
+    }
+
+    return result
   } catch {
     return []
   }
@@ -118,7 +148,7 @@ export default function CommunityDetailModal({ isOpen, postId, onClose }: Commun
 
   const { data: comments = [] } = useQuery({
     queryKey: ['admin-community-comments', postId],
-    queryFn: () => fetchComments(postId!),
+    queryFn: () => fetchCommentsWithReplies(postId!),
     enabled: isOpen && postId !== null,
   })
 
@@ -259,7 +289,7 @@ export default function CommunityDetailModal({ isOpen, postId, onClose }: Commun
                         {comments.map((comment) => (
                           <div
                             key={comment.id}
-                            className={`flex items-start justify-between gap-2 py-2.5 pr-3 ${comment.depth === 1 ? 'pl-7' : 'pl-3'}`}
+                            className={`flex items-start justify-between gap-2 py-2.5 pr-3 ${comment.depth >= 2 ? 'pl-7' : 'pl-3'}`}
                           >
                             <div className="min-w-0 flex-1">
                               <div className="flex items-center gap-2">


### PR DESCRIPTION
## 📌 개요

- 어드민 커뮤니티 상세 모달에서 대댓글이 표시되지 않는 버그 수정
- 실제 API는 부모 댓글만 반환하므로, `hasChildren: true`인 댓글의 대댓글을 별도 API로 조회하여 병합

## 🔧 작업 내용

- [x] `fetchCommentsWithReplies` 함수 추가 — 부모 댓글 조회 후 대댓글 병렬 조회 및 평탄화
- [x] 들여쓰기 조건 수정 (`depth === 1` → `depth >= 2`)

## 📎 관련 이슈

Closes #427

## 💬 리뷰어 참고 사항

- 기존 mock 데이터에서는 대댓글이 같은 배열에 포함되어 있어 동작했으나, 실제 API는 부모 댓글만 반환
- 대댓글 REST API: `GET /community/comments/{commentId}/replies`
- `hasChildren: true`인 댓글에 대해 `Promise.all`로 병렬 조회