### PR TITLE
fix: 어드민 페이지 토큰 만료 시 어드민 로그인 페이지로 리다이렉트 처리(#429)

### DIFF
--- a/src/lib/api/api.ts
+++ b/src/lib/api/api.ts
@@ -39,7 +39,7 @@ async function fetchNewAccessToken(): Promise<string | null> {
     useUserStore.getState().clearAll()
 
     if (typeof window !== 'undefined') {
-      window.location.href = '/auth/login'
+      window.location.href = window.location.pathname.startsWith('/admin') ? '/admin/login' : '/auth/login'
     }
 
     return null


### PR DESCRIPTION
## 📌 개요

- 어드민 페이지에서 토큰 만료 시 일반 사용자 로그인(`/auth/login`)으로 리다이렉트되던 버그 수정

## 🔧 작업 내용

- [x] `fetchNewAccessToken()` 실패 시 현재 경로 기반 리다이렉트 분기 처리
  - `/admin/*` 경로 → `/admin/login`
  - 그 외 경로 → `/auth/login` (기존 동작 유지)

## 📎 관련 이슈

Closes #429

## 💬 리뷰어 참고 사항

- `src/lib/api/api.ts` 1줄 수정으로, `window.location.pathname`이 `/admin`으로 시작하는지 확인하여 분기합니다