### PR TITLE
fix: 로그인 상태 메인 페이지 hydration mismatch 수정(#464)

### DIFF
--- a/src/components/header/components/MobileNavigation.tsx
+++ b/src/components/header/components/MobileNavigation.tsx
@@ -30,6 +30,7 @@ export default function MobileNavigation({ isOpen, onClose }: MobileNavigationPr
   useOutsideClick(isOpen, [sideNavRef], onClose)
 
   const { isLogin } = useUserStore()
+  const hasHydrated = useUserStore((state) => state._hasHydrated)
   const { openLogoutConfirm } = useLogout(onClose)
 
   useEffect(() => {
@@ -75,7 +76,7 @@ export default function MobileNavigation({ isOpen, onClose }: MobileNavigationPr
             </IconButton>
           </div>
           <div className="flex items-center gap-2">
-            {isLogin() ? (
+            {hasHydrated && isLogin() ? (
               <button
                 type="button"
                 onClick={openLogoutConfirm}
@@ -93,11 +94,11 @@ export default function MobileNavigation({ isOpen, onClose }: MobileNavigationPr
               </Link>
             )}
             <Link
-              href={isLogin() ? ROUTES.MYPAGE : ROUTES.SIGNUP}
+              href={hasHydrated && isLogin() ? ROUTES.MYPAGE : ROUTES.SIGNUP}
               onClick={onClose}
               className="border-primary-200 bg-primary-200 flex-1 rounded-sm border py-2 text-center text-sm font-bold text-white"
             >
-              {isLogin() ? '마이페이지' : '회원가입'}
+              {hasHydrated && isLogin() ? '마이페이지' : '회원가입'}
             </Link>
           </div>
         </div>

--- a/src/components/header/components/UserControls.tsx
+++ b/src/components/header/components/UserControls.tsx
@@ -24,6 +24,7 @@ export default function UserControls({ isSideOpen, setIsSideOpen, hideMenuButton
   const user = useUserStore((state) => state.user)
   const [isNotificationOpen, setIsNotificationOpen] = useState(false)
   const { isLogin } = useUserStore()
+  const hasHydrated = useUserStore((state) => state._hasHydrated)
   useNotificationSSE()
   const handleBellToggle = () => {
     setIsNotificationOpen((prev) => !prev)
@@ -43,7 +44,7 @@ export default function UserControls({ isSideOpen, setIsSideOpen, hideMenuButton
 
   return (
     <div className="flex items-center gap-2 xl:gap-4">
-      {isLogin() ? (
+      {hasHydrated && isLogin() ? (
         <div className="flex items-center gap-1">
           <Link href={ROUTES.CHAT} className="ml-1" aria-label="채팅">
             <MessageCircleMore className="text-white" strokeWidth={1.5} />

--- a/src/features/community/CommunityPage.tsx
+++ b/src/features/community/CommunityPage.tsx
@@ -167,6 +167,7 @@ export default function CommunityPage({ initialQuestionData, initialInfoData }: 
 
   // const { title: headerTitle, description: headerDescription } = getHeaderContent()
   const { isLogin } = useUserStore()
+  const hasHydrated = useUserStore((state) => state._hasHydrated)
 
   // 페이지 진입 시 스크롤 최상단으로 이동
   useEffect(() => {
@@ -269,7 +270,7 @@ export default function CommunityPage({ initialQuestionData, initialInfoData }: 
                   onTabChange={handleTabChange}
                   ariaLabel="커뮤니티 타입"
                 />
-                {isLogin() ? (
+                {hasHydrated && isLogin() ? (
                   <Link
                     href={`${ROUTES.COMMUNITY_POST}?tab=${activeCommunityTypeTab}`}
                     className="bg-primary-300 rounded-lg px-3 py-2 text-white"
@@ -397,7 +398,7 @@ export default function CommunityPage({ initialQuestionData, initialInfoData }: 
           ) : null}
         </div>
       </div>
-      {!isMd && isLogin() ? (
+      {!isMd && hasHydrated && isLogin() ? (
         <Link
           href={`${ROUTES.COMMUNITY_POST}?tab=${activeCommunityTypeTab}`}
           className={`bg-primary-200 fixed right-4 bottom-4 rounded-full px-3 py-3 text-white ${Z_INDEX.FLOATING_BUTTON}`}

--- a/src/features/home/Home.tsx
+++ b/src/features/home/Home.tsx
@@ -22,7 +22,8 @@ import { productListQueryKey, extractProductSearchParams } from '@/lib/queries/p
 
 function Home() {
   const { isLogin } = useUserStore()
-  const isLoggedIn = isLogin()
+  const hasHydrated = useUserStore((state) => state._hasHydrated)
+  const isLoggedIn = hasHydrated && isLogin()
   const isMd = useMediaQuery('(min-width: 768px)')
   const { searchParams, pathname, push } = useFilterNavigation()
   const router = useRouter()


### PR DESCRIPTION
## 📌 개요

- 로그인 상태에서 메인 페이지 새로고침 시 React error #418 (Hydration mismatch) 수정
- Zustand store의 `_hasHydrated` 플래그를 활용하여 hydration 전에는 서버와 동일한 UI를 렌더링

## 🔧 작업 내용

- [x] UserControls: `_hasHydrated` 체크 추가하여 hydration 전 비로그인 UI 유지
- [x] Home: 플로팅 버튼 조건에 `_hasHydrated` 체크 추가
- [x] MobileNavigation: 로그인/로그아웃, 마이페이지/회원가입 분기에 `_hasHydrated` 체크 추가
- [x] CommunityPage: 글쓰기 버튼, 플로팅 버튼 조건에 `_hasHydrated` 체크 추가

## 📎 관련 이슈

Closes #464

## 📋 QA 티켓

https://www.notion.so/320f2b307961812398a8c0ac84f9e939

## 💬 리뷰어 참고 사항

- 이전 수정(#282)에서 `skipHydration`으로 우회했으나 근본 해결 아니었음
- 이번 수정: `_hasHydrated` 플래그로 hydration 완료 전까지 서버 렌더링과 동일한 UI 유지
- hydration 완료 후 React가 정상 re-render하여 로그인 UI로 전환 (mismatch 없음)
- `ProductList.tsx`, `SellerProfileCard.tsx`의 `isLogin()` 사용은 이벤트 핸들러 내부(클릭 시)이므로 hydration과 무관하여 수정 불필요