### PR TITLE
fix: 마이페이지 차단 유저 탭 필드명 매핑 수정(#470)

### DIFF
--- a/src/features/my-page/MyPage.tsx
+++ b/src/features/my-page/MyPage.tsx
@@ -112,8 +112,14 @@ function MyPage() {
     queryFn: async ({ pageParam }) => {
       const response = await api.get('/profile/me/blocked-users', { params: { page: pageParam, size: 10 } })
       const data = response.data.data
+      const blockedList = data.blockedUsers || data.content || []
       return {
-        content: data.blockedUsers || data.content || [],
+        content: blockedList.map((u: { blockedUserId: number; blockedUserNickname?: string; nickname?: string; profileImageUrl?: string; blockedAt: string }) => ({
+          blockedUserId: u.blockedUserId,
+          nickname: u.nickname || u.blockedUserNickname || '',
+          profileImageUrl: u.profileImageUrl,
+          blockedAt: u.blockedAt,
+        })),
         page: data.page ?? 0,
         hasNext: data.hasNext ?? false,
         total: data.total ?? data.totalElements ?? 0,


### PR DESCRIPTION
## 📌 개요

- 마이페이지 차단 유저 탭에서 `Cannot read properties of undefined (reading 'charAt')` 에러 발생
- REST API가 `blockedUserNickname` 필드를 반환하는데, 컴포넌트는 `nickname`을 참조하여 발생한 필드명 불일치
- PR #471에서 마이페이지 GraphQL → REST 전환 시 누락된 필드 매핑 추가

## 🔧 작업 내용

- [x] `MyPage.tsx` — 차단 유저 응답에서 `blockedUserNickname` → `nickname` 필드 매핑 추가

## 📎 관련 이슈

Closes #470

## 📋 QA 티켓

https://www.notion.so/320f2b3079618146beb8ce1fe80f7417

## 💬 리뷰어 참고 사항

- PR #471의 후속 수정입니다