### PR TITLE
refactor: Vercel React Best Practice 규칙 기반 메인 그룹 코드 리팩토링(#456)

### DIFF
--- a/src/app/(main)/community/[id]/[name]/opengraph-image.tsx
+++ b/src/app/(main)/community/[id]/[name]/opengraph-image.tsx
@@ -44,11 +44,11 @@ export default async function OGImage({ params }: { params: Promise<{ id: string
         <p style={{ fontSize: 40, fontWeight: 700, color: OG_COLORS.textPrimary, overflow: 'hidden' }}>
           {post.title.slice(0, 50)}
         </p>
-        {preview && (
+        {preview ? (
           <p style={{ fontSize: 24, color: OG_COLORS.textSecondary, overflow: 'hidden' }}>
             {preview}
           </p>
-        )}
+        ) : null}
         <div style={{ display: 'flex', gap: '8px', fontSize: 20, color: OG_COLORS.textSecondary, marginTop: '8px' }}>
           <span>{post.authorNickname}</span>
           <span style={{ color: 'rgba(0,0,0,0.2)' }}>·</span>

--- a/src/app/(main)/graphql-demo/page.tsx
+++ b/src/app/(main)/graphql-demo/page.tsx
@@ -139,39 +139,39 @@ export default function GraphQLDemoPage() {
       {/* Profile Section */}
       <section className="bg-white rounded-lg border border-gray-200 p-6">
         <h2 className="text-lg font-semibold text-gray-800 mb-4">User Profile</h2>
-        {profileLoading && (
+        {profileLoading ? (
           <p className="text-gray-500 text-sm">Loading profile...</p>
-        )}
-        {profileError && (
+        ) : null}
+        {profileError ? (
           <p className="text-red-500 text-sm">
             Error loading profile: {profileError.message}
           </p>
-        )}
-        {profileData?.userProfile && (
+        ) : null}
+        {profileData?.userProfile ? (
           <div className="flex items-start gap-4">
-            {profileData.userProfile.profileImageUrl && (
+            {profileData.userProfile.profileImageUrl ? (
               /* eslint-disable-next-line @next/next/no-img-element */
               <img
                 src={profileData.userProfile.profileImageUrl}
                 alt={profileData.userProfile.nickname}
                 className="w-16 h-16 rounded-full object-cover"
               />
-            )}
+            ) : null}
             <div className="space-y-1">
               <p className="font-semibold text-gray-900">
                 {profileData.userProfile.nickname}
               </p>
-              {profileData.userProfile.introduction && (
+              {profileData.userProfile.introduction ? (
                 <p className="text-gray-600 text-sm">
                   {profileData.userProfile.introduction}
                 </p>
-              )}
+              ) : null}
               <p className="text-yellow-500 text-sm font-medium">
                 Rating: {profileData.userProfile.rating}
               </p>
             </div>
           </div>
-        )}
+        ) : null}
       </section>
 
       {/* Community Posts Section */}
@@ -190,15 +190,15 @@ export default function GraphQLDemoPage() {
           />
         </div>
 
-        {postsLoading && (
+        {postsLoading ? (
           <p className="text-gray-500 text-sm">Loading posts...</p>
-        )}
-        {postsError && (
+        ) : null}
+        {postsError ? (
           <p className="text-red-500 text-sm">
             Error loading posts: {postsError.message}
           </p>
-        )}
-        {postsData?.communityPosts && (
+        ) : null}
+        {postsData?.communityPosts ? (
           <>
             <p className="text-gray-500 text-xs mb-3">
               Total: {postsData.communityPosts.total} posts
@@ -227,21 +227,21 @@ export default function GraphQLDemoPage() {
               ))}
             </ul>
           </>
-        )}
+        ) : null}
       </section>
 
       {/* Products Section */}
       <section className="bg-white rounded-lg border border-gray-200 p-6">
         <h2 className="text-lg font-semibold text-gray-800 mb-4">Products</h2>
-        {productsLoading && (
+        {productsLoading ? (
           <p className="text-gray-500 text-sm">Loading products...</p>
-        )}
-        {productsError && (
+        ) : null}
+        {productsError ? (
           <p className="text-red-500 text-sm">
             Error loading products: {productsError.message}
           </p>
-        )}
-        {productsData?.products && (
+        ) : null}
+        {productsData?.products ? (
           <>
             <p className="text-gray-500 text-xs mb-3">
               Total: {productsData.products.totalElements} products
@@ -275,7 +275,7 @@ export default function GraphQLDemoPage() {
               ))}
             </ul>
           </>
-        )}
+        ) : null}
       </section>
     </div>
   );

--- a/src/app/(main)/html-sitemap/page.tsx
+++ b/src/app/(main)/html-sitemap/page.tsx
@@ -231,7 +231,7 @@ export default async function HtmlSitemapPage() {
         </ul>
       </section>
 
-      {products.length > 0 && (
+      {products.length > 0 ? (
         <section className="mb-8">
           <h2 className="mb-3 text-lg font-semibold">중고거래 상품 ({products.length})</h2>
           <ul className="space-y-1 pl-4">
@@ -244,9 +244,9 @@ export default async function HtmlSitemapPage() {
             ))}
           </ul>
         </section>
-      )}
+      ) : null}
 
-      {questionPosts.length > 0 && (
+      {questionPosts.length > 0 ? (
         <section className="mb-8">
           <h2 className="mb-3 text-lg font-semibold">질문 게시글 ({questionPosts.length})</h2>
           <ul className="space-y-1 pl-4">
@@ -259,9 +259,9 @@ export default async function HtmlSitemapPage() {
             ))}
           </ul>
         </section>
-      )}
+      ) : null}
 
