### PR TITLE
fix: 어드민 탈퇴 사유별 분포 도넛 차트 미표시 수정(#451)

### DIFF
--- a/src/features/admin/components/members/MembersDashboard.tsx
+++ b/src/features/admin/components/members/MembersDashboard.tsx
@@ -23,10 +23,13 @@ export default function MembersDashboard() {
   const [monthlyReasons, setMonthlyReasons] = useState<MonthlyWithdrawalReasonStat[]>([])
 
   useEffect(() => {
-    Promise.all([fetchMemberStats(), fetchWithdrawalReasons()]).then(([statsData, reasonsData]) => {
-      setStats(statsData)
-      setReasons(reasonsData)
-    })
+    fetchMemberStats()
+      .then((statsData) => setStats(statsData))
+      .catch((error) => console.error('회원 통계 조회 실패:', error))
+
+    fetchWithdrawalReasons()
+      .then((reasonsData) => setReasons(reasonsData))
+      .catch((error) => console.error('탈퇴 사유 조회 실패:', error))
     // Monthly withdrawal reasons - still mock only (no API endpoint)
     import('@/features/admin/mocks/mockMemberStats').then(({ mockMonthlyWithdrawalReasons }) => {
       setMonthlyReasons(mockMonthlyWithdrawalReasons)

--- a/src/features/admin/components/members/WithdrawalReasonChart.tsx
+++ b/src/features/admin/components/members/WithdrawalReasonChart.tsx
@@ -19,6 +19,15 @@ interface WithdrawalReasonChartProps {
 }
 
 export default function WithdrawalReasonChart({ data }: WithdrawalReasonChartProps) {
+  if (!data || data.length === 0) {
+    return (
+      <div className="rounded-lg border border-gray-200 bg-white p-6">
+        <h3 className="mb-4 text-base font-semibold text-gray-800">탈퇴 사유별 분포</h3>
+        <p className="py-12 text-center text-sm text-gray-500">데이터가 없습니다</p>
+      </div>
+    )
+  }
+
   const displayData = data.map((d) => ({
     ...d,
     label: reasonLabelMap[d.reason] ?? d.reason,


### PR DESCRIPTION
## 📌 개요

- /admin/members 페이지에서 '탈퇴 사유 분석' 탭의 도넛 차트가 표시되지 않는 버그 수정

## 🔧 작업 내용

- [ ] MembersDashboard에서 API 호출 에러 처리 개선 (Promise.all → 개별 처리)
- [ ] WithdrawalReasonChart에 빈 데이터 상태 처리 추가

## 📎 관련 이슈

Closes #451

## 📋 QA 티켓

https://www.notion.so/31ff2b307961818a89eccbd9e0cec19a

## 💬 리뷰어 참고 사항

- Promise.all 사용 시 하나의 API가 실패하면 전체가 실패하는 문제를 개별 try-catch로 분리
- 빈 데이터 시 사용자에게 안내 메시지 표시