### PR TITLE
fix: 상품 상세/유저 페이지 GraphQL → REST API 전환(#469)

### DIFF
--- a/src/features/UserPage.tsx
+++ b/src/features/UserPage.tsx
@@ -4,7 +4,7 @@ import ProfileData from '@/components/profile/ProfileData'
 import { useState } from 'react'
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useRouter, useParams } from 'next/navigation'
-import { fetchGraphQL } from '@/lib/api/graphql'
+import { api } from '@/lib/api/api'
 import { ProductListItem } from '@/components/product/ProductListItem'
 import LoadMoreButton from '@/components/commons/button/LoadMoreButton'
 import EmptyState from '@/components/EmptyState'
@@ -35,12 +35,8 @@ function UserPage() {
   } = useQuery({
     queryKey: ['userPage', id],
     queryFn: async () => {
-      const data = await fetchGraphQL<{ userProfile: any }>(`
-        query UserProfile($userId: Int!) {
-          userProfile(userId: $userId) { id nickname profileImageUrl introduction rating isBlocked }
-        }
-      `, { userId: Number(id) })
-      return data.userProfile
+      const response = await api.get(`/profile/${id}`)
+      return response.data.data
     },
     enabled: !!id,
     refetchOnWindowFocus: false,
@@ -56,15 +52,10 @@ function UserPage() {
   } = useInfiniteQuery({
     queryKey: ['userProducts', id],
     queryFn: async ({ pageParam }) => {
-      const data = await fetchGraphQL<{ userProducts: any }>(`
-        query UserProducts($userId: Int!, $page: Int!, $size: Int!) {
-          userProducts(userId: $userId, page: $page, size: $size) {
-            content { id title price mainImageUrl petDetailType productStatus productType tradeStatus createdAt viewCount favoriteCount isFavorite }
-            page hasNext total totalElements
-          }
-        }
-      `, { userId: Number(id), page: pageParam, size: 10 })
-      return data.userProducts
+      const response = await api.get(`/profile/${id}/products`, {
+        params: { page: pageParam, size: 10 },
+      })
+      return response.data.data
     },
     getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.page + 1 : undefined),
     initialPageParam: 0,
@@ -74,11 +65,7 @@ function UserPage() {
   const isMyProfile = user?.id === userData?.id
 
   const { mutate: unblockUser } = useMutation({
-    mutationFn: () => fetchGraphQL(`
-      mutation UnblockUser($userId: Int!) {
-        unblockUser(userId: $userId) { success }
-      }
-    `, { userId: Number(userData?.id) }),
+    mutationFn: () => api.delete(`/reports/blocks/users/${userData?.id}`),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['userPage', id] })
     },

--- a/src/features/product-detail/ProductDetail.tsx
+++ b/src/features/product-detail/ProductDetail.tsx
@@ -2,7 +2,7 @@
 
 import { useParams } from 'next/navigation'
 import { useQuery } from '@tanstack/react-query'
-import { fetchGraphQL } from '@/lib/api/graphql'
+import { api } from '@/lib/api/api'
 import Footer from '@/components/footer/Footer'
 import MainImage from './components/MainImage'
 import SubImages from './components/SubImages'
@@ -15,51 +15,6 @@ import SellerOtherProducts from './components/SellerOtherProducts'
 import { useEffect } from 'react'
 import type { ProductDetailItem } from '@/types/product'
 
-const GET_PRODUCT = `
-  query GetProduct($id: Int!) {
-    product(id: $id) {
-      id
-      title
-      description
-      price
-      mainImageUrl
-      subImageUrls
-      productType
-      tradeStatus
-      petType
-      petDetailType
-      category
-      productStatus
-      addressSido
-      addressGugun
-      createdAt
-      viewCount
-      favoriteCount
-      isFavorite
-      sellerInfo {
-        sellerId
-        sellerNickname
-        sellerProfileImageUrl
-      }
-      sellerOtherProducts {
-        id
-        title
-        price
-        mainImageUrl
-        petDetailType
-        productStatus
-        tradeStatus
-        createdAt
-        favoriteCount
-      }
-    }
-  }
-`
-
-interface GetProductData {
-  product: ProductDetailItem
-}
-
 interface ProductDetailProps {
   initialData: ProductDetailItem
 }
@@ -68,13 +23,16 @@ function ProductDetail({ initialData }: ProductDetailProps) {
   const params = useParams<{ id: string }>()
   const id = params.id
 
-  const { data: apolloData, isLoading: loading } = useQuery({
+  const { data: restData } = useQuery({
     queryKey: ['product', id],
-    queryFn: () => fetchGraphQL<GetProductData>(GET_PRODUCT, { id: Number(id) }),
+    queryFn: async () => {
+      const response = await api.get(`/products/${id}`)
+      return response.data.data as ProductDetailItem
+    },
     enabled: !!id,
   })
 
-  const data = apolloData?.product ?? initialData
+  const data = restData ?? initialData
 
   useEffect(() => {
     window.scrollTo(0, 0)


### PR DESCRIPTION
## 📌 개요

- 상품 상세 페이지, 유저 프로필 페이지에서 GraphQL BFF 서버리스 함수를 경유하면서 콜드스타트 지연(1.88초~3.46초) 발생
- REST API 직접 호출로 전환하여 응답 속도 개선

## 🔧 작업 내용

- [x] `ProductDetail.tsx` — 상품 상세 조회 GraphQL → REST 전환
- [x] `UserPage.tsx` — 유저 프로필 조회, 유저 상품 목록, 차단 해제 GraphQL → REST 전환

## 📎 관련 이슈

Closes #469