-      {infoPosts.length > 0 && (
+      {infoPosts.length > 0 ? (
         <section className="mb-8">
           <h2 className="mb-3 text-lg font-semibold">정보 게시글 ({infoPosts.length})</h2>
           <ul className="space-y-1 pl-4">
@@ -274,7 +274,7 @@ export default async function HtmlSitemapPage() {
             ))}
           </ul>
         </section>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -83,7 +83,7 @@ export default async function HomePage({ searchParams }: HomePageProps) {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
-      {firstImageUrl && (
+      {firstImageUrl ? (
         <link
           rel="preload"
           as="image"
@@ -91,7 +91,7 @@ export default async function HomePage({ searchParams }: HomePageProps) {
           imageSizes={IMAGE_SIZES.productThumbnail}
           fetchPriority="high"
         />
-      )}
+      ) : null}
       <HydrationBoundary state={dehydrate(queryClient)}>
         <Suspense fallback={<StaticHomeFallback products={products} totalElements={totalElements} />}>
           <FilterNavigationProvider>

--- a/src/components/ClientComponents.tsx
+++ b/src/components/ClientComponents.tsx
@@ -29,8 +29,8 @@ export default function ClientComponents() {
   return (
     <>
       <AuthValidator />
-      {isLoginModalOpen && <LoginModal />}
-      {hasToasts && <ToastContainer />}
+      {isLoginModalOpen ? <LoginModal /> : null}
+      {hasToasts ? <ToastContainer /> : null}
     </>
   )
 }

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -17,7 +17,7 @@ export default function EmptyState({ icon: Icon, title, description, className =
       </div>
       <div className="flex flex-col items-center gap-2">
         <p className="heading-h4">{title}</p>
-        {description && <p className="text-gray-500">{description}</p>}
+        {description ? <p className="text-gray-500">{description}</p> : null}
       </div>
     </div>
   )

--- a/src/components/commons/Input.tsx
+++ b/src/components/commons/Input.tsx
@@ -40,11 +40,11 @@ export default function Input({
         Icon && 'pl-9',
       )}
     >
-      {Icon && (
+      {Icon ? (
         <div className="absolute left-0 flex h-full w-9 items-center justify-center">
           <Icon className="h-4 w-4 text-gray-400" strokeWidth={2} />
         </div>
-      )}
+      ) : null}
       <input
         id={id}
         type={type}
@@ -61,12 +61,12 @@ export default function Input({
         )}
         {...rest}
       />
-      {suffix && <span className="absolute top-1/2 right-3 -translate-y-1/2 text-sm text-gray-500">{suffix}</span>}
-      {value && onClear && (
+      {suffix ? <span className="absolute top-1/2 right-3 -translate-y-1/2 text-sm text-gray-500">{suffix}</span> : null}
+      {value && onClear ? (
         <button onClick={onClear} type="button" aria-label="입력 내용 지우기" className="mr-2 cursor-pointer rounded-full bg-gray-300 p-0.5">
           <X size={14} />
         </button>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/src/components/commons/InputField.tsx
+++ b/src/components/commons/InputField.tsx
@@ -28,12 +28,12 @@ export default function InputField({ error, checkResult, registration, className
   return (
     <div className={cn('flex flex-col gap-1', className)}>
       <Input {...inputProps} {...registration} inputClass={inputClass} id={id} suffix={suffix} />
-      {error && <p className="text-danger-500 text-xs font-semibold">{error.message}</p>}
-      {checkResult?.message && (
+      {error ? <p className="text-danger-500 text-xs font-semibold">{error.message}</p> : null}
+      {checkResult?.message ? (
         <p className={cn('text-xs font-semibold', checkResult.status === 'error' ? 'text-danger-500' : 'text-success-500')}>
           {checkResult.message}
         </p>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/src/components/commons/RequiredLabel.tsx
+++ b/src/components/commons/RequiredLabel.tsx
@@ -11,7 +11,7 @@ export default function RequiredLabel({ htmlFor, children, labelClass, required 
   return (
     <label htmlFor={htmlFor} className={cn('text-gray-900', labelClass)}>
       <span>{children}</span>
-      {required && <span className="text-danger-500">*</span>}
+      {required ? <span className="text-danger-500">*</span> : null}
     </label>
   )
 }

--- a/src/components/commons/ToastCard.tsx
+++ b/src/components/commons/ToastCard.tsx
@@ -36,10 +36,10 @@ export default function ToastCard({ type, title, children, durationMs, showBar, 
           </div>
 
           <div className="min-w-0 flex-1">
-            {title && <strong className={cn('truncate text-[15px] font-semibold', TOAST_COLORS[type].text)}>{title}</strong>}
-            {children && (
+            {title ? <strong className={cn('truncate text-[15px] font-semibold', TOAST_COLORS[type].text)}>{title}</strong> : null}
+            {children ? (
               <div className={cn('mt-0.5 text-sm leading-5 wrap-break-word', TOAST_COLORS[type].text)}>{children}</div>
-            )}
+            ) : null}
           </div>
 
           <button
@@ -56,14 +56,14 @@ export default function ToastCard({ type, title, children, durationMs, showBar, 
           </button>
         </div>
 
-        {showBar && (
+        {showBar ? (
           <ToastProgress
             trackClass={TOAST_COLORS[type].bar}
             fillClass={TOAST_COLORS[type].text}
             durationMs={durationMs}
             onEnd={onClose}
           />
-        )}
+        ) : null}
       </div>
     </motion.div>
   )

--- a/src/components/commons/button/Button.tsx
+++ b/src/components/commons/button/Button.tsx
@@ -25,8 +25,8 @@ export default function Button({ children, icon: Icon, iconSrc, variant, size = 
       className={cn(buttonVariants({ variant, size, iconPosition, disabled: disabled || undefined }), className)}
       {...rest}
     >
-      {Icon && <Icon size={iconSize} {...iconProps} />}
-      {iconSrc && <Image src={iconSrc} alt="" width={iconSize ?? 16} height={iconSize ?? 16} className="object-contain" />}
+      {Icon ? <Icon size={iconSize} {...iconProps} /> : null}
+      {iconSrc ? <Image src={iconSrc} alt="" width={iconSize ?? 16} height={iconSize ?? 16} className="object-contain" /> : null}
       {children}
     </button>
   )

--- a/src/components/commons/select/CascadingSelectField.tsx
+++ b/src/components/commons/select/CascadingSelectField.tsx
@@ -85,7 +85,7 @@ export default function CascadingSelectField<T extends FieldValues>({
                     buttonClassName={buttonClassName}
                     optionClassName={optionClassName}
                   />
-                  {fieldState.error && <p className="text-xs font-semibold text-red-500">{fieldState.error.message}</p>}
+                  {fieldState.error ? <p className="text-xs font-semibold text-red-500">{fieldState.error.message}</p> : null}
                 </div>
 
                 <Controller
@@ -103,7 +103,7 @@ export default function CascadingSelectField<T extends FieldValues>({
                         buttonClassName={buttonClassName}
                         optionClassName={optionClassName}
                       />
-                      {secondaryFieldState.error && <p className="text-xs font-semibold text-red-500">{secondaryFieldState.error.message}</p>}
+                      {secondaryFieldState.error ? <p className="text-xs font-semibold text-red-500">{secondaryFieldState.error.message}</p> : null}
                     </div>
                   )}
                 />

--- a/src/components/commons/select/SelectDropdown.tsx
+++ b/src/components/commons/select/SelectDropdown.tsx
@@ -62,7 +62,7 @@ function SelectOption({ option, isSelected, onSelect, optionClassName, optionRef
       )}
     >
       <span>{option.label}</span>
-      {isSelected && <Check size={14} className="shrink-0 text-gray-600" />}
+      {isSelected ? <Check size={14} className="shrink-0 text-gray-600" /> : null}
     </button>
   )
 }
@@ -192,9 +192,9 @@ export default function SelectDropdown({
         placeholder={placeholder}
       />
 
-      {isOpen && !disabled && (
+      {isOpen && !disabled ? (
         <SelectOptions options={options} selectedValue={value} onSelect={handleSelect} placeholder={placeholder} optionClassName={optionClassName} />
-      )}
+      ) : null}
     </div>
   )
 }

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -107,7 +107,7 @@ export default function Header() {
           <div className="flex h-12 items-center justify-between gap-4">
             <nav className="flex items-center gap-8" aria-label="주 메뉴">
               <Logo />
-              {isXl && (
+              {isXl ? (
                 <>
                   <Link
                     href={ROUTES.HOME}
@@ -122,24 +122,24 @@ export default function Header() {
                     커뮤니티
                   </Link>
                 </>
-              )}
+              ) : null}
             </nav>
             <div className="flex items-center gap-1 xl:gap-8">
-              {!hideSearchBar && (
+              {!hideSearchBar ? (
                 <Suspense>
                   <SearchBar className="hidden md:h-9 xl:block" inputClass="text-sm py-0" />
                 </Suspense>
-              )}
-              {!hideSearchBar && !isXl && (
-                <IconButton aria-label="검색" onClick={() => setIsSearchOpen(!isSearchOpen)}>
+              ) : null}
+              {!hideSearchBar && !isXl ? (
+                <IconButton aria-label="검색" onClick={() => setIsSearchOpen((prev) => !prev)}>
                   <Search className="text-white" />
                 </IconButton>
-              )}
+              ) : null}
               <UserControls isSideOpen={isSideOpen} setIsSideOpen={setIsSideOpen} hideMenuButton={hideMenuButton} />
             </div>
           </div>
           {/* 모바일 검색바 - 아코디언 */}
-          {!hideSearchBar && (
+          {!hideSearchBar ? (
             <div
               className="overflow-hidden transition-all duration-300 xl:hidden"
               style={{
@@ -152,7 +152,7 @@ export default function Header() {
                 <SearchBar className="h-8 xl:hidden" inputClass="py-1 text-sm" />
               </Suspense>
             </div>
-          )}
+          ) : null}
         </div>
       </header>
       <MobileNavigation isOpen={isSideOpen} onClose={() => setIsSideOpen(false)} />

--- a/src/components/header/SimpleHeader.tsx
+++ b/src/components/header/SimpleHeader.tsx
@@ -18,7 +18,7 @@ export default function SimpleHeader({ title, description, href, layoutClassname
       ) : (
         <span className="heading-h2">{title}</span>
       )}
-      {description && <p>{description}</p>}
+      {description ? <p>{description}</p> : null}
     </div>
   )
 }

--- a/src/components/header/components/MobileNavigation.tsx
+++ b/src/components/header/components/MobileNavigation.tsx
@@ -108,7 +108,7 @@ export default function MobileNavigation({ isOpen, onClose }: MobileNavigationPr
           <div>
             <button
               type="button"
-              onClick={() => setIsCommunityOpen(!isCommunityOpen)}
+              onClick={() => setIsCommunityOpen((prev) => !prev)}
               className="flex w-full cursor-pointer items-center justify-between py-2"
             >
               <span className="font-bold">커뮤니티</span>
@@ -130,7 +130,7 @@ export default function MobileNavigation({ isOpen, onClose }: MobileNavigationPr
             </div>
           </div>
           <div>
-            <button type="button" onClick={() => setIsCustomerOpen(!isCustomerOpen)} className="flex w-full items-center justify-between py-2">
+            <button type="button" onClick={() => setIsCustomerOpen((prev) => !prev)} className="flex w-full items-center justify-between py-2">
               <span className="font-bold">고객센터</span>
               <ChevronDown className={cn('h-5 w-5 transition-transform', isCustomerOpen && 'rotate-180')} />
             </button>

--- a/src/components/header/components/UserControls.tsx
+++ b/src/components/header/components/UserControls.tsx
@@ -2,7 +2,7 @@
 
 import UserMenu from '../components/user-section/UserMenu'
 import AuthMenu from '../components/user-section/AuthMenu'
-import { useState } from 'react'
+import React, { useState } from 'react'
 import { useUserStore } from '@/store/userStore'
 import Link from 'next/link'
 import { ROUTES } from '@/constants/routes'
@@ -15,7 +15,7 @@ import { useNotificationSSE } from '@/hooks/useNotifications'
 
 interface UserControlsProps {
   isSideOpen: boolean
-  setIsSideOpen: (isSideOpen: boolean) => void
+  setIsSideOpen: React.Dispatch<React.SetStateAction<boolean>>
   hideMenuButton?: boolean
 }
 
@@ -26,7 +26,7 @@ export default function UserControls({ isSideOpen, setIsSideOpen, hideMenuButton
   const { isLogin } = useUserStore()
   useNotificationSSE()
   const handleBellToggle = () => {
-    setIsNotificationOpen(!isNotificationOpen)
+    setIsNotificationOpen((prev) => !prev)
   }
   const { data: unreadCountData } = useQuery({
     queryKey: ['notifications', 'unreadCount'],
@@ -52,12 +52,12 @@ export default function UserControls({ isSideOpen, setIsSideOpen, hideMenuButton
             <IconButton aria-label="알림" size="lg" className="hover:bg-transparent">
               <Bell size={24} className="stroke-white" />
             </IconButton>
-            {(unreadCountData?.unreadCount ?? 0) > 0 && (
+            {(unreadCountData?.unreadCount ?? 0) > 0 ? (
               <span className="bg-danger-500 absolute top-0 -right-2 flex size-5 items-center justify-center rounded-full p-2 text-sm text-white">
                 {unreadCountData?.unreadCount}
               </span>
-            )}
-            {isNotificationOpen && <NotificationsDropdown isNotificationOpen={isNotificationOpen} setIsNotificationOpen={setIsNotificationOpen} />}
+            ) : null}
+            {isNotificationOpen ? <NotificationsDropdown isNotificationOpen={isNotificationOpen} setIsNotificationOpen={setIsNotificationOpen} /> : null}
           </div>
           <UserMenu
             isNotificationOpen={false}

--- a/src/components/header/components/notification-section/NotificationItem.tsx
+++ b/src/components/header/components/notification-section/NotificationItem.tsx
@@ -33,11 +33,11 @@ export default function NotificationItem({ handleReadNotification, ...notificati
           <p className="line-clamp-2 text-left text-sm text-gray-900">{notification.content}</p>
           <p className="flex items-center text-xs text-gray-500">{getTimeAgo(notification.createdAt)}</p>
         </div>
-        {!notification.isRead && (
+        {!notification.isRead ? (
           <div className="flex pt-2">
             <div className="bg-primary-500 size-2 rounded-full" />
           </div>
-        )}
+        ) : null}
       </div>
     </div>
   )

--- a/src/components/header/components/user-section/AuthMenu.tsx
+++ b/src/components/header/components/user-section/AuthMenu.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import React from 'react'
 import Link from 'next/link'
 import { ROUTES } from '@/constants/routes'
 import { useMediaQuery } from '@/hooks/useMediaQuery'
@@ -8,7 +9,7 @@ import IconButton from '@/components/commons/button/IconButton'
 
 interface AuthMenuProps {
   isSideOpen: boolean
-  setIsSideOpen: (isSideOpen: boolean) => void
+  setIsSideOpen: React.Dispatch<React.SetStateAction<boolean>>
   hideMenuButton?: boolean
 }
 
@@ -21,7 +22,7 @@ export default function AuthMenu({ isSideOpen, setIsSideOpen, hideMenuButton = f
       </Link>
     </div>
   ) : hideMenuButton ? null : (
-    <IconButton aria-label="메뉴" onClick={() => setIsSideOpen(!isSideOpen)}>
+    <IconButton aria-label="메뉴" onClick={() => setIsSideOpen((prev) => !prev)}>
       <Menu className="text-white" />
     </IconButton>
   )

--- a/src/components/header/components/user-section/UserMenu.tsx
+++ b/src/components/header/components/user-section/UserMenu.tsx
@@ -7,7 +7,7 @@ import { ROUTES } from '@/constants/routes'
 import { useUserStore } from '@/store/userStore'
 import ProfileAvatar from '@/components/commons/ProfileAvatar'
 import Link from 'next/link'
-import { useRef } from 'react'
+import React, { useRef } from 'react'
 import { useOutsideClick } from '@/hooks/useOutsideClick'
 import { useMediaQuery } from '@/hooks/useMediaQuery'
 import IconButton from '@/components/commons/button/IconButton'
@@ -15,11 +15,11 @@ import { useLogout } from '@/hooks/useLogout'
 
 interface UserMenuProps {
   isNotificationOpen: boolean
-  setIsNotificationOpen: (isNotificationOpen: boolean) => void
+  setIsNotificationOpen: React.Dispatch<React.SetStateAction<boolean>>
   isUserMenuOpen: boolean
-  setIsUserMenuOpen: (isUserMenuOpen: boolean) => void
+  setIsUserMenuOpen: React.Dispatch<React.SetStateAction<boolean>>
   isSideOpen: boolean
-  setIsSideOpen: (isSideOpen: boolean) => void
+  setIsSideOpen: React.Dispatch<React.SetStateAction<boolean>>
   userNickname?: string
 }
 
@@ -41,7 +41,7 @@ export default function UserMenu({
     if (isNotificationOpen) {
       setIsNotificationOpen(false)
     }
-    setIsUserMenuOpen(!isUserMenuOpen)
+    setIsUserMenuOpen((prev) => !prev)
   }
 
   // 로그아웃 버튼 클릭 시 확인 모달 열기
@@ -53,7 +53,7 @@ export default function UserMenu({
   return isMd ? (
     <div className="relative flex cursor-pointer items-center gap-2" onClick={handleAvatarToggle}>
       <ProfileAvatar imageUrl={user?.profileImageUrl} nickname={user?.nickname || ''} size="sm" />
-      {isUserMenuOpen && (
+      {isUserMenuOpen ? (
         <div
           className={cn(
             'absolute top-12 right-0 flex w-32 flex-col divide-y divide-gray-100 rounded-lg border border-gray-200 bg-white shadow-lg md:w-48',
@@ -76,10 +76,10 @@ export default function UserMenu({
             로그아웃
           </button>
         </div>
-      )}
+      ) : null}
     </div>
   ) : (
-    <IconButton aria-label="메뉴" onClick={() => setIsSideOpen(!isSideOpen)}>
+    <IconButton aria-label="메뉴" onClick={() => setIsSideOpen((prev) => !prev)}>
       <Menu className="text-white" />
     </IconButton>
   )

--- a/src/components/modal/BlockModal.tsx
+++ b/src/components/modal/BlockModal.tsx
@@ -62,11 +62,11 @@ export default function BlockModal({ isOpen, onCancel, userNickname, userId }: B
     >
       <ModalTitle heading="사용자 차단하기" description={`정말로 ${userNickname}를 차단하시겠습니까?`} />
       <AnimatePresence>
-        {userBlockError && (
+        {userBlockError ? (
           <InlineNotification type="error" onClose={() => setUserBlockError(null)}>
             {userBlockError}
           </InlineNotification>
-        )}
+        ) : null}
       </AnimatePresence>
       <AlertBox alertList={USER_BLOCK_ALERT_LIST} />
       <div className="flex justify-end gap-3">

--- a/src/components/modal/DeleteConfirmModal.tsx
+++ b/src/components/modal/DeleteConfirmModal.tsx
@@ -38,15 +38,15 @@ export default function DeleteConfirmModal({ isOpen, product, onConfirm, onCance
       }}
       onClose={onCancel}
     >
-      {product && (
+      {product ? (
         <>
           <ModalTitle heading="상품 삭제" description="정말로 이 상품을 삭제하시겠습니까?" />
           <AnimatePresence>
-            {error && (
+            {error ? (
               <InlineNotification type="error" onClose={() => onClearError?.()}>
                 {error}
               </InlineNotification>
-            )}
+            ) : null}
           </AnimatePresence>
           <AlertBox alertList={PRODUCT_DELETE_ALERT_LIST} />
           <ul>
@@ -89,7 +89,7 @@ export default function DeleteConfirmModal({ isOpen, product, onConfirm, onCance
             </Button>
           </div>
         </>
-      )}
+      ) : null}
     </dialog>
   )
 }

--- a/src/components/modal/DeletePostConfirmModal.tsx
+++ b/src/components/modal/DeletePostConfirmModal.tsx
@@ -25,11 +25,11 @@ export default function DeletePostConfirmModal({ isOpen, postId, onConfirm, onCa
       <div className="flex w-11/12 flex-col gap-4 rounded-lg bg-white p-5 md:w-[16vw] md:min-w-96" ref={modalRef}>
         <ModalTitle heading="게시글 삭제" description="정말로 이 게시글을 삭제하시겠습니까?" />
         <AnimatePresence>
-          {error && (
+          {error ? (
             <InlineNotification type="error" onClose={() => onClearError?.()}>
               {error}
             </InlineNotification>
-          )}
+          ) : null}
         </AnimatePresence>
         <div className="flex justify-end gap-3">
           <Button onClick={onCancel} size="sm" className="cursor-pointer rounded-lg border border-gray-300 bg-white">

--- a/src/components/modal/DeleteReplyModal.tsx
+++ b/src/components/modal/DeleteReplyModal.tsx
@@ -49,11 +49,11 @@ export default function DeleteReplyModal({ isOpen, onCancel, replyId, onConfirm 
     >
       <ModalTitle heading="댓글 삭제하기" description="정말로 이 댓글을 삭제하시겠습니까?" />
       <AnimatePresence>
-        {replyDeleteError && (
+        {replyDeleteError ? (
           <InlineNotification type="error" onClose={() => setReplyDeleteError(null)}>
             {replyDeleteError}
           </InlineNotification>
-        )}
+        ) : null}
       </AnimatePresence>
       <div className="flex justify-end gap-3">
         <Button type="button" onClick={() => dialogRef.current?.close()} size="sm" className="cursor-pointer rounded-lg border border-gray-300 bg-white">

--- a/src/components/modal/ReportModalBase.tsx
+++ b/src/components/modal/ReportModalBase.tsx
@@ -80,11 +80,11 @@ export default function ReportModalBase({ isOpen, heading, description, reasons,
     >
       <ModalTitle heading={heading} description={description} />
       <AnimatePresence>
-        {error && (
+        {error ? (
           <InlineNotification type="error" onClose={() => onClearError?.()}>
             {error}
           </InlineNotification>
-        )}
+        ) : null}
       </AnimatePresence>
       <form onSubmit={handleSubmit(handleFormSubmit)} className="flex flex-col gap-4">
         <div className="flex flex-col gap-6 pt-2">
@@ -121,11 +121,11 @@ export default function ReportModalBase({ isOpen, heading, description, reasons,
                 })}
               />
               <p className="text-sm font-semibold text-gray-400">{titleLength}/300자</p>
-              {errors.detailReason && <p className="text-danger-500 text-xs font-semibold"> {errors.detailReason.message}</p>}
+              {errors.detailReason ? <p className="text-danger-500 text-xs font-semibold"> {errors.detailReason.message}</p> : null}
             </div>
           </div>
 
-          {isOpen && (
+          {isOpen ? (
             <div className="flex w-full flex-col gap-3">
               <ImageUploadField
                 setValue={setValue}
@@ -140,7 +140,7 @@ export default function ReportModalBase({ isOpen, heading, description, reasons,
                 headingClassName="text-gray-900 font-semibold"
               />
             </div>
-          )}
+          ) : null}
         </div>
 
         <div className="flex justify-end gap-3">

--- a/src/components/modal/UserReportModal.tsx
+++ b/src/components/modal/UserReportModal.tsx
@@ -30,7 +30,7 @@ export default function UserReportModal({ isOpen, userNickname, userId, onCancel
       setUserReportError(
         <div className="flex flex-col gap-0.5">
           <p className="text-base font-semibold">{isDuplicate ? '이미 신고한 사용자입니다.' : '사용자 신고에 실패했습니다.'}</p>
-          {!isDuplicate && <p>잠시 후 다시 시도해주세요.</p>}
+          {!isDuplicate ? <p>잠시 후 다시 시도해주세요.</p> : null}
         </div>,
       )
     }

--- a/src/components/modal/WithdrawModal.tsx
+++ b/src/components/modal/WithdrawModal.tsx
@@ -71,11 +71,11 @@ export default function WithdrawModal({ isOpen, onConfirm, onCancel, error, onCl
     >
       <ModalTitle heading="회원탈퇴" description="정말로 탈퇴하시겠습니까?" />
       <AnimatePresence>
-        {error && (
+        {error ? (
           <InlineNotification type="error" onClose={() => onClearError?.()}>
             {error}
           </InlineNotification>
-        )}
+        ) : null}
       </AnimatePresence>
       <AlertBox alertList={WITH_DRAW_ALERT_LIST} />
 
@@ -118,7 +118,7 @@ export default function WithdrawModal({ isOpen, onConfirm, onCancel, error, onCl
                 })}
               />
               <p className="text-sm font-semibold text-gray-400">{titleLength}/500자</p>
-              {errors.detailReason && <p className="text-danger-500 text-xs font-semibold"> {errors.detailReason.message}</p>}
+              {errors.detailReason ? <p className="text-danger-500 text-xs font-semibold"> {errors.detailReason.message}</p> : null}
             </div>
           </div>
 

--- a/src/components/product/ProductList.tsx
+++ b/src/components/product/ProductList.tsx
@@ -33,7 +33,7 @@ export default function ProductList({ products, showMoreButton = false, sellerId
           <ProductCard data-index={index} data={product} />
         </li>
       ))}
-      {showMoreButton && sellerId && products.length >= 4 && (
+      {showMoreButton && sellerId && products.length >= 4 ? (
         <button
           type="button"
           onClick={() => goToUserPage(sellerId)}
@@ -41,7 +41,7 @@ export default function ProductList({ products, showMoreButton = false, sellerId
         >
           더보기
         </button>
-      )}
+      ) : null}
     </ul>
   )
 }

--- a/src/components/product/ProductStateFilter.tsx
+++ b/src/components/product/ProductStateFilter.tsx
@@ -88,7 +88,7 @@ export function ProductStateFilter({
               )}
             >
               <span>{item.title}</span>
-              {subTitle && <span className="text-xs font-medium">{item.subtitle}</span>}
+              {subTitle ? <span className="text-xs font-medium">{item.subtitle}</span> : null}
             </label>
           </div>
         ))}

--- a/src/components/product/components/ProductBadge.tsx
+++ b/src/components/product/components/ProductBadge.tsx
@@ -10,7 +10,7 @@ export function ProductBadge({ petTypeName, productStatusName, productTypeName }
   return (
     <div className="gap-xs z-1 flex flex-wrap">
       <Badge className="bg-primary-700 text-white">{petTypeName}</Badge>
-      {productTypeName !== '판매요청' && <Badge className="bg-primary-200 text-gray-900">{productStatusName}</Badge>}
+      {productTypeName !== '판매요청' ? <Badge className="bg-primary-200 text-gray-900">{productStatusName}</Badge> : null}
     </div>
   )
 }

--- a/src/components/profile/ProfileData.tsx
+++ b/src/components/profile/ProfileData.tsx
@@ -103,10 +103,10 @@ export default function ProfileData({
           </div>
           <p className="w-full text-sm font-semibold text-gray-500">{data?.introduction || '소개글을 작성해주세요'}</p>
           {/* 데스크탑 내 정보 */}
-          {isMyProfile && (
+          {isMyProfile ? (
             <>
               <div className="flex flex-col gap-3.5">
-                {isMd && (
+                {isMd ? (
                   <div className="flex flex-col gap-2.5">
                     <ProductMetaItem
                       icon={MapPin}
@@ -117,8 +117,8 @@ export default function ProfileData({
                     <ProductMetaItem icon={Calendar} iconSize={17} label={`가입일: ${formattedJoinDate}`} className="gap-2" />
                     <ProductMetaItem icon={Route} iconSize={17} label={`가입 경로: ${provider}`} className="gap-2" />
                   </div>
-                )}
-                {!isProfileEditPage && (
+                ) : null}
+                {!isProfileEditPage ? (
                   <Link
                     href={ROUTES.PROFILE_UPDATE}
                     className="bg-primary-200 flex items-center justify-center gap-2.5 rounded-lg px-3 py-2 text-white transition-all"
@@ -126,7 +126,7 @@ export default function ProfileData({
                     <Settings size={19} />
                     <span className="lg:text-sm lg:font-bold">내 정보 수정</span>
                   </Link>
-                )}
+                ) : null}
               </div>
               <button
                 type="button"
@@ -136,12 +136,12 @@ export default function ProfileData({
                 회원탈퇴
               </button>
             </>
-          )}
+          ) : null}
 
           {/* 다른 유저 프로필 */}
-          {!isMyProfile && (
+          {!isMyProfile ? (
             <>
-              {data?.isBlocked && (
+              {data?.isBlocked ? (
                 <div className="flex flex-col gap-3.5">
                   <div className="bg-danger-100/30 border-danger-100 text-danger-800 flex items-center justify-center gap-2 rounded-lg border p-2.5 font-medium">
                     <ShieldAlert />
@@ -155,7 +155,7 @@ export default function ProfileData({
                     차단 해제하기
                   </Button>
                 </div>
-              )}
+              ) : null}
               <div className="flex items-center justify-between">
                 {data?.isReported ? (
                   <div className="flex w-full items-center justify-start gap-2 px-3 py-1.5 text-sm text-gray-500">
@@ -173,7 +173,7 @@ export default function ProfileData({
                   </button>
                 )}
 
-                {!data?.isBlocked && (
+                {!data?.isBlocked ? (
                   <button
                     type="button"
                     className="flex w-full cursor-pointer items-center justify-center gap-2 rounded-lg bg-transparent px-3 py-1.5 text-sm text-gray-500 hover:bg-gray-100 md:py-1.5"
@@ -182,10 +182,10 @@ export default function ProfileData({
                     <Ban size={16} />
                     차단하기
                   </button>
-                )}
+                ) : null}
               </div>
             </>
-          )}
+          ) : null}
         </div>
       </div>
     </aside>

--- a/src/features/UserPage.tsx
+++ b/src/features/UserPage.tsx
@@ -121,13 +121,13 @@ function UserPage() {
       <div className="pb-4xl relative bg-white pt-0 md:pt-8">
         <div className="mx-auto max-w-7xl">
           <AnimatePresence>
-            {unblockError && (
+            {unblockError ? (
               <div className="absolute top-4 left-1/2 z-50 -translate-x-1/2 md:pt-8">
                 <InlineNotification type="error" onClose={() => setUnblockError(null)}>
                   {unblockError}
                 </InlineNotification>
               </div>
-            )}
+            ) : null}
           </AnimatePresence>
         </div>
         <div className="mx-auto flex max-w-7xl flex-col gap-0 md:flex-row md:gap-8">
@@ -154,7 +154,7 @@ function UserPage() {
                       <ProductListItem key={product.id} product={product} />
                     ))}
                   </ul>
-                  {hasNextPage && <LoadMoreButton onClick={() => fetchNextPage()} isLoading={isFetchingNextPage} />}
+                  {hasNextPage ? <LoadMoreButton onClick={() => fetchNextPage()} isLoading={isFetchingNextPage} /> : null}
                 </>
               ) : (
                 <EmptyState icon={Package} title={'등록한 상품이 없습니다'} />

--- a/src/features/chatting-page/components/ChatLog.tsx
+++ b/src/features/chatting-page/components/ChatLog.tsx
@@ -171,7 +171,7 @@ export function ChatLog({
   return (
     <div ref={scrollRef} onScroll={handleScroll} className="flex h-full flex-col gap-4 overflow-y-auto">
       <AnimatePresence>
-        {connectionError && (
+        {connectionError ? (
           <div className="sticky top-0 left-1/2 z-10 w-fit -translate-x-1/2">
             <InlineNotification type="error" onClose={() => onClearConnectionError?.()}>
               <div className="flex flex-col gap-0.5">
@@ -180,14 +180,14 @@ export function ChatLog({
               </div>
             </InlineNotification>
           </div>
-        )}
-        {imageUploadError && (
+        ) : null}
+        {imageUploadError ? (
           <div className="sticky top-0 left-1/2 z-10 w-fit -translate-x-1/2">
             <InlineNotification type="error" onClose={() => onClearImageUploadError?.()}>
               {imageUploadError}
             </InlineNotification>
           </div>
-        )}
+        ) : null}
       </AnimatePresence>
       {Object.entries(groupedMessages).map(([dateKey, messages]) => (
         <div key={dateKey} className="flex flex-col gap-2">

--- a/src/features/chatting-page/components/ChatRoomInfo.tsx
+++ b/src/features/chatting-page/components/ChatRoomInfo.tsx
@@ -43,11 +43,11 @@ export function ChatRoomInfo({ data, onLeaveRoom, onBack }: ChatRoomInfoProps) {
     <div className="flex flex-col gap-2.5 bg-white p-3.5">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
-          {onBack && (
+          {onBack ? (
             <button onClick={onBack} className="p-1 md:hidden">
               <ArrowLeft size={24} />
             </button>
-          )}
+          ) : null}
           <SellerAvatar profileImageUrl={data?.opponentProfileImageUrl} nickname={data?.opponentNickname} />
           <p>{data?.opponentNickname}</p>
         </div>

--- a/src/features/chatting-page/components/ChatRooms.tsx
+++ b/src/features/chatting-page/components/ChatRooms.tsx
@@ -68,14 +68,14 @@ export function ChatRooms({ rooms, handleSelectRoom, selectedRoomId, hasNextPage
                         </p>
                       </div>
                       <div className="flex items-center gap-1">
-                        {roomData.lastMessageTime && (
+                        {roomData.lastMessageTime ? (
                           <span className="text-sm leading-none font-medium text-gray-500">{getTimeAgo(roomData.lastMessageTime)}</span>
-                        )}
-                        {roomData.unreadCount >= 1 && (
+                        ) : null}
+                        {roomData.unreadCount >= 1 ? (
                           <p className="bg-danger-500 tex-sm flex size-5 items-center justify-center rounded-full text-white">
                             {roomData.unreadCount}
                           </p>
-                        )}
+                        ) : null}
                       </div>
                     </div>
                     <div className="border-primary-100 bg-primary-50 flex items-center gap-2 overflow-hidden rounded-lg border px-2.5 py-3">
@@ -92,11 +92,11 @@ export function ChatRooms({ rooms, handleSelectRoom, selectedRoomId, hasNextPage
             })}
         </ul>
         <div ref={targetRef} className="h-10" aria-hidden="true" />
-        {isFetchingNextPage && (
+        {isFetchingNextPage ? (
           <div className="flex items-center justify-center py-8">
             <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-blue-600" aria-label="채팅방 로딩 중" role="status" />
           </div>
-        )}
+        ) : null}
       </div>
     </section>
   )

--- a/src/features/community/CommunityDetail.tsx
+++ b/src/features/community/CommunityDetail.tsx
@@ -3,7 +3,12 @@
 import { useRouter, useParams, usePathname, useSearchParams } from 'next/navigation'
 import { useMutation, useQueryClient, useQuery } from '@tanstack/react-query'
 import { fetchGraphQL } from '@/lib/api/graphql'
-import MdPreview from './components/markdown/MdPreview'
+import dynamic from 'next/dynamic'
+
+const MdPreview = dynamic(() => import('./components/markdown/MdPreview'), {
+  ssr: false,
+  loading: () => <div className="p-3 text-sm text-gray-400">로딩 중...</div>,
+})
 import { getBoardType } from '@/lib/utils/getBoardType'
 import Badge from '@/components/commons/badge/Badge'
 import { formatDate } from '@/lib/utils/formatDate'
@@ -179,7 +184,7 @@ export default function CommunityDetail({ initialPostData, initialCommentData }:
     }
   }
   const handleMoreToggle = () => {
-    setIsMoreMenuOpen(!isMoreMenuOpen)
+    setIsMoreMenuOpen((prev) => !prev)
   }
 
   const handlePostEdit = (postId: number) => {
@@ -267,7 +272,7 @@ export default function CommunityDetail({ initialPostData, initialCommentData }:
                 <IconButton aria-label="더보기" className="" size="sm" onClick={handleMoreToggle}>
                   <EllipsisVertical size={16} className="text-gray-500" />
                 </IconButton>
-                {isMoreMenuOpen && (
+                {isMoreMenuOpen ? (
                   <div
                     className="absolute top-7 right-0 flex flex-col rounded border border-gray-200 bg-white shadow-md md:min-w-14"
                     ref={modalRef}
@@ -312,7 +317,7 @@ export default function CommunityDetail({ initialPostData, initialCommentData }:
                       </button>
                     )}
                   </div>
-                )}
+                ) : null}
               </div>
               <div className="flex items-baseline justify-between md:items-center">
                 <div className="flex items-center gap-3.5">
@@ -338,13 +343,13 @@ export default function CommunityDetail({ initialPostData, initialCommentData }:
                 <span>{data.commentCount}</span>
               </div>
 
-              {commentData?.comments && <CommentList comments={commentData.comments} postId={id!} />}
+              {commentData?.comments ? <CommentList comments={commentData.comments} postId={id!} /> : null}
               <AnimatePresence>
-                {commentPostError && (
+                {commentPostError ? (
                   <InlineNotification type="error" onClose={() => setCommentPostError(null)}>
                     {commentPostError}
                   </InlineNotification>
-                )}
+                ) : null}
               </AnimatePresence>
               <CommentForm
                 id="comment-input"

--- a/src/features/community/CommunityPage.tsx
+++ b/src/features/community/CommunityPage.tsx
@@ -200,7 +200,7 @@ export default function CommunityPage({ initialQuestionData, initialInfoData }: 
       <div className="pb-4xl mx-auto max-w-7xl px-0 md:px-4">
         <div className="flex w-full flex-col">
           {/* 모바일: 필터 영역 */}
-          {!isMd && (
+          {!isMd ? (
             <div className={cn(!isFilterCollapsed && `sticky top-16 ${Z_INDEX.DROPDOWN}`)}>
               {/* 접히는 필터 영역 */}
               <div
@@ -257,10 +257,10 @@ export default function CommunityPage({ initialQuestionData, initialInfoData }: 
                 </div>
               </div>
             </div>
-          )}
+          ) : null}
 
           {/* 데스크탑 */}
-          {isMd && (
+          {isMd ? (
             <div className="mb-7 flex w-full flex-col gap-4">
               <div className="flex items-center justify-between">
                 <CommunityTabs
@@ -269,14 +269,14 @@ export default function CommunityPage({ initialQuestionData, initialInfoData }: 
                   onTabChange={handleTabChange}
                   ariaLabel="커뮤니티 타입"
                 />
-                {isLogin() && (
+                {isLogin() ? (
                   <Link
                     href={`${ROUTES.COMMUNITY_POST}?tab=${activeCommunityTypeTab}`}
                     className="bg-primary-300 rounded-lg px-3 py-2 text-white"
                   >
                     글쓰기
                   </Link>
-                )}
+                ) : null}
               </div>
 
               <div className="flex flex-row items-center justify-between gap-5">
@@ -310,7 +310,7 @@ export default function CommunityPage({ initialQuestionData, initialInfoData }: 
                 </div>
               </div>
             </div>
-          )}
+          ) : null}
           <div
             id={`panel-${COMMUNITY_TABS.find((tab) => tab.id === activeCommunityTypeTab)?.code}`}
             role="tabpanel"
@@ -386,24 +386,25 @@ export default function CommunityPage({ initialQuestionData, initialInfoData }: 
               </ul>
             )}
           </div>
-          {hasNextPage &&
-            (isMd ? (
+          {hasNextPage ? (
+            isMd ? (
               <LoadMoreButton onClick={() => fetchNextPage()} isLoading={isFetchingNextPage} className="border-0" />
             ) : (
               <div className="px-3.5">
                 <LoadMoreButton onClick={() => fetchNextPage()} isLoading={isFetchingNextPage} className="border-0" />
               </div>
-            ))}
+            )
+          ) : null}
         </div>
       </div>
-      {!isMd && isLogin() && (
+      {!isMd && isLogin() ? (
         <Link
           href={`${ROUTES.COMMUNITY_POST}?tab=${activeCommunityTypeTab}`}
           className={`bg-primary-200 fixed right-4 bottom-4 rounded-full px-3 py-3 text-white ${Z_INDEX.FLOATING_BUTTON}`}
         >
           <Plus />
         </Link>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/src/features/community/components/CommentItem.tsx
+++ b/src/features/community/components/CommentItem.tsx
@@ -40,7 +40,7 @@ export function CommentItem({
   const [isReplyDeleteModalOpen, setIsReplyDeleteModalOpen] = useState(false)
 
   const handleMoreToggle = () => {
-    setIsMoreMenuOpen(!isMoreMenuOpen)
+    setIsMoreMenuOpen((prev) => !prev)
   }
 
   const modalRef = useRef<HTMLButtonElement>(null)
@@ -68,9 +68,9 @@ export function CommentItem({
           <div className="flex items-center gap-3.5">
             <div className="flex items-center gap-1.5">
               <p>{comment.authorNickname}</p>
-              {Number(comment.authorId) === user?.id && (
+              {Number(comment.authorId) === user?.id ? (
                 <p className="bg-primary-200 rounded-full px-2.5 py-1 text-xs font-semibold text-white">작성자</p>
-              )}
+              ) : null}
             </div>
             <p className="text-sm text-gray-400">{formatDate(comment.createdAt)}</p>
           </div>
@@ -81,20 +81,20 @@ export function CommentItem({
               답글
             </button>
             {/* 답글 버튼 (대댓글이 아니고, hasChildren이 있을 때만) */}
-            {!isReply && hasChildren && (
+            {!isReply && hasChildren ? (
               <button className="cursor-pointer self-start text-sm text-blue-500 hover:underline" type="button" onClick={onToggleReplies}>
                 {isRepliesOpen ? '답글 접기' : `답글 ${childrenCount}개`}
               </button>
-            )}
+            ) : null}
           </div>
         </div>
 
-        {isMyComment && (
+        {isMyComment ? (
           <div className="relative ml-auto">
             <IconButton aria-label="더보기" className="" size="sm" onClick={handleMoreToggle}>
               <EllipsisVertical size={16} className="text-gray-500" />
             </IconButton>
-            {isMoreMenuOpen && (
+            {isMoreMenuOpen ? (
               <button
                 className="absolute top-7 right-0 cursor-pointer rounded border border-gray-200 bg-white px-3 py-1.5 text-sm whitespace-nowrap shadow-md hover:bg-gray-50"
                 type="button"
@@ -103,9 +103,9 @@ export function CommentItem({
               >
                 삭제
               </button>
-            )}
+            ) : null}
           </div>
-        )}
+        ) : null}
       </div>
       <DeleteReplyModal
         isOpen={isReplyDeleteModalOpen}

--- a/src/features/community/components/CommentList.tsx
+++ b/src/features/community/components/CommentList.tsx
@@ -159,7 +159,7 @@ export function CommentList({ comments, postId }: CommentListProps) {
           {/* 대댓글 목록 */}
           <div className={`grid transition-all duration-300 ${openRepliesCommentId === comment.id ? 'mt-3.5 grid-rows-[1fr]' : 'grid-rows-[0fr]'}`}>
             <div className="overflow-hidden">
-              {openRepliesCommentId === comment.id && repliesData?.comments && (
+              {openRepliesCommentId === comment.id && repliesData?.comments ? (
                 <ul className="flex flex-col gap-2 pb-3.5 pl-10">
                   {repliesData.comments.map((reply, index) => (
                     <li key={reply.id}>
@@ -167,17 +167,17 @@ export function CommentList({ comments, postId }: CommentListProps) {
                     </li>
                   ))}
                 </ul>
-              )}
+              ) : null}
             </div>
           </div>
-          {replyingToId === comment.id && (
+          {replyingToId === comment.id ? (
             <div className="pb-3.5 pl-10">
               <AnimatePresence>
-                {replyPostError && (
+                {replyPostError ? (
                   <InlineNotification type="error" onClose={() => setReplyPostError(null)}>
                     {replyPostError}
                   </InlineNotification>
-                )}
+                ) : null}
               </AnimatePresence>
               <CommentForm
                 id={String(comment.id)}
@@ -188,7 +188,7 @@ export function CommentList({ comments, postId }: CommentListProps) {
                 onCancel={() => handleOpenReplyForm(comment.id)}
               />
             </div>
-          )}
+          ) : null}
         </li>
       ))}
     </ul>

--- a/src/features/community/components/CommunityPostForm.tsx
+++ b/src/features/community/components/CommunityPostForm.tsx
@@ -14,6 +14,7 @@ import Markdown from './markdown/Markdown'
 import { ArrowLeft } from 'lucide-react'
 import { fetchGraphQL } from '@/lib/api/graphql'
 import { useEffect, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
 import { useMediaQuery } from '@/hooks/useMediaQuery'
 import SimpleHeader from '@/components/header/SimpleHeader'
 import { Z_INDEX } from '@/constants/ui'
@@ -80,7 +81,6 @@ export default function CommunityPostForm() {
   const titleLength = useWatch({ control, name: 'title' })?.length ?? 0
 
   const [postError, setPostError] = useState<React.ReactNode | null>(null)
-  const [postLoadError, setPostLoadError] = useState(false)
 
   const handleCancel = () => {
     clearDraft(getValues('boardType'))
@@ -122,28 +122,27 @@ export default function CommunityPostForm() {
     }
   }
 
-  useEffect(() => {
-    const loadPost = async () => {
-      if (isEditMode && id) {
-        try {
-          const { communityPost: data } = await fetchGraphQL<{ communityPost: any }>(`
-            query CommunityPost($id: Int!) {
-              communityPost(id: $id) { id title content boardType imageUrls }
-            }
-          `, { id: Number(id) })
-          reset({
-            boardType: data.boardType,
-            title: data.title,
-            content: data.content,
-            imageUrls: data.imageUrls ?? [],
-          })
-        } catch {
-          setPostLoadError(true) // 에러 상태 설정
-        }
+  const { data: editPostData, isError: postLoadError } = useQuery({
+    queryKey: ['community-edit-post', id],
+    queryFn: () => fetchGraphQL<{ communityPost: any }>(`
+      query CommunityPost($id: Int!) {
+        communityPost(id: $id) { id title content boardType imageUrls }
       }
+    `, { id: Number(id!) }),
+    enabled: isEditMode && !!id,
+  })
+
+  useEffect(() => {
+    if (editPostData) {
+      const data = editPostData.communityPost
+      reset({
+        boardType: data.boardType,
+        title: data.title,
+        content: data.content,
+        imageUrls: data.imageUrls ?? [],
+      })
     }
-    loadPost()
-  }, [id, isEditMode, reset])
+  }, [editPostData, reset])
 
   // 새 글 작성 시 폼 데이터 변경마다 sessionStorage에 자동 저장
   useEffect(() => {
@@ -214,11 +213,11 @@ export default function CommunityPostForm() {
       <div className="bg-[#F3F4F6]">
         <div className="px-lg mx-auto max-w-7xl pt-5">
           <AnimatePresence>
-            {postError && (
+            {postError ? (
               <InlineNotification type="error" onClose={() => setPostError(null)}>
                 {postError}
               </InlineNotification>
-            )}
+            ) : null}
           </AnimatePresence>
         </div>
       </div>
@@ -246,7 +245,7 @@ export default function CommunityPostForm() {
                         optionClassName="text-base"
                         buttonClassName="border border-gray-400 bg-white text-gray-900 px-3 py-3 text-base"
                       />
-                      {fieldState.error && <p className="text-xs font-semibold text-red-500">{fieldState.error.message}</p>}
+                      {fieldState.error ? <p className="text-xs font-semibold text-red-500">{fieldState.error.message}</p> : null}
                     </div>
                   )}
                 />
@@ -274,9 +273,9 @@ export default function CommunityPostForm() {
                       <RequiredLabel labelClass="heading-h5">내용</RequiredLabel>
                       <Markdown value={field.value} onChange={field.onChange} placeholder="내용을 입력하세요" height={320} />
                       <div className="flex flex-col gap-1">
-                        {fieldState.error && (
+                        {fieldState.error ? (
                           <p className="pt-1.5 text-xs font-semibold text-red-500">{fieldState.error.message}</p>
-                        )}
+                        ) : null}
                         <p className="text-sm text-gray-500">{field.value?.length ?? 0}/1000자</p>
                       </div>
                     </div>
@@ -304,7 +303,7 @@ export default function CommunityPostForm() {
           </form>
         </div>
       </div>
-      {showDraftModal && (
+      {showDraftModal ? (
         <DraftModal
           initialBoardType={initialBoardType}
           setIsDraftChecked={setIsDraftChecked}
@@ -314,7 +313,7 @@ export default function CommunityPostForm() {
           getSavedDraft={getSavedDraft}
           reset={reset}
         />
-      )}
+      ) : null}
     </>
   )
 }

--- a/src/features/community/components/markdown/Markdown.tsx
+++ b/src/features/community/components/markdown/Markdown.tsx
@@ -4,7 +4,12 @@ import { useRef, useState, type DragEvent, type ClipboardEvent, type ChangeEvent
 import { useMdCommands } from './useMdCommands'
 import { useMdImageUpload } from './useMdImageUpload'
 import MdToolbar from './MdToolbar'
-import MdPreview from './MdPreview'
+import dynamic from 'next/dynamic'
+
+const MdPreview = dynamic(() => import('./MdPreview'), {
+  ssr: false,
+  loading: () => <div className="p-3 text-sm text-gray-400">로딩 중...</div>,
+})
 import MdFooter from './MdFooter'
 
 interface MarkDownProps {
@@ -118,7 +123,7 @@ export default function Markdown({ value, onChange, placeholder = DEFAULT_PLACEH
         <input ref={fileInputRef} type="file" accept="image/*" onChange={handleFileChange} className="hidden" />
 
         {/* 편집 모드: textarea */}
-        {currentTab === 'edit' && (
+        {currentTab === 'edit' ? (
           <div className="relative">
             <textarea
               ref={textareaRef}
@@ -132,16 +137,16 @@ export default function Markdown({ value, onChange, placeholder = DEFAULT_PLACEH
               className="w-full resize-none bg-white p-3 outline-none"
               disabled={isUploading}
             />
-            {isUploading && (
+            {isUploading ? (
               <div className="absolute inset-0 flex items-center justify-center bg-white/70">
                 <span className="text-sm text-gray-500">이미지 업로드 중...</span>
               </div>
-            )}
+            ) : null}
           </div>
-        )}
+        ) : null}
 
         {/* 미리보기 모드: 렌더링된 마크다운 */}
-        {currentTab === 'preview' && <MdPreview value={value} height={height} />}
+        {currentTab === 'preview' ? <MdPreview value={value} height={height} /> : null}
 
         {/* 푸터: 마크다운 문법 안내 */}
         <MdFooter>

--- a/src/features/home/Home.tsx
+++ b/src/features/home/Home.tsx
@@ -256,17 +256,17 @@ function Home() {
           {/* 무한 스크롤 감지용 요소 */}
           <div ref={targetRef} className="h-10" aria-hidden="true" />
 
-          {isFetchingNextPage && (
+          {isFetchingNextPage ? (
             <div className="flex items-center justify-center py-8">
               <div role="status" aria-live="polite">
                 <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-blue-600" aria-hidden="true"></div>
                 <span className="sr-only">상품 로딩 중</span>
               </div>
             </div>
-          )}
+          ) : null}
         </div>
       </div>
-      {isLoggedIn && (
+      {isLoggedIn ? (
         <div className={`fixed right-10 bottom-5 ${Z_INDEX.FLOATING_BUTTON}`}>
           <Button
             size={isMd ? 'lg' : 'md'}
@@ -277,7 +277,7 @@ function Home() {
             상품등록
           </Button>
         </div>
-      )}
+      ) : null}
     </>
   )
 }

--- a/src/features/home/components/StaticHomeFallback.tsx
+++ b/src/features/home/components/StaticHomeFallback.tsx
@@ -159,9 +159,9 @@ function StaticProductCard({ product, index }: { product: Product; index: number
         <div className="top-sm px-sm absolute flex w-full justify-between">
           <div className="gap-xs z-1 flex flex-wrap">
             <Badge className="bg-primary-700 text-white">{petTypeName}</Badge>
-            {productTypeName !== '판매요청' && (
+            {productTypeName !== '판매요청' ? (
               <Badge className="bg-primary-200 text-gray-900">{productStatusName}</Badge>
-            )}
+            ) : null}
           </div>
         </div>
         <Badge className={cn('bottom-sm right-sm absolute z-1 text-white', productTradeColor)}>

--- a/src/features/home/components/filter/DetailFilter.tsx
+++ b/src/features/home/components/filter/DetailFilter.tsx
@@ -31,7 +31,7 @@ export const DetailFilter = memo(function DetailFilterSection({
         ariaControls="detail-filter-content"
         filterReset={filterReset}
       />
-      {isOpen && (
+      {isOpen ? (
         <div
           className="bg-primary-100 flex flex-col gap-3.5 rounded-lg px-3 py-2.5 md:flex-row md:gap-10"
           role="group"
@@ -42,7 +42,7 @@ export const DetailFilter = memo(function DetailFilterSection({
           <PriceFilter selectedPriceRange={selectedPriceRange} headingClassName={headingClassName} />
           <LocationFilter headingClassName={headingClassName} />
         </div>
-      )}
+      ) : null}
     </div>
   )
 })

--- a/src/features/home/components/filter/DetailFilterButton.tsx
+++ b/src/features/home/components/filter/DetailFilterButton.tsx
@@ -33,11 +33,11 @@ export function DetailFilterButton({ isOpen, onClick, ariaControls, filterReset 
       <div className={cn('flex items-center gap-2')}>
         <FilterIcon className={cn('h-4 w-4')} aria-hidden="true" />
         <span className={cn('font-sm font-bold')}>세부 필터</span>
-        {isMd && (
+        {isMd ? (
           <p className={cn('bg-primary-50 items-center justify-center overflow-hidden rounded-md px-3 py-1 text-sm')} aria-hidden="true">
             상품상태 · 가격대 · 지역
           </p>
-        )}
+        ) : null}
       </div>
 
       <div className="flex items-center gap-4">

--- a/src/features/home/components/filter/LocationFilter.tsx
+++ b/src/features/home/components/filter/LocationFilter.tsx
@@ -35,13 +35,13 @@ export function LocationFilter({ headingClassName }: LocationFilterProps) {
   // 선택된 시/도에 따른 구/군 목록
   const availableGugun = selectedSido ? CITIES[selectedSido] || [] : []
 
-  // 시/도나 구/군이 변경되면 URL 업데이트
-  useEffect(() => {
+  // URL 업데이트 헬퍼
+  const updateURL = (sido: Province | '', gugun: string) => {
     const params = new URLSearchParams(searchParams.toString())
-    if (selectedSido) {
-      params.set('addressSido', selectedSido)
-      if (selectedGugun) {
-        params.set('addressGugun', selectedGugun)
+    if (sido) {
+      params.set('addressSido', sido)
+      if (gugun) {
+        params.set('addressGugun', gugun)
       } else {
         params.delete('addressGugun')
       }
@@ -50,13 +50,20 @@ export function LocationFilter({ headingClassName }: LocationFilterProps) {
       params.delete('addressGugun')
     }
     push(`${pathname}?${params.toString()}`)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedSido, selectedGugun])
+  }
 
-  // 시/도가 변경되면 구/군 초기화
+  // 시/도가 변경되면 구/군 초기화 + URL 업데이트
   const handleSidoChange = (value: string) => {
-    setSelectedSido(value as Province | '')
-    setSelectedGugun('') // 구/군 초기화
+    const newSido = value as Province | ''
+    setSelectedSido(newSido)
+    setSelectedGugun('')
+    updateURL(newSido, '')
+  }
+
+  // 구/군 변경 시 URL 업데이트
+  const handleGugunChange = (value: string) => {
+    setSelectedGugun(value)
+    updateURL(selectedSido, value)
   }
 
   return (
@@ -86,7 +93,7 @@ export function LocationFilter({ headingClassName }: LocationFilterProps) {
           </span>
           <SelectDropdown
             value={selectedGugun}
-            onChange={(value: string) => setSelectedGugun(value)}
+            onChange={handleGugunChange}
             options={availableGugun.map((gugun) => ({
               value: gugun,
               label: gugun,

--- a/src/features/home/components/filter/PetTypeFilter.tsx
+++ b/src/features/home/components/filter/PetTypeFilter.tsx
@@ -83,7 +83,7 @@ export function PetTypeFilter({ activeTab, headingClassName, selectedDetailPet, 
               {pet.name}
             </Button>
           ))}
-          {hasMoreItems && !showAll && (
+          {hasMoreItems && !showAll ? (
             <Button
               type="button"
               size="sm"
@@ -92,7 +92,7 @@ export function PetTypeFilter({ activeTab, headingClassName, selectedDetailPet, 
             >
               더보기 ({filteredPetDetails.length - INITIAL_DISPLAY_COUNT}개)
             </Button>
-          )}
+          ) : null}
         </div>
       </div>
     </div>

--- a/src/features/home/components/tab/ProductPetTypeTabs.tsx
+++ b/src/features/home/components/tab/ProductPetTypeTabs.tsx
@@ -61,9 +61,9 @@ export function ProductPetTypeTabs({ activeTab, onTabChange }: ProductPetTypeTab
           </Button>
         ))}
       </div>
-      {showFade && (
+      {showFade ? (
         <div className="pointer-events-none absolute top-0 right-0 bottom-0 w-12 bg-linear-to-l from-white via-white/80 to-transparent md:hidden" />
-      )}
+      ) : null}
     </div>
   )
 }

--- a/src/features/login/components/LoginForm.tsx
+++ b/src/features/login/components/LoginForm.tsx
@@ -89,7 +89,7 @@ export function LoginForm() {
               error={errors.password}
               registration={register('password', authValidationRules.password)}
             />
-            {errors.root && <p className="text-danger-500 text-sm">{errors.root.message}</p>}
+            {errors.root ? <p className="text-danger-500 text-sm">{errors.root.message}</p> : null}
           </div>
           <Link href={ROUTES.FIND_PASSWORD} className="text-primary-300 text-sm font-medium">
             비밀번호를 잊으셨나요?

--- a/src/features/login/components/TitleSection.tsx
+++ b/src/features/login/components/TitleSection.tsx
@@ -13,11 +13,11 @@ export function TitleSection({ title, desc, link, linkPath }: TitleSectionProps)
       <h1 className="heading-h2">{title}</h1>
       <div className="flex items-center gap-2">
         <span>{desc}</span>
-        {link && linkPath && (
+        {link && linkPath ? (
           <Link href={linkPath} className="text-primary-600">
             {link}
           </Link>
-        )}
+        ) : null}
       </div>
     </div>
   )

--- a/src/features/my-page/MyPage.tsx
+++ b/src/features/my-page/MyPage.tsx
@@ -299,13 +299,13 @@ function MyPage() {
           <ProfileData setIsWithdrawModalOpen={setIsWithdrawModalOpen} data={myData!} isMyProfile />
           <section className="relative flex flex-1 flex-col gap-3.5 md:gap-7">
             <AnimatePresence>
-              {unblockError && (
+              {unblockError ? (
                 <div className="absolute top-11 left-1/2 z-50 w-11/12 -translate-x-1/2 md:w-auto md:pt-8">
                   <InlineNotification type="error" onClose={() => setUnblockError(null)}>
                     {unblockError}
                   </InlineNotification>
                 </div>
-              )}
+              ) : null}
             </AnimatePresence>
             <Tabs
               tabs={MY_PAGE_TABS}

--- a/src/features/my-page/components/MyList.tsx
+++ b/src/features/my-page/components/MyList.tsx
@@ -135,7 +135,7 @@ export default function MyList({ id, title, price, mainImageUrl, tradeStatus, vi
   const handleMoreToggle = (e: React.MouseEvent) => {
     e.preventDefault()
     e.stopPropagation()
-    setIsMoreMenuOpen(!isMoreMenuOpen)
+    setIsMoreMenuOpen((prev) => !prev)
   }
   return (
     <li id={id.toString()} className="w-full pt-5 pb-5 md:p-0">
@@ -154,21 +154,21 @@ export default function MyList({ id, title, price, mainImageUrl, tradeStatus, vi
             onError={handleImageError}
             unoptimized={imgError || usePlaceholder || !mainImageUrl}
           />
-          {!isMd && trade_status && <Badge className={cn('absolute top-2 left-2 bg-[#48BB78] text-white', productTradeColor)}>{trade_status}</Badge>}
+          {!isMd && trade_status ? <Badge className={cn('absolute top-2 left-2 bg-[#48BB78] text-white', productTradeColor)}>{trade_status}</Badge> : null}
         </div>
         <div className="flex flex-1 items-start">
           <div className="flex h-fit flex-1 flex-col items-start gap-2">
-            {isMd && trade_status && <Badge className={cn('bg-[#48BB78] text-white', productTradeColor)}>{trade_status}</Badge>}
+            {isMd && trade_status ? <Badge className={cn('bg-[#48BB78] text-white', productTradeColor)}>{trade_status}</Badge> : null}
             <div className="flex w-full items-start justify-between">
               <div className="flex w-full flex-col gap-1">
-                {isMd && <h3 className="heading-h5 line-clamp-2 w-96 truncate">{title}</h3>}
-                {!isMd && (
+                {isMd ? <h3 className="heading-h5 line-clamp-2 w-96 truncate">{title}</h3> : null}
+                {!isMd ? (
                   <div className="relative flex w-full items-start justify-between gap-2">
                     <h3 className="line-clamp-2 w-full text-[17px] font-bold">{title}</h3>
                     <IconButton size="sm" onClick={handleMoreToggle} aria-label="상품 옵션 메뉴 열기">
                       <EllipsisVertical size={16} className="text-gray-500" />
                     </IconButton>
-                    {isMoreMenuOpen && (
+                    {isMoreMenuOpen ? (
                       <div
                         className={cn(
                           'absolute top-7 right-0 flex w-fit flex-col items-end rounded-lg border border-gray-300 bg-white',
@@ -176,7 +176,7 @@ export default function MyList({ id, title, price, mainImageUrl, tradeStatus, vi
                         )}
                         ref={modalRef}
                       >
-                        {isMyProductTab && !isCompleted && (
+                        {isMyProductTab && !isCompleted ? (
                           <Button
                             size="sm"
                             className="hover:bg-primary-300 w-fit cursor-pointer gap-3 rounded-none border-b border-gray-300 hover:font-bold hover:text-white"
@@ -185,7 +185,7 @@ export default function MyList({ id, title, price, mainImageUrl, tradeStatus, vi
                             <SquarePen size={16} />
                             <span>수정</span>
                           </Button>
-                        )}
+                        ) : null}
                         <Button
                           size="sm"
                           className="text-danger-500 hover:bg-primary-300 w-fit cursor-pointer gap-3 rounded-none hover:font-bold hover:text-white"
@@ -197,12 +197,12 @@ export default function MyList({ id, title, price, mainImageUrl, tradeStatus, vi
                           <span>삭제</span>
                         </Button>
                       </div>
-                    )}
+                    ) : null}
                   </div>
-                )}
+                ) : null}
                 <span className="font-bold text-gray-500 md:font-medium">{formatPrice(price)} 원</span>
-                {!isMd && !isCompleted && isSalesTab && <StatusDropdown className="w-full" value={currentTradeStatusKo} onChange={handleProductType} />}
-                {!isMd && !isCompleted && isPurchasesTab && (
+                {!isMd && !isCompleted && isSalesTab ? <StatusDropdown className="w-full" value={currentTradeStatusKo} onChange={handleProductType} /> : null}
+                {!isMd && !isCompleted && isPurchasesTab ? (
                   <Button
                     size="sm"
                     className="h-fit w-32 flex-1 cursor-pointer border border-gray-300 hover:bg-gray-300"
@@ -210,14 +210,14 @@ export default function MyList({ id, title, price, mainImageUrl, tradeStatus, vi
                   >
                     구매완료
                   </Button>
-                )}
+                ) : null}
               </div>
             </div>
             <ProductMetaItem icon={Eye} label={`조회 ${viewCount}`} className="text-sm text-gray-400" />
           </div>
           <div className="flex flex-col items-end gap-2">
-            {isMd && !isCompleted && isSalesTab && <StatusDropdown className="w-32" value={currentTradeStatusKo} onChange={handleProductType} />}
-            {isMd && !isCompleted && isPurchasesTab && (
+            {isMd && !isCompleted && isSalesTab ? <StatusDropdown className="w-32" value={currentTradeStatusKo} onChange={handleProductType} /> : null}
+            {isMd && !isCompleted && isPurchasesTab ? (
               <Button
                 size="sm"
                 className="h-fit w-32 flex-1 cursor-pointer border border-gray-300 hover:bg-gray-300"
@@ -225,10 +225,10 @@ export default function MyList({ id, title, price, mainImageUrl, tradeStatus, vi
               >
                 구매완료
               </Button>
-            )}
-            {isMd && (
+            ) : null}
+            {isMd ? (
               <div className="flex w-full min-w-32 gap-1">
-                {isMyProductTab && !isCompleted && (
+                {isMyProductTab && !isCompleted ? (
                   <Button
                     size="sm"
                     className="hover:bg-primary-300 flex-1 cursor-pointer border border-gray-300 hover:font-bold hover:text-white"
@@ -236,7 +236,7 @@ export default function MyList({ id, title, price, mainImageUrl, tradeStatus, vi
                   >
                     수정
                   </Button>
-                )}
+                ) : null}
                 <Button
                   size="sm"
                   className="hover:bg-primary-300 flex-1 cursor-pointer border border-gray-300 hover:font-bold hover:text-white"
@@ -245,7 +245,7 @@ export default function MyList({ id, title, price, mainImageUrl, tradeStatus, vi
                   {isWishlistTab ? '찜 취소' : '삭제'}
                 </Button>
               </div>
-            )}
+            ) : null}
           </div>
         </div>
       </Link>

--- a/src/features/my-page/components/MyPagePanel.tsx
+++ b/src/features/my-page/components/MyPagePanel.tsx
@@ -155,10 +155,10 @@ export default function MyPagePanel({
                   <MyList key={product.id} {...product} activeTab={activeMyPageTab} handleConfirmModal={handleConfirmModal} />
                 ))}
               </ul>
-              {hasNextPage && <LoadMoreButton onClick={() => fetchNextPage()} isLoading={isFetchingNextPage} />}
+              {hasNextPage ? <LoadMoreButton onClick={() => fetchNextPage()} isLoading={isFetchingNextPage} /> : null}
             </>
           ) : (
-            config && <EmptyState icon={config.emptyIcon} title={config.emptyTitle} description={config.emptyDescription} />
+            config ? <EmptyState icon={config.emptyIcon} title={config.emptyTitle} description={config.emptyDescription} /> : null
           )
         ) : myBlockedData?.length ? (
           <>
@@ -177,7 +177,7 @@ export default function MyPagePanel({
                 </li>
               ))}
             </ul>
-            {hasNextPage && <LoadMoreButton onClick={() => fetchNextPage()} isLoading={isFetchingNextPage} />}
+            {hasNextPage ? <LoadMoreButton onClick={() => fetchNextPage()} isLoading={isFetchingNextPage} /> : null}
           </>
         ) : null}
       </div>

--- a/src/features/my-page/components/MyPageTitle.tsx
+++ b/src/features/my-page/components/MyPageTitle.tsx
@@ -25,9 +25,9 @@ export default function MyPageTitle({ heading, count, description, buttonLabel, 
     <div className="flex justify-between">
       <div>
         <h2 className="flex items-center gap-2 text-lg font-bold">{heading}</h2>
-        {description && <p>{count !== undefined ? `총 ${count}${description}` : description}</p>}
+        {description ? <p>{count !== undefined ? `총 ${count}${description}` : description}</p> : null}
       </div>
-      {buttonLabel && (
+      {buttonLabel ? (
         <Button
           size="sm"
           icon={Plus}
@@ -37,7 +37,7 @@ export default function MyPageTitle({ heading, count, description, buttonLabel, 
         >
           {buttonLabel}
         </Button>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/src/features/product-detail/components/ProductBadges.tsx
+++ b/src/features/product-detail/components/ProductBadges.tsx
@@ -22,7 +22,7 @@ export default function ProductBadges({ tradeStatus, petDetailType, category, pr
 
   return (
     <div className="flex items-center gap-2 md:gap-1">
-      {tradeStatus && <Badge className={cn('px-2.5 py-1.5 text-sm font-semibold text-white', productTradeColor)}>{productTradeName}</Badge>}
+      {tradeStatus ? <Badge className={cn('px-2.5 py-1.5 text-sm font-semibold text-white', productTradeColor)}>{productTradeName}</Badge> : null}
       <Badge className={cn('bg-primary-700 px-2.5 py-1.5 text-sm font-semibold text-white')}>{petTypeName}</Badge>
       <Badge className={cn('border bg-white px-2.5 py-1.5 text-sm font-semibold text-gray-900')}>{categoryName}</Badge>
       <Badge className={cn('bg-primary-200 px-2.5 py-1.5 text-sm font-semibold')}>{productStatusName}</Badge>

--- a/src/features/product-post/ProductPost.tsx
+++ b/src/features/product-post/ProductPost.tsx
@@ -88,7 +88,7 @@ function ProductPost() {
       <div className="bg-[#F3F4F6] pt-5">
         <div className="px-lg pb-4xl mx-auto max-w-7xl">
           <div className="gap-2xl flex w-full flex-col">
-            {!isEditMode && (
+            {!isEditMode ? (
               <Tabs
                 tabs={PRODUCT_TYPE_TABS}
                 activeTab={activeProductTypeTab}
@@ -96,13 +96,13 @@ function ProductPost() {
                 ariaLabel="상품 타입"
                 excludeTabId="tab-all"
               />
-            )}
-            {activeProductTypeTab === 'tab-sales' && (
+            ) : null}
+            {activeProductTypeTab === 'tab-sales' ? (
               <ProductPostForm isEditMode={isEditMode} productId={id} initialData={productData} />
-            )}
-            {activeProductTypeTab === 'tab-purchases' && (
+            ) : null}
+            {activeProductTypeTab === 'tab-purchases' ? (
               <ProductRequestForm isEditMode={isEditMode} productId={id} initialData={productData} />
-            )}
+            ) : null}
           </div>
         </div>
       </div>

--- a/src/features/product-post/components/FormSectionHeader.tsx
+++ b/src/features/product-post/components/FormSectionHeader.tsx
@@ -8,7 +8,7 @@ export default function FormSectionHeader({ heading, description, headingClassNa
   return (
     <div className="flex flex-col gap-1">
       <h2 className={headingClassName ?? 'heading-h3'}>{heading}</h2>
-      {description && <p>{description}</p>}
+      {description ? <p>{description}</p> : null}
     </div>
   )
 }

--- a/src/features/product-post/components/basicInfoSection/BasicInfoSection.tsx
+++ b/src/features/product-post/components/basicInfoSection/BasicInfoSection.tsx
@@ -52,7 +52,7 @@ export default function BasicInfoSection({
               placeholder="카테고리를 선택해주세요"
               buttonClassName="border-gray-400 bg-white border text-gray-900 px-3 py-3 border"
             />
-            {fieldState.error && <p className="text-xs font-semibold text-red-500">{fieldState.error.message}</p>}
+            {fieldState.error ? <p className="text-xs font-semibold text-red-500">{fieldState.error.message}</p> : null}
           </div>
         )}
       />

--- a/src/features/product-post/components/basicInfoSection/components/ProductDescriptionFiled.tsx
+++ b/src/features/product-post/components/basicInfoSection/components/ProductDescriptionFiled.tsx
@@ -30,7 +30,7 @@ export function ProductDescriptionFiled({
         )}
         {...register('description', productPostValidationRules.description)}
       />
-      {errors.description && <p className="text-xs font-semibold text-red-500">{errors.description.message}</p>}
+      {errors.description ? <p className="text-xs font-semibold text-red-500">{errors.description.message}</p> : null}
     </div>
   )
 }

--- a/src/features/product-post/components/imageUploadField/ImageUploadField.tsx
+++ b/src/features/product-post/components/imageUploadField/ImageUploadField.tsx
@@ -48,7 +48,7 @@ export default function ImageUploadField<T extends FieldValues>({
         subImagesField={subImagesField}
         maxFiles={maxFiles}
       />
-      {errorMessage && <p className="text-danger-500 text-sm font-semibold">{errorMessage}</p>}
+      {errorMessage ? <p className="text-danger-500 text-sm font-semibold">{errorMessage}</p> : null}
     </div>
   )
 

--- a/src/features/product-post/components/imageUploadField/components/SortableImageItem.tsx
+++ b/src/features/product-post/components/imageUploadField/components/SortableImageItem.tsx
@@ -35,7 +35,7 @@ export default function SortableImageItem({ url, index, onRemove }: SortableImag
       <div className="h-full w-full cursor-grab active:cursor-grabbing" {...listeners}>
         <Image src={url} alt={`preview-${index}`} fill className="object-cover" unoptimized />
       </div>
-      {index === 0 && <Badge className="absolute top-1 left-1 bg-gray-900 text-white">대표</Badge>}
+      {index === 0 ? <Badge className="absolute top-1 left-1 bg-gray-900 text-white">대표</Badge> : null}
     </div>
   )
 }

--- a/src/features/product-post/components/imageUploadField/components/SortableImageList.tsx
+++ b/src/features/product-post/components/imageUploadField/components/SortableImageList.tsx
@@ -20,9 +20,9 @@ export default function SortableImageList({ previewUrls, onDragEnd, onRemoveImag
           {previewUrls.map((imgUrl, i) => (
             <SortableImageItem key={imgUrl} url={imgUrl} index={i} onRemove={() => onRemoveImage(i)} />
           ))}
-          {previewUrls.length < 5 && (
+          {previewUrls.length < 5 ? (
             <Button size={isMd ? 'lg' : 'sm'} className="bg-primary-300 flex cursor-pointer flex-col rounded-full text-white" icon={Plus} />
-          )}
+          ) : null}
         </div>
       </SortableContext>
     </DndContext>

--- a/src/features/product-post/components/priceAndStatusSection/PriceAndStatusSection.tsx
+++ b/src/features/product-post/components/priceAndStatusSection/PriceAndStatusSection.tsx
@@ -25,7 +25,7 @@ export default function PriceAndStatusSection({
     <section className="flex flex-col gap-5 rounded-xl border border-gray-100 bg-white px-6 py-5">
       <FormSectionHeader heading={heading} />
       <PriceField register={register} errors={errors} label={priceLabel} suffix="원" />
-      {showProductStateFilter && (
+      {showProductStateFilter ? (
         <Controller
           name="productStatus"
           control={control}
@@ -39,11 +39,11 @@ export default function PriceAndStatusSection({
                 selectedProductStatus={field.value || null}
                 onProductStatusChange={(status) => field.onChange(status ?? '')}
               />
-              {fieldState.error && <p className="text-xs font-semibold text-red-500">{fieldState.error.message}</p>}
+              {fieldState.error ? <p className="text-xs font-semibold text-red-500">{fieldState.error.message}</p> : null}
             </>
           )}
         />
-      )}
+      ) : null}
     </section>
   )
 }

--- a/src/features/profile-update/ProfileUpdate.tsx
+++ b/src/features/profile-update/ProfileUpdate.tsx
@@ -109,16 +109,16 @@ function ProfileUpdate() {
       <div className="pb-4xl bg-[#F3F4F6] pt-0 md:bg-white md:pt-8">
         <h1 className="sr-only">프로필 수정</h1>
         <div className="mx-auto flex max-w-7xl flex-col gap-0 md:flex-row md:gap-8 md:p-0">
-          {isMd && <ProfileData setIsWithdrawModalOpen={setIsWithdrawModalOpen} data={myData!} isMyProfile />}
-          {!isMd && (
+          {isMd ? <ProfileData setIsWithdrawModalOpen={setIsWithdrawModalOpen} data={myData!} isMyProfile /> : null}
+          {!isMd ? (
             <div className="flex flex-col gap-2 border-b border-gray-200 bg-white p-5">
               <h2 className="heading-h3">기본 정보</h2>
               <p className="text-gray-500">프로필 이미지, 닉네임, 거주지를 수정할 수 있습니다</p>
             </div>
-          )}
+          ) : null}
           <div className="flex w-full flex-col gap-8 p-5 md:p-0">
             <ProfileUpdateBaseForm myData={myData!} />
-            {!isSocialLogin && <ProfileUpdatePasswordForm />}
+            {!isSocialLogin ? <ProfileUpdatePasswordForm /> : null}
           </div>
         </div>
       </div>

--- a/src/features/profile-update/components/ProfileUpdateBaseForm.tsx
+++ b/src/features/profile-update/components/ProfileUpdateBaseForm.tsx
@@ -205,12 +205,12 @@ export default function ProfileUpdateBaseForm({ myData }: ProfileUpdateBaseFormP
     <form className="flex w-full flex-col gap-6 rounded-xl border border-gray-200 bg-white p-5 md:p-7" onSubmit={handleSubmit(onSubmit)}>
       <fieldset className="flex flex-col gap-8">
         <legend className="sr-only">프로필 정보 수정 폼</legend>
-        {isMd && (
+        {isMd ? (
           <div className="flex flex-col gap-2">
             <h2 className="heading-h3">기본 정보</h2>
             <p className="text-gray-500">프로필 이미지, 닉네임, 거주지를 수정할 수 있습니다</p>
           </div>
-        )}
+        ) : null}
 
         <div className="flex flex-col gap-6">
           <div className="flex flex-col gap-10">
@@ -243,7 +243,7 @@ export default function ProfileUpdateBaseForm({ myData }: ProfileUpdateBaseFormP
                   <Camera className="" size={20} />
                 </button>
               </div>
-              {errors.profileImageUrl && <p className="text-danger-500 text-xs font-semibold">{errors.profileImageUrl.message}</p>}
+              {errors.profileImageUrl ? <p className="text-danger-500 text-xs font-semibold">{errors.profileImageUrl.message}</p> : null}
               <p className="text-sm">프로필 사진을 변경하려면 카메라 아이콘을 클릭하세요</p>
             </div>
 
@@ -324,7 +324,7 @@ export default function ProfileUpdateBaseForm({ myData }: ProfileUpdateBaseFormP
                       {...register('introduction', profileValidationRules.introduction)}
                     />
                     <p className="text-sm font-semibold text-gray-400">{titleLength}/1000자</p>
-                    {errors.introduction && <p className="text-danger-500 text-xs font-semibold"> {errors.introduction.message}</p>}
+                    {errors.introduction ? <p className="text-danger-500 text-xs font-semibold"> {errors.introduction.message}</p> : null}
                   </div>
                 </div>
               </div>
@@ -334,21 +334,21 @@ export default function ProfileUpdateBaseForm({ myData }: ProfileUpdateBaseFormP
               본인 인증 정보의 변경이 필요한 경우, 고객센터 1:1 문의를 통해 문의주세요.
             </p>
             <AnimatePresence>
-              {updateError && (
+              {updateError ? (
                 <InlineNotification type="error" onClose={() => setUpdateError(null)}>
                   {updateError}
                 </InlineNotification>
-              )}
-              {updateSuccess && (
+              ) : null}
+              {updateSuccess ? (
                 <InlineNotification type="success" onClose={() => setUpdateSuccess(null)}>
                   {updateSuccess}
                 </InlineNotification>
-              )}
-              {updateWarning && (
+              ) : null}
+              {updateWarning ? (
                 <InlineNotification type="warning" onClose={() => setUpdateWarning(null)}>
                   {updateWarning}
                 </InlineNotification>
-              )}
+              ) : null}
             </AnimatePresence>
           </div>
           <Button size="md" className="bg-primary-300 w-full cursor-pointer text-white" type="submit">

--- a/src/features/profile-update/components/ProfileUpdatePasswordForm.tsx
+++ b/src/features/profile-update/components/ProfileUpdatePasswordForm.tsx
@@ -170,21 +170,21 @@ export default function ProfileUpdatePasswordForm() {
             />
           </div>
           <AnimatePresence>
-            {pwUpdateError && (
+            {pwUpdateError ? (
               <InlineNotification type="error" onClose={() => setPwUpdateError(null)}>
                 {pwUpdateError}
               </InlineNotification>
-            )}
-            {pwUpdateSuccess && (
+            ) : null}
+            {pwUpdateSuccess ? (
               <InlineNotification type="success" onClose={() => setPwUpdateSuccess(null)}>
                 {pwUpdateSuccess}
               </InlineNotification>
-            )}
-            {pwUpdateWarning && (
+            ) : null}
+            {pwUpdateWarning ? (
               <InlineNotification type="warning" onClose={() => setPwUpdateWarning(null)}>
                 {pwUpdateWarning}
               </InlineNotification>
-            )}
+            ) : null}
           </AnimatePresence>
           <Button size="md" className="bg-primary-300 w-full cursor-pointer text-white" type="submit">
             비밀번호 변경

--- a/src/features/signup/components/BirthDateField.tsx
+++ b/src/features/signup/components/BirthDateField.tsx
@@ -105,7 +105,7 @@ export function BirthDateField<T extends FieldValues>({ control }: BirthDateFiel
                   className="focus:border-primary-500 w-full rounded-lg border border-gray-400 px-3 py-2 text-sm placeholder:text-gray-400 focus:outline-none md:py-3"
                 />
               </div>
-              {fieldState.error && <p className="text-danger-500 text-xs font-semibold">{fieldState.error.message}</p>}
+              {fieldState.error ? <p className="text-danger-500 text-xs font-semibold">{fieldState.error.message}</p> : null}
             </div>
           )
         }}

--- a/src/features/signup/components/SignUpForm.tsx
+++ b/src/features/signup/components/SignUpForm.tsx
@@ -170,11 +170,11 @@ export function SignUpForm() {
           <PasswordField register={register} errors={errors} control={control} setError={setError} clearErrors={clearErrors} />
         </div>
         <AnimatePresence>
-          {signupNotification && (
+          {signupNotification ? (
             <InlineNotification type={signupNotification.type} onClose={() => setSignupNotification(null)}>
               {signupNotification.message}
             </InlineNotification>
-          )}
+          ) : null}
         </AnimatePresence>
         <Button size="md" className="bg-primary-300 w-full cursor-pointer text-white" type="submit" disabled={isSubmitting}>
           {isSubmitting ? '가입 중...' : '회원가입'}

--- a/src/features/signup/components/SocialSignUpForm.tsx
+++ b/src/features/signup/components/SocialSignUpForm.tsx
@@ -132,11 +132,11 @@ export function SocialSignUpForm() {
           <BirthDateField control={control} />
         </div>
         <AnimatePresence>
-          {signupNotification && (
+          {signupNotification ? (
             <InlineNotification type={signupNotification.type} onClose={() => setSignupNotification(null)}>
               {signupNotification.message}
             </InlineNotification>
-          )}
+          ) : null}
         </AnimatePresence>
         <Button size="md" className="bg-primary-300 w-full cursor-pointer text-white" type="submit" disabled={isSubmitting}>
           {isSubmitting ? '가입 중...' : '회원가입'}


### PR DESCRIPTION
## 📌 개요

- Vercel React Best Practice Skill(58개 규칙)로 메인 그룹 코드(src/ 전체, admin 제외)를 스캔하여 발견된 5가지 위반 사항을 리팩토링

## 🔧 작업 내용

- [x] `bundle-dynamic-imports` (CRITICAL): MdPreview.tsx — react-markdown을 next/dynamic으로 지연 로딩 (CommunityDetail, Markdown 2개소)
- [x] `client-swr-dedup` (MEDIUM-HIGH): CommunityPostForm.tsx — useEffect+fetchGraphQL을 useQuery로 전환
- [x] `rerender-dependencies` (MEDIUM): LocationFilter.tsx — eslint-disable 제거, useEffect → 이벤트 핸들러로 URL 동기화 리팩토링
- [x] `rerender-functional-setstate` (MEDIUM): 7개 파일 10개소 — `setState(!value)` → `setState(prev => !prev)` 함수형 업데이터 + prop 타입 `React.Dispatch<React.SetStateAction<boolean>>` 적용
- [x] `rendering-conditional-render` (MEDIUM): 69개 파일 — `&&` 조건부 렌더링 → 삼항 연산자 (`? : null`) 일괄 전환

## 📎 관련 이슈

Closes #456

## 💬 리뷰어 참고 사항

- 어드민 그룹 리팩토링(#455)에 이어 메인 그룹 전체를 동일 규칙으로 리팩토링
- `rendering-conditional-render` 변경이 69개 파일로 가장 많지만, 모두 `&& → ? : null` 기계적 변환
- `LocationFilter.tsx`의 eslint-disable 제거는 useEffect → 이벤트 핸들러 구조 변경으로 해결