### PR TITLE
fix: SearchBar id/name 속성 추가로 접근성 경고 해결(#475)

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -127,7 +127,7 @@ export default function Header() {
             <div className="flex items-center gap-1 xl:gap-8">
               {!hideSearchBar ? (
                 <Suspense>
-                  <SearchBar className="hidden md:h-9 xl:block" inputClass="text-sm py-0" />
+                  <SearchBar id="search-desktop" className="hidden md:h-9 xl:block" inputClass="text-sm py-0" />
                 </Suspense>
               ) : null}
               {!hideSearchBar && !isXl ? (
@@ -149,7 +149,7 @@ export default function Header() {
               }}
             >
               <Suspense>
-                <SearchBar className="h-8 xl:hidden" inputClass="py-1 text-sm" />
+                <SearchBar id="search-mobile" className="h-8 xl:hidden" inputClass="py-1 text-sm" />
               </Suspense>
             </div>
           ) : null}

--- a/src/components/header/components/SearchBar.tsx
+++ b/src/components/header/components/SearchBar.tsx
@@ -8,6 +8,7 @@ import { useSearchParams, useRouter, usePathname } from 'next/navigation'
 import { ROUTES } from '@/constants/routes'
 
 interface SearchBarProps {
+  id?: string
   placeholder?: string
   className?: string
   borderColor?: string
@@ -16,6 +17,7 @@ interface SearchBarProps {
 }
 
 export default function SearchBar({
+  id,
   placeholder = '원하는 반려동물 용품을 검색해보세요',
   borderColor = 'border-gray-100',
   className,
@@ -73,6 +75,8 @@ export default function SearchBar({
   return (
     <div className={cn('h-5 flex-1 md:h-10 md:min-w-120', className)} role="search" aria-label={placeholder}>
       <Input
+        id={id}
+        name={paramName}
         type="text"
         value={keyword}
         placeholder={placeholder}

--- a/src/features/community/CommunityPage.tsx
+++ b/src/features/community/CommunityPage.tsx
@@ -222,6 +222,7 @@ export default function CommunityPage({ initialQuestionData, initialInfoData }: 
                     />
                   </div>
                   <SearchBar
+                    id="community-search-mobile"
                     placeholder="게시글 검색"
                     borderColor="border-gray-300"
                     className="h-11 max-w-full"
@@ -283,6 +284,7 @@ export default function CommunityPage({ initialQuestionData, initialInfoData }: 
                   />
                 </div>
                 <SearchBar
+                  id="community-search-desktop"
                   placeholder="게시글 제목이나 내용, 작성자로 검색해보세요"
                   borderColor="border-gray-300"
                   className="h-11 max-w-full"


### PR DESCRIPTION
## 📌 개요

- SearchBar 컴포넌트의 Input에 id/name 속성이 없어 발생하던 브라우저 콘솔 경고 수정

## 🔧 작업 내용

- [x] `SearchBar.tsx` — `id` prop 추가, `name`을 `paramName`으로 동적 연결
- [x] `Header.tsx` — 데스크톱(`search-desktop`), 모바일(`search-mobile`) 고유 id 전달
- [x] `CommunityPage.tsx` — 데스크톱(`community-search-desktop`), 모바일(`community-search-mobile`) 고유 id 전달

## 📎 관련 이슈

Closes #475

## 💬 리뷰어 참고 사항

- SearchBar는 공통 컴포넌트로 여러 곳에서 사용되므로, id를 내부 하드코딩이 아닌 prop으로 받아 호출부에서 고유 값을 전달하도록 설계
- CORB 경고(이미지 8건)는 CDN/백엔드 CORS 설정 문제로 프론트엔드에서 해결 불가