### PR TITLE
fix: 커뮤니티 페이지 GraphQL → REST API 전환(#466)

### DIFF
--- a/src/features/community/CommunityDetail.tsx
+++ b/src/features/community/CommunityDetail.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter, useParams, usePathname, useSearchParams } from 'next/navigation'
 import { useMutation, useQueryClient, useQuery } from '@tanstack/react-query'
-import { fetchGraphQL } from '@/lib/api/graphql'
+import { api } from '@/lib/api/api'
 import dynamic from 'next/dynamic'
 
 const MdPreview = dynamic(() => import('./components/markdown/MdPreview'), {
@@ -32,69 +32,6 @@ import SimpleHeader from '@/components/header/SimpleHeader'
 import InlineNotification from '@/components/commons/InlineNotification'
 import { useOutsideClick } from '@/hooks/useOutsideClick'
 
-const GET_COMMUNITY_POST = `
-  query GetCommunityPost($id: Int!) {
-    communityPost(id: $id) {
-      id
-      title
-      content
-      authorNickname
-      authorProfileImageUrl
-      authorId
-      boardType
-      viewCount
-      commentCount
-      createdAt
-      updatedAt
-      imageUrls
-    }
-  }
-`
-
-const GET_COMMUNITY_COMMENTS = `
-  query GetCommunityComments($postId: Int!, $page: Int, $size: Int) {
-    communityPostComments(postId: $postId, page: $page, size: $size) {
-      comments {
-        id
-        content
-        authorId
-        authorNickname
-        authorProfileImageUrl
-        createdAt
-        depth
-        parentId
-        hasChildren
-        childrenCount
-      }
-    }
-  }
-`
-
-const CREATE_COMMENT = `
-  mutation CreateComment($postId: Int!, $content: String!) {
-    createComment(postId: $postId, content: $content) {
-      success
-    }
-  }
-`
-
-const DELETE_POST = `
-  mutation DeletePost($id: Int!) {
-    deletePost(id: $id) {
-      success
-    }
-  }
-`
-
-interface GetCommunityPostData {
-  communityPost: CommunityDetailItem
-}
-
-interface GetCommunityCommentsData {
-  communityPostComments: {
-    comments: Comment[]
-  }
-}
 
 interface CommunityDetailProps {
   initialPostData?: CommunityDetailItem
@@ -138,23 +75,29 @@ export default function CommunityDetail({ initialPostData, initialCommentData }:
     error,
   } = useQuery({
     queryKey: ['community', id],
-    queryFn: () => fetchGraphQL<GetCommunityPostData>(GET_COMMUNITY_POST, { id: Number(id) }),
+    queryFn: async () => {
+      const response = await api.get(`/community/posts/${id}`)
+      return response.data.data as CommunityDetailItem
+    },
     enabled: !!id,
   })
 
-  const data = postQueryData?.communityPost ?? initialPostData
+  const data = postQueryData ?? initialPostData
 
   const { data: commentQueryData, isLoading: isLoadingCommentData } = useQuery({
     queryKey: ['community', id, 'comments'],
-    queryFn: () => fetchGraphQL<GetCommunityCommentsData>(GET_COMMUNITY_COMMENTS, { postId: Number(id), page: 0, size: 100 }),
+    queryFn: async () => {
+      const response = await api.get(`/community/posts/${id}/comments`, { params: { page: 0, size: 100 } })
+      return response.data.data as { comments: Comment[] }
+    },
     enabled: !!id,
   })
 
-  const commentData = commentQueryData?.communityPostComments ?? initialCommentData ?? undefined
+  const commentData = commentQueryData ?? initialCommentData ?? undefined
 
   const replyMutation = useMutation({
     mutationFn: (requestData: CommentPostRequestData) =>
-      fetchGraphQL(CREATE_COMMENT, { postId: Number(id), content: requestData.content }),
+      api.post(`/community/posts/${id}/comments`, { content: requestData.content }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['community', id, 'comments'] })
       reset()
@@ -171,7 +114,7 @@ export default function CommunityDetail({ initialPostData, initialCommentData }:
 
   const handlePostDelete = async (postId: number) => {
     try {
-      await fetchGraphQL(DELETE_POST, { id: postId })
+      await api.delete(`/community/posts/${postId}`)
       queryClient.invalidateQueries({ queryKey: ['community'] })
       router.push('/community')
     } catch {

--- a/src/features/community/CommunityPage.tsx
+++ b/src/features/community/CommunityPage.tsx
@@ -9,7 +9,7 @@ import SearchBar from '@/components/header/components/SearchBar'
 import SelectDropdown from '@/components/commons/select/SelectDropdown'
 import { ROUTES } from '@/constants/routes'
 import { useInfiniteQuery } from '@tanstack/react-query'
-import { fetchGraphQL } from '@/lib/api/graphql'
+import { api } from '@/lib/api/api'
 import { UserRound, Clock, MessageSquare, Eye, Dot, Plus, MessageSquareText } from 'lucide-react'
 import LoadMoreButton from '@/components/commons/button/LoadMoreButton'
 import { getTimeAgo } from '@/lib/utils/getTimeAgo'
@@ -96,15 +96,10 @@ export default function CommunityPage({ initialQuestionData, initialInfoData }: 
   } = useInfiniteQuery({
     queryKey: ['community', 'question', searchType, currentKeyword, sortBy],
     queryFn: async ({ pageParam }) => {
-      const data = await fetchGraphQL<{ communityPosts: any }>(`
-        query CommunityPosts($page: Int!, $size: Int!, $boardType: String, $searchType: String, $keyword: String, $sortBy: String) {
-          communityPosts(page: $page, size: $size, boardType: $boardType, searchType: $searchType, keyword: $keyword, sortBy: $sortBy) {
-            content { id title contentPreview authorNickname boardType viewCount commentCount createdAt updatedAt isModified }
-            page hasNext hasPrevious total totalElements numberOfElements
-          }
-        }
-      `, { page: pageParam, size: 10, boardType: 'QUESTION', searchType, keyword: currentKeyword || undefined, sortBy: sortBy || undefined })
-      return data.communityPosts
+      const response = await api.get('/community/posts', {
+        params: { page: pageParam, size: 10, boardType: 'QUESTION', searchType, keyword: currentKeyword || undefined, sortBy: sortBy || undefined },
+      })
+      return response.data.data
     },
     getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.page + 1 : undefined),
     initialPageParam: 0,
@@ -123,15 +118,10 @@ export default function CommunityPage({ initialQuestionData, initialInfoData }: 
   } = useInfiniteQuery({
     queryKey: ['community', 'info', searchType, currentKeyword, sortBy],
     queryFn: async ({ pageParam }) => {
-      const data = await fetchGraphQL<{ communityPosts: any }>(`
-        query CommunityPosts($page: Int!, $size: Int!, $boardType: String, $searchType: String, $keyword: String, $sortBy: String) {
-          communityPosts(page: $page, size: $size, boardType: $boardType, searchType: $searchType, keyword: $keyword, sortBy: $sortBy) {
-            content { id title contentPreview authorNickname boardType viewCount commentCount createdAt updatedAt isModified }
-            page hasNext hasPrevious total totalElements numberOfElements
-          }
-        }
-      `, { page: pageParam, size: 10, boardType: 'INFO', searchType, keyword: currentKeyword || undefined, sortBy: sortBy || undefined })
-      return data.communityPosts
+      const response = await api.get('/community/posts', {
+        params: { page: pageParam, size: 10, boardType: 'INFO', searchType, keyword: currentKeyword || undefined, sortBy: sortBy || undefined },
+      })
+      return response.data.data
     },
     getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.page + 1 : undefined),
     initialPageParam: 0,

--- a/src/features/community/components/CommentList.tsx
+++ b/src/features/community/components/CommentList.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react'
 import { usePathname, useSearchParams } from 'next/navigation'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { fetchGraphQL } from '@/lib/api/graphql'
+import { api } from '@/lib/api/api'
 import type { Comment, CommentPostRequestData } from '@/types'
 import { CommentItem } from './CommentItem'
 import { CommentForm } from './CommentForm'
@@ -46,24 +46,15 @@ export function CommentList({ comments, postId }: CommentListProps) {
   const { data: repliesData } = useQuery({
     queryKey: ['community', postId, 'replies', openRepliesCommentId],
     queryFn: async () => {
-      const data = await fetchGraphQL<{ communityReplies: { comments: Comment[] } }>(`
-        query CommunityReplies($commentId: Int!) {
-          communityReplies(commentId: $commentId) {
-            comments { id content authorId authorNickname authorProfileImageUrl createdAt depth parentId hasChildren childrenCount }
-          }
-        }
-      `, { commentId: openRepliesCommentId })
-      return data.communityReplies
+      const response = await api.get(`/community/comments/${openRepliesCommentId}/replies`)
+      return response.data.data as { comments: Comment[] }
     },
     enabled: !!openRepliesCommentId,
   })
 
   const replyMutation = useMutation({
-    mutationFn: (requestData: CommentPostRequestData) => fetchGraphQL(`
-      mutation CreateComment($postId: Int!, $content: String!, $parentId: Int) {
-        createComment(postId: $postId, content: $content, parentId: $parentId) { success }
-      }
-    `, { postId: Number(postId), content: requestData.content, parentId: requestData.parentId }),
+    mutationFn: (requestData: CommentPostRequestData) =>
+      api.post(`/community/posts/${postId}/comments`, { content: requestData.content, parentId: requestData.parentId }),
     onSuccess: (_data, variables) => {
       const parentId = variables.parentId
       // 대댓글 목록 refetch
@@ -87,11 +78,7 @@ export function CommentList({ comments, postId }: CommentListProps) {
   })
 
   const deleteMutation = useMutation({
-    mutationFn: (commentId: number) => fetchGraphQL(`
-      mutation DeleteComment($commentId: Int!) {
-        deleteComment(commentId: $commentId) { success }
-      }
-    `, { commentId }),
+    mutationFn: (commentId: number) => api.delete(`/community/comments/${commentId}`),
     onSuccess: () => {
       // 댓글 목록 refetch
       queryClient.invalidateQueries({ queryKey: ['community', postId, 'comments'] })


### PR DESCRIPTION
## 📌 개요

커뮤니티 페이지(목록, 상세, 댓글)의 데이터 페칭을 GraphQL BFF(`fetchGraphQL`)에서 REST API 직접 호출(`api` axios 인스턴스)로 전환하여 콜드스타트 지연 문제를 해결합니다.

## 🔧 작업 내용

- **CommunityPage.tsx**: 질문/정보 게시판 `useInfiniteQuery` 2개를 `api.get('/community/posts')` 호출로 전환
- **CommunityDetail.tsx**: 게시글 상세 조회, 댓글 목록 조회, 댓글 작성, 게시글 삭제를 REST API로 전환. GraphQL 쿼리 문자열 및 래퍼 타입(`GetCommunityPostData`, `GetCommunityCommentsData`) 제거
- **CommentList.tsx**: 대댓글 조회, 대댓글 작성, 댓글 삭제를 REST API로 전환

## 📎 관련 이슈

Closes #466