### PR TITLE
fix: 마이페이지 GraphQL → REST API 전환(#470)

### DIFF
--- a/src/features/my-page/MyPage.tsx
+++ b/src/features/my-page/MyPage.tsx
@@ -4,7 +4,7 @@ import { useUserStore } from '@/store/userStore'
 import { useEffect, useState } from 'react'
 import { useRouter, usePathname, useSearchParams } from 'next/navigation'
 import { useMutation, useInfiniteQuery, useQueryClient, useQuery } from '@tanstack/react-query'
-import { fetchGraphQL } from '@/lib/api/graphql'
+import { api } from '@/lib/api/api'
 import Tabs from '@/components/Tabs'
 import { MY_PAGE_TABS, type MyPageTabId } from '@/constants/constants'
 import MyPagePanel from './components/MyPagePanel'
@@ -43,12 +43,8 @@ function MyPage() {
   } = useQuery({
     queryKey: ['mypage', user?.id],
     queryFn: async () => {
-      const data = await fetchGraphQL<{ myProfile: any }>(`
-        query MyProfile {
-          myProfile { id email name nickname birthDate profileImageUrl introduction addressSido addressGugun createdAt rating }
-        }
-      `)
-      return data.myProfile
+      const response = await api.get('/profile/me')
+      return response.data.data
     },
     enabled: !!user,
   })
@@ -63,15 +59,8 @@ function MyPage() {
   } = useInfiniteQuery({
     queryKey: ['myProducts', user?.id],
     queryFn: async ({ pageParam }) => {
-      const data = await fetchGraphQL<{ myProducts: any }>(`
-        query MyProducts($page: Int!, $size: Int!) {
-          myProducts(page: $page, size: $size) {
-            content { id title price mainImageUrl petDetailType productStatus productType tradeStatus createdAt viewCount favoriteCount isFavorite }
-            page hasNext total totalElements
-          }
-        }
-      `, { page: pageParam, size: 10 })
-      return data.myProducts
+      const response = await api.get('/profile/me/products', { params: { page: pageParam, size: 10 } })
+      return response.data.data
     },
     getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.page + 1 : undefined),
     initialPageParam: 0,
@@ -87,15 +76,8 @@ function MyPage() {
   } = useInfiniteQuery({
     queryKey: ['myRequest', user?.id],
     queryFn: async ({ pageParam }) => {
-      const data = await fetchGraphQL<{ myRequests: any }>(`
-        query MyRequests($page: Int!, $size: Int!) {
-          myRequests(page: $page, size: $size) {
-            content { id title price mainImageUrl petDetailType productStatus productType tradeStatus createdAt viewCount favoriteCount isFavorite }
-            page hasNext total totalElements
-          }
-        }
-      `, { page: pageParam, size: 10 })
-      return data.myRequests
+      const response = await api.get('/profile/me/purchase-requests', { params: { page: pageParam, size: 10 } })
+      return response.data.data
     },
     getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.page + 1 : undefined),
     initialPageParam: 0,
@@ -111,15 +93,8 @@ function MyPage() {
   } = useInfiniteQuery({
     queryKey: ['myFavorite', user?.id],
     queryFn: async ({ pageParam }) => {
-      const data = await fetchGraphQL<{ myFavorites: any }>(`
-        query MyFavorites($page: Int!, $size: Int!) {
-          myFavorites(page: $page, size: $size) {
-            content { id title price mainImageUrl petDetailType productStatus productType tradeStatus createdAt viewCount favoriteCount isFavorite }
-            page hasNext total totalElements
-          }
-        }
-      `, { page: pageParam, size: 10 })
-      return data.myFavorites
+      const response = await api.get('/profile/me/favorites', { params: { page: pageParam, size: 10 } })
+      return response.data.data
     },
     getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.page + 1 : undefined),
     initialPageParam: 0,
@@ -135,15 +110,14 @@ function MyPage() {
   } = useInfiniteQuery({
     queryKey: ['myBlocked', user?.id],
     queryFn: async ({ pageParam }) => {
-      const data = await fetchGraphQL<{ myBlockedUsers: any }>(`
-        query MyBlockedUsers($page: Int!, $size: Int!) {
-          myBlockedUsers(page: $page, size: $size) {
-            content { blockedUserId blockedUserNickname blockedAt }
-            page hasNext total
-          }
-        }
-      `, { page: pageParam, size: 10 })
-      return data.myBlockedUsers
+      const response = await api.get('/profile/me/blocked-users', { params: { page: pageParam, size: 10 } })
+      const data = response.data.data
+      return {
+        content: data.blockedUsers || data.content || [],
+        page: data.page ?? 0,
+        hasNext: data.hasNext ?? false,
+        total: data.total ?? data.totalElements ?? 0,
+      }
     },
     getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.page + 1 : undefined),
     initialPageParam: 0,
@@ -166,11 +140,7 @@ function MyPage() {
   }[activeMyPageTab]
 
   const { mutate: deleteProductMutate } = useMutation({
-    mutationFn: (id: number) => fetchGraphQL(`
-      mutation DeleteProduct($id: Int!) {
-        deleteProduct(id: $id) { success }
-      }
-    `, { id }),
+    mutationFn: (id: number) => api.delete(`/products/${id}`),
     onSuccess: () => {
       if (activeMyPageTab === 'tab-sales') {
         queryClient.invalidateQueries({ queryKey: ['myProducts', user?.id] })
@@ -207,11 +177,7 @@ function MyPage() {
 
   const handleWithdraw = async (data: WithDrawFormValues) => {
     try {
-      await fetchGraphQL(`
-        mutation Withdraw($reason: String!, $detailReason: String!) {
-          withdraw(reason: $reason, detailReason: $detailReason) { success }
-        }
-      `, { reason: data.reason, detailReason: data.detailReason })
+      await api.delete('/auth/withdraw', { data: { reason: data.reason, detailReason: data.detailReason } })
       clearAll()
       router.push('/')
     } catch {
@@ -225,11 +191,7 @@ function MyPage() {
   }
 
   const { mutate: unblockUser } = useMutation({
-    mutationFn: (blockedUserId: number) => fetchGraphQL(`
-      mutation UnblockUser($userId: Int!) {
-        unblockUser(userId: $userId) { success }
-      }
-    `, { userId: blockedUserId }),
+    mutationFn: (blockedUserId: number) => api.delete(`/reports/blocks/users/${blockedUserId}`),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['myBlocked'] })
     },

--- a/src/features/my-page/components/MyList.tsx
+++ b/src/features/my-page/components/MyList.tsx
@@ -17,7 +17,7 @@ import { ProductMetaItem } from '@/components/product/ProductMetaItem'
 import { getTradeStatus } from '@/lib/utils/getTradeStatus'
 import { getTradeStatusColor } from '@/lib/utils/getTradeStatusColor'
 import { cn } from '@/lib/utils/cn'
-import { fetchGraphQL } from '@/lib/api/graphql'
+import { api } from '@/lib/api/api'
 import { ROUTES } from '@/constants/routes'
 import { useMediaQuery } from '@/hooks/useMediaQuery'
 import IconButton from '@/components/commons/button/IconButton'
@@ -78,11 +78,7 @@ export default function MyList({ id, title, price, mainImageUrl, tradeStatus, vi
   const isMd = useMediaQuery('(min-width: 768px)')
   const queryClient = useQueryClient()
   const { mutate } = useMutation({
-    mutationFn: (newStatus: TransactionStatus) => fetchGraphQL(`
-      mutation UpdateTradeStatus($id: Int!, $tradeStatus: String!) {
-        updateTradeStatus(id: $id, tradeStatus: $tradeStatus) { success }
-      }
-    `, { id, tradeStatus: newStatus }),
+    mutationFn: (newStatus: TransactionStatus) => api.patch(`/products/${id}/trade-status`, { tradeStatus: newStatus }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['myRequest'] })
       queryClient.invalidateQueries({ queryKey: ['myProducts'] })
@@ -90,11 +86,7 @@ export default function MyList({ id, title, price, mainImageUrl, tradeStatus, vi
   })
 
   const { mutate: cancelFavorite } = useMutation({
-    mutationFn: () => fetchGraphQL(`
-      mutation ToggleFavorite($productId: Int!) {
-        toggleFavorite(productId: $productId) { success }
-      }
-    `, { productId: id }),
+    mutationFn: () => api.post(`/products/${id}/favorite`),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['myFavorite'] })
     },


### PR DESCRIPTION
## 📌 개요

- 마이페이지 찜 목록 탭 클릭 시 `Cannot return null for non-nullable field Product.petDetailType.` 에러 발생
- GraphQL 스키마에서 `petDetailType`이 `String!`(non-nullable)로 정의되어 있으나, 백엔드에서 일부 상품의 `petDetailType`을 null로 반환하여 전체 응답 실패
- **해결 방향**: GraphQL 스키마 수정(최소 변경)도 가능하나, 마이페이지도 서버리스 콜드스타트 지연(1.69초)이 발생하고 있어 REST API 직접 호출로 전환하여 **에러 해결 + 콜드스타트 지연 개선**을 동시에 달성

## 🔧 작업 내용

- [x] `MyPage.tsx` — myProfile, myProducts, myRequests, myFavorites, myBlockedUsers, deleteProduct, withdraw, unblockUser (8개 GraphQL → REST)
- [x] `MyList.tsx` — updateTradeStatus, toggleFavorite (2개 GraphQL → REST)

## 📎 관련 이슈

Closes #470

## 📋 QA 티켓

https://www.notion.so/320f2b3079618146beb8ce1fe80f7417

## 💬 리뷰어 참고 사항

- GraphQL 스키마의 non-nullable 필드 검증을 우회하는 것이 아니라, 중간 레이어(BFF)를 제거하여 근본적으로 해결
- `myBlockedUsers` 응답은 REST에서 `blockedUsers` 키를 사용하므로 별도 정규화 처리 포함