### PR TITLE
fix: 마이페이지 차단 유저 탭 API 응답 파싱 오류 수정(#477)

### DIFF
--- a/src/features/my-page/MyPage.tsx
+++ b/src/features/my-page/MyPage.tsx
@@ -112,7 +112,8 @@ function MyPage() {
     queryFn: async ({ pageParam }) => {
       const response = await api.get('/profile/me/blocked-users', { params: { page: pageParam, size: 10 } })
       const data = response.data.data
-      const blockedList = data.blockedUsers || data.content || []
+      const paged = data.blockedUsers ?? data
+      const blockedList = paged.content ?? []
       return {
         content: blockedList.map((u: { blockedUserId: number; blockedUserNickname?: string; nickname?: string; profileImageUrl?: string; blockedAt: string }) => ({
           blockedUserId: u.blockedUserId,
@@ -120,9 +121,9 @@ function MyPage() {
           profileImageUrl: u.profileImageUrl,
           blockedAt: u.blockedAt,
         })),
-        page: data.page ?? 0,
-        hasNext: data.hasNext ?? false,
-        total: data.total ?? data.totalElements ?? 0,
+        page: paged.page ?? 0,
+        hasNext: paged.hasNext ?? false,
+        total: paged.total ?? paged.totalElements ?? 0,
       }
     },
     getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.page + 1 : undefined),


### PR DESCRIPTION
## 📌 개요

- `/mypage?tab=tab-blocked` 접속 시 API 응답 구조 불일치로 에러 화면이 표시되던 버그 수정

## 🔧 작업 내용

- [x] `MyPage.tsx` — blocked users queryFn에서 `data.blockedUsers`를 배열이 아닌 페이지네이션 래퍼 객체로 올바르게 처리

## 📎 관련 이슈

Closes #477

## 📋 QA 티켓

https://www.notion.so/321f2b307961813b80cec9694f9115ec

## 💬 리뷰어 참고 사항

- REST API 응답: `data.blockedUsers = { page, content: [], total, ... }` (페이지네이션 객체)
- 기존 코드는 `data.blockedUsers`를 배열로 간주하여 `.map()` 호출 시 런타임 에러 발생
- `paged = data.blockedUsers ?? data`로 래퍼를 꺼낸 뒤 `paged.content`에서 실제 배열 추출