### PR TITLE
fix: 커뮤니티 게시글 신고 GraphQL resolver 필드명 수정(#479)

### DIFF
--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -320,7 +320,7 @@ export const resolvers = {
     ) => {
       await fetchAPI(`/reports/community-posts/${args.postId}`, context, {
         method: 'POST',
-        body: JSON.stringify({ reason: args.reason, details: args.details }),
+        body: JSON.stringify({ reasonCode: args.reason, detailReason: args.details }),
       })
       return { success: true }
     },


### PR DESCRIPTION
## 📌 개요

- GraphQL resolver에서 백엔드 REST API로 전송하는 신고 요청의 필드명이 불일치하여 400 에러가 발생하던 버그 수정

## 🔧 작업 내용

- [x] `resolvers.ts` — reportPost mutation의 `{ reason, details }` → `{ reasonCode, detailReason }` 수정
- [x] 다른 report mutation(reportUser) 확인 — 이미 올바른 필드명 사용 중

## 📎 관련 이슈

Closes #479

## 📋 QA 티켓

https://www.notion.so/321f2b3079618157bdbdff28f2336baa

## 💬 리뷰어 참고 사항

- 백엔드 ReportedRequestData 타입이 `{ reasonCode, detailReason }` 필드를 기대
- GraphQL resolver가 `{ reason, details }`로 보내서 400 에러 발생