### PR TITLE
fix: admin 상품 테이블 tradeStatus null 거래 상태 기본값 설정(#433)

### DIFF
--- a/src/lib/api/admin.ts
+++ b/src/lib/api/admin.ts
@@ -113,7 +113,14 @@ export async function fetchAdminProducts(params: FetchParams): Promise<AdminTabl
   }
 
   const { data } = await api.get<ApiResponse<PageResponse<AdminProduct>>>(`/admin/products?${searchParams.toString()}`)
-  return toAdminTableResponse(data.data, params.page, params.pageSize)
+
+  // tradeStatus가 null인 경우 productType에 따라 기본값 설정
+  const normalized = data.data.content.map((item) => ({
+    ...item,
+    tradeStatus: item.tradeStatus ?? (item.productType === 'REQUEST' ? 'BUYING' : 'SELLING'),
+  }))
+
+  return toAdminTableResponse({ ...data.data, content: normalized }, params.page, params.pageSize)
 }
 
 export async function fetchAdminProductDetail(id: number): Promise<ProductDetailItem | null> {


### PR DESCRIPTION
## 📌 개요

- admin 상품 관리 테이블에서 `tradeStatus: null`인 상품의 거래 상태 badge가 빈 값으로 표시되는 버그 수정

## 🔧 작업 내용

- [x] `fetchAdminProducts`에서 `tradeStatus: null` 데이터 정규화
  - `productType: "REQUEST"` → `"BUYING"` (요청중)
  - `productType: "SELL"` → `"SELLING"` (판매중)

## 📎 관련 이슈

Closes #433

## 💬 리뷰어 참고 사항

- 백엔드에서 `productType: "REQUEST"`인 상품 중 매칭되지 않은 항목은 `tradeStatus: null`로 응답
- 메인 사이트에서는 이미 "요청중" badge로 처리 중이며, admin 테이블도 동일하게 처리