### PR TITLE
fix: 관리자 로그인 시 userRole 누락으로 어드민 접근 불가 수정(#462)

### DIFF
--- a/src/features/admin/components/auth/AdminLogin.tsx
+++ b/src/features/admin/components/auth/AdminLogin.tsx
@@ -53,7 +53,7 @@ export default function AdminLogin() {
       }
 
       // ADMIN 확인 후 최종 로그인 처리
-      handleLogin(user, accessToken, refreshToken)
+      handleLogin({ ...user, userRole }, accessToken, refreshToken)
       router.push(ROUTES.ADMIN)
     } catch {
       useUserStore.getState().clearAll()


### PR DESCRIPTION
## 📌 개요

- 관리자 로그인 후 어드민 페이지 접근 불가 버그 수정
- 로그인 응답의 user 객체에 userRole이 없어 AdminAuthGuard에서 항상 리다이렉트되는 문제

## 🔧 작업 내용

- [ ] AdminLogin에서 handleLogin 호출 시 /profile/me에서 가져온 userRole을 user 객체에 병합

## 📎 관련 이슈

Closes #462

## 📋 QA 티켓

https://www.notion.so/320f2b30796181a7ba4df7ee68ee5eab

## 💬 리뷰어 참고 사항

- 1줄 변경: `handleLogin(user, accessToken, refreshToken)` → `handleLogin({ ...user, userRole }, accessToken, refreshToken)`
- /profile/me 응답에서 확인한 userRole을 Zustand store에 저장하여 AdminAuthGuard가 정상 동작하도록 함