### PR TITLE
fix: 어드민 신고 관리 페이지 API 응답 필드명 매핑 수정(#481)

### DIFF
--- a/src/lib/api/admin.ts
+++ b/src/lib/api/admin.ts
@@ -238,8 +238,9 @@ export async function fetchAdminReports(
   }
 
   const { data } = await api.get<ApiResponse<PageResponse<AdminReport> & { total: number }>>(`/admin/reports?${searchParams.toString()}`)
+  const reportData = data.data
   return toAdminTableResponse(
-    { ...data.data, totalElements: data.data.totalElements ?? data.data.total },
+    { ...reportData, content: reportData.content ?? (reportData as any).reports ?? [], totalElements: reportData.totalElements ?? reportData.total },
     params.page,
     params.pageSize,
   )


### PR DESCRIPTION
## 📌 개요

- 어드민 신고 관리 페이지에서 백엔드 응답 필드명(`reports`)과 프론트엔드 기대 필드명(`content`) 불일치로 테이블 데이터가 표시되지 않던 버그 수정

## 🔧 작업 내용

- [x] `admin.ts` — `fetchAdminReports`에서 `reports` → `content` 필드 매핑 추가

## 📎 관련 이슈

Closes #481

## 📋 QA 티켓

https://www.notion.so/321f2b307961816b9473cf8819902f74

## 💬 리뷰어 참고 사항

- 백엔드 응답: `{ reports: [...], page, size, totalElements }`
- 프론트엔드 `toAdminTableResponse`는 `{ content: [...] }` 기대
- `reports` 필드를 `content`로 매핑하여 호환성 확보