### PR TITLE
refactor: 어드민 네이티브 select를 SelectDropdown 컴포넌트로 통일(#439)

### DIFF
--- a/src/features/admin/components/members/SignupTrendChart.tsx
+++ b/src/features/admin/components/members/SignupTrendChart.tsx
@@ -10,6 +10,7 @@ import {
   Tooltip,
   ResponsiveContainer,
 } from 'recharts'
+import SelectDropdown from '@/components/commons/select/SelectDropdown'
 import type { MemberTrendStat } from '@/features/admin/types/adminApi'
 
 type Period = 'monthly' | 'yearly'
@@ -41,16 +42,18 @@ export default function SignupTrendChart({ data }: SignupTrendChartProps) {
         <h3 className="text-base font-semibold text-gray-800">
           {period === 'monthly' ? '월별' : '연별'} 회원 가입 추세
         </h3>
-        <select
-          id="signup-trend-period"
-          name="signup-trend-period"
-          value={period}
-          onChange={(e) => setPeriod(e.target.value as Period)}
-          className="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-        >
-          <option value="monthly">월별</option>
-          <option value="yearly">연별</option>
-        </select>
+        <div className="w-[100px]">
+          <SelectDropdown
+            id="signup-trend-period"
+            value={period}
+            onChange={(value) => setPeriod(value as Period)}
+            options={[
+              { value: 'monthly', label: '월별' },
+              { value: 'yearly', label: '연별' },
+            ]}
+            buttonClassName="py-1.5"
+          />
+        </div>
       </div>
       <ResponsiveContainer width="100%" height={360}>
         <BarChart data={chartData}>

--- a/src/features/admin/components/members/WithdrawalReasonTrendChart.tsx
+++ b/src/features/admin/components/members/WithdrawalReasonTrendChart.tsx
@@ -11,6 +11,7 @@ import {
   Legend,
   ResponsiveContainer,
 } from 'recharts'
+import SelectDropdown from '@/components/commons/select/SelectDropdown'
 import { WITHDRAW_REASON } from '@/constants/constants'
 import type { MonthlyWithdrawalReasonStat } from '@/features/admin/mocks/mockMemberStats'
 
@@ -46,20 +47,18 @@ export default function WithdrawalReasonTrendChart({ data }: WithdrawalReasonTre
         <h3 className="text-base font-semibold text-gray-800">
           탈퇴 사유별 월별 추세
         </h3>
-        <select
-          id="withdrawal-reason-filter"
-          name="withdrawal-reason-filter"
-          value={selectedReason}
-          onChange={(e) => setSelectedReason(e.target.value)}
-          className="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-        >
-          <option value="all">전체 사유</option>
-          {REASON_BARS.map((bar) => (
-            <option key={bar.dataKey} value={bar.dataKey}>
-              {bar.name}
-            </option>
-          ))}
-        </select>
+        <div className="w-[140px]">
+          <SelectDropdown
+            id="withdrawal-reason-filter"
+            value={selectedReason}
+            onChange={setSelectedReason}
+            options={[
+              { value: 'all', label: '전체 사유' },
+              ...REASON_BARS.map((bar) => ({ value: bar.dataKey, label: bar.name })),
+            ]}
+            buttonClassName="py-1.5"
+          />
+        </div>
       </div>
       <ResponsiveContainer width="100%" height={360}>
         <BarChart data={data}>

--- a/src/features/admin/components/members/WithdrawalTrendChart.tsx
+++ b/src/features/admin/components/members/WithdrawalTrendChart.tsx
@@ -10,6 +10,7 @@ import {
   Tooltip,
   ResponsiveContainer,
 } from 'recharts'
+import SelectDropdown from '@/components/commons/select/SelectDropdown'
 import type { MemberTrendStat } from '@/features/admin/types/adminApi'
 
 type Period = 'monthly' | 'yearly'
@@ -41,16 +42,18 @@ export default function WithdrawalTrendChart({ data }: WithdrawalTrendChartProps
         <h3 className="text-base font-semibold text-gray-800">
           {period === 'monthly' ? '월별' : '연별'} 회원 탈퇴 추세
         </h3>
-        <select
-          id="withdrawal-trend-period"
-          name="withdrawal-trend-period"
-          value={period}
-          onChange={(e) => setPeriod(e.target.value as Period)}
-          className="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-        >
-          <option value="monthly">월별</option>
-          <option value="yearly">연별</option>
-        </select>
+        <div className="w-[100px]">
+          <SelectDropdown
+            id="withdrawal-trend-period"
+            value={period}
+            onChange={(value) => setPeriod(value as Period)}
+            options={[
+              { value: 'monthly', label: '월별' },
+              { value: 'yearly', label: '연별' },
+            ]}
+            buttonClassName="py-1.5"
+          />
+        </div>
       </div>
       <ResponsiveContainer width="100%" height={360}>
         <BarChart data={chartData}>

--- a/src/features/admin/components/table/AdminTablePagination.tsx
+++ b/src/features/admin/components/table/AdminTablePagination.tsx
@@ -2,6 +2,7 @@
 
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { cn } from '@/lib/utils/cn'
+import SelectDropdown from '@/components/commons/select/SelectDropdown'
 import type { PaginationConfig, PaginationState } from '../../types/adminTable'
 
 interface AdminTablePaginationProps {
@@ -47,17 +48,18 @@ export default function AdminTablePagination({
         <span>
           {total > 0 ? `${start}-${end} / 총 ${total}건` : '데이터 없음'}
         </span>
-        <select
-          value={pageSize}
-          onChange={(e) => onPageSizeChange(Number(e.target.value))}
-          className="cursor-pointer rounded border border-gray-300 px-2 py-1 text-sm outline-none"
-        >
-          {paginationConfig.pageSizeOptions.map((size) => (
-            <option key={size} value={size}>
-              {size}개씩
-            </option>
-          ))}
-        </select>
+        <div className="w-[100px]">
+          <SelectDropdown
+            id="page-size"
+            value={String(pageSize)}
+            onChange={(value) => onPageSizeChange(Number(value))}
+            options={paginationConfig.pageSizeOptions.map((size) => ({
+              value: String(size),
+              label: `${size}개씩`,
+            }))}
+            buttonClassName="py-1"
+          />
+        </div>
       </div>
 
       <div className="flex items-center gap-1">


### PR DESCRIPTION
## 📌 개요

- 어드민 페이지의 네이티브 `<select>` 요소를 커스텀 `SelectDropdown` 컴포넌트로 교체하여 드롭다운 디자인 통일

## 🔧 작업 내용

- [x] `SignupTrendChart.tsx` — 월별/연별 드롭다운 SelectDropdown으로 교체
- [x] `WithdrawalTrendChart.tsx` — 월별/연별 드롭다운 SelectDropdown으로 교체
- [x] `WithdrawalReasonTrendChart.tsx` — 탈퇴 사유 드롭다운 SelectDropdown으로 교체
- [x] `AdminTablePagination.tsx` — 페이지 사이즈 드롭다운 SelectDropdown으로 교체

## 📎 관련 이슈

Closes #439

## 💬 리뷰어 참고 사항

- 네이티브 `<select>`의 화살표가 border에 붙는 문제를 해결하기 위해 기존 `SelectDropdown` 컴포넌트로 통일했습니다
- 테이블 필터 드롭다운과 동일한 디자인이 적용됩니다