### PR TITLE
fix: 어드민 신고 모달 img eslint-disable 누락 수정(#444)

### DIFF
--- a/src/features/admin/components/reports/CommunityReportDetailModal.tsx
+++ b/src/features/admin/components/reports/CommunityReportDetailModal.tsx
@@ -84,6 +84,7 @@ export default function CommunityReportDetailModal({
                 <p className="mb-1.5 text-sm font-medium text-gray-500">첨부 이미지</p>
                 <div className="grid grid-cols-3 gap-3">
                   {report.imageUrls.map((src, idx) => (
+                    /* eslint-disable-next-line @next/next/no-img-element */
                     <img
                       key={idx}
                       src={src}

--- a/src/features/admin/components/reports/ProductRequestReportDetailModal.tsx
+++ b/src/features/admin/components/reports/ProductRequestReportDetailModal.tsx
@@ -84,6 +84,7 @@ export default function ProductRequestReportDetailModal({
                 <p className="mb-1.5 text-sm font-medium text-gray-500">첨부 이미지</p>
                 <div className="grid grid-cols-3 gap-3">
                   {report.imageUrls.map((src, idx) => (
+                    /* eslint-disable-next-line @next/next/no-img-element */
                     <img
                       key={idx}
                       src={src}

--- a/src/features/admin/components/reports/ProductSellReportDetailModal.tsx
+++ b/src/features/admin/components/reports/ProductSellReportDetailModal.tsx
@@ -80,6 +80,7 @@ export default function ProductSellReportDetailModal({ isOpen, report, onClose }
                 <p className="mb-1.5 text-sm font-medium text-gray-500">첨부 이미지</p>
                 <div className="grid grid-cols-3 gap-3">
                   {report.imageUrls.map((src, idx) => (
+                    /* eslint-disable-next-line @next/next/no-img-element */
                     <img
                       key={idx}
                       src={src}

--- a/src/features/admin/components/reports/UserReportDetailModal.tsx
+++ b/src/features/admin/components/reports/UserReportDetailModal.tsx
@@ -88,6 +88,7 @@ export default function UserReportDetailModal({ isOpen, report, onClose }: UserR
                 <p className="mb-1.5 text-sm font-medium text-gray-500">첨부 이미지</p>
                 <div className="grid grid-cols-3 gap-3">
                   {report.imageUrls.map((src, idx) => (
+                    /* eslint-disable-next-line @next/next/no-img-element */
                     <img
                       key={idx}
                       src={src}


### PR DESCRIPTION
## 📌 개요

- 어드민 신고 상세 모달 4개 파일에서 CDN 이미지 `<img>` 태그에 eslint-disable 주석 추가

## 🔧 작업 내용

- [ ] CommunityReportDetailModal.tsx에 eslint-disable 추가
- [ ] ProductRequestReportDetailModal.tsx에 eslint-disable 추가
- [ ] ProductSellReportDetailModal.tsx에 eslint-disable 추가
- [ ] UserReportDetailModal.tsx에 eslint-disable 추가

## 📎 관련 이슈

Closes #444

## 📋 QA 티켓

https://www.notion.so/31ff2b307961817e9f51c150937fec0a

## 💬 리뷰어 참고 사항

- 프로젝트 컨벤션상 CDN 이미지는 next/image 대신 <img> + eslint-disable을 사용