### PR TITLE
fix: 어드민 차트 select 요소 id/name 속성 누락 수정(#437)

### DIFF
--- a/src/features/admin/components/members/SignupTrendChart.tsx
+++ b/src/features/admin/components/members/SignupTrendChart.tsx
@@ -42,6 +42,8 @@ export default function SignupTrendChart({ data }: SignupTrendChartProps) {
           {period === 'monthly' ? '월별' : '연별'} 회원 가입 추세
         </h3>
         <select
+          id="signup-trend-period"
+          name="signup-trend-period"
           value={period}
           onChange={(e) => setPeriod(e.target.value as Period)}
           className="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"

--- a/src/features/admin/components/members/WithdrawalReasonTrendChart.tsx
+++ b/src/features/admin/components/members/WithdrawalReasonTrendChart.tsx
@@ -47,6 +47,8 @@ export default function WithdrawalReasonTrendChart({ data }: WithdrawalReasonTre
           탈퇴 사유별 월별 추세
         </h3>
         <select
+          id="withdrawal-reason-filter"
+          name="withdrawal-reason-filter"
           value={selectedReason}
           onChange={(e) => setSelectedReason(e.target.value)}
           className="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"

--- a/src/features/admin/components/members/WithdrawalTrendChart.tsx
+++ b/src/features/admin/components/members/WithdrawalTrendChart.tsx
@@ -42,6 +42,8 @@ export default function WithdrawalTrendChart({ data }: WithdrawalTrendChartProps
           {period === 'monthly' ? '월별' : '연별'} 회원 탈퇴 추세
         </h3>
         <select
+          id="withdrawal-trend-period"
+          name="withdrawal-trend-period"
           value={period}
           onChange={(e) => setPeriod(e.target.value as Period)}
           className="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"


### PR DESCRIPTION
## 📌 개요

- 어드민 회원 관리 페이지 차트 컴포넌트의 `<select>` 요소에 `id`/`name` 속성이 누락되어 콘솔 경고 발생하는 문제 수정

## 🔧 작업 내용

- [x] `SignupTrendChart.tsx` — select에 id/name 추가
- [x] `WithdrawalTrendChart.tsx` — select에 id/name 추가
- [x] `WithdrawalReasonTrendChart.tsx` — select에 id/name 추가

## 📎 관련 이슈

Closes #437

## 💬 리뷰어 참고 사항

- 3개 파일 모두 동일한 패턴의 수정입니다 (`id`, `name` 속성 추가)