### PR TITLE
chore: 어드민 커뮤니티 신고 테이블 컬럼 및 상세 모달 개선(#483)

### DIFF
--- a/src/features/admin/components/reports/CommunityReportDetailModal.tsx
+++ b/src/features/admin/components/reports/CommunityReportDetailModal.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { X } from 'lucide-react'
 import type { AdminReport } from '../../types/adminApi'
-import { COMMUNITY_REPORT_REASON_EN_TO_KO } from '../../configs/communityReportTableConfig'
+import { COMMUNITY_REPORT_REASON_EN_TO_KO, TARGET_TYPE_EN_TO_KO } from '../../configs/communityReportTableConfig'
 import { formatDate } from '../common/formatDate'
 import Field from '../common/Field'
 import DeleteConfirmDialog from '../common/DeleteConfirmDialog'
@@ -30,7 +30,7 @@ export default function CommunityReportDetailModal({ isOpen, report, onClose }: 
   }, [isOpen, report])
 
   useEffect(() => {
-    if (isOpen && report) {
+    if (isOpen && report?.targetId) {
       api.get(`/community/posts/${report.targetId}`)
         .then((res) => setPostDetail(res.data.data))
         .catch(() => setPostDetail(null))
@@ -43,8 +43,6 @@ export default function CommunityReportDetailModal({ isOpen, report, onClose }: 
     setShowDeleteConfirm(false)
     onClose()
   }
-
-  const targetTypeMap: Record<string, string> = { COMMUNITY_POST: '커뮤니티 게시글' }
 
   return (
     <dialog
@@ -80,7 +78,7 @@ export default function CommunityReportDetailModal({ isOpen, report, onClose }: 
                 value={report.reasonCodes.map((c) => COMMUNITY_REPORT_REASON_EN_TO_KO[c] || c).join(', ')}
               />
               <Field label="신고일자" value={formatDate(report.createdAt)} />
-              <Field label="게시글 유형" value={targetTypeMap[report.targetType] || report.targetType} />
+              <Field label="게시글 유형" value={TARGET_TYPE_EN_TO_KO[report.targetType] || report.targetType} />
 
               {/* 게시글 제목 */}
               <div className="col-span-2">

--- a/src/features/admin/configs/communityReportTableConfig.ts
+++ b/src/features/admin/configs/communityReportTableConfig.ts
@@ -10,7 +10,11 @@ const COMMUNITY_REPORT_REASON_EN_TO_KO: Record<string, string> = {
   ETC: '기타',
 }
 
-export { COMMUNITY_REPORT_REASON_EN_TO_KO }
+const TARGET_TYPE_EN_TO_KO: Record<string, string> = {
+  COMMUNITY_POST: '커뮤니티 게시글',
+}
+
+export { COMMUNITY_REPORT_REASON_EN_TO_KO, TARGET_TYPE_EN_TO_KO }
 
 export const communityReportTableConfig: TableConfig<AdminReport> = {
   title: '커뮤니티 신고 관리',
@@ -23,10 +27,7 @@ export const communityReportTableConfig: TableConfig<AdminReport> = {
       label: '게시글 유형',
       type: 'text',
       width: '110px',
-      format: (v) => {
-        const typeMap: Record<string, string> = { COMMUNITY_POST: '커뮤니티 게시글' }
-        return typeMap[v as string] || (v as string)
-      },
+      format: (v) => TARGET_TYPE_EN_TO_KO[v as string] || (v as string),
     },
     { key: 'reporterId', label: '신고자', type: 'number', width: '80px' },
     { key: 'targetId', label: '게시글 ID', type: 'number', width: '100px' },


### PR DESCRIPTION
## Summary

- 어드민 커뮤니티 신고 관리 테이블 컬럼 순서 변경 및 상세 모달 레이아웃 개선

## Changed Files

- `communityReportTableConfig.ts` — 테이블 컬럼: 신고 ID, 게시글 유형, 신고자, 게시글 ID, 신고항목, 신고일자
- `CommunityReportDetailModal.tsx` — 모달: targetId로 게시글 상세 조회하여 제목/내용/작성자 표시

## Test plan

- [ ] 어드민 신고 관리 페이지 접속하여 테이블 컬럼 순서 확인
- [ ] 신고 데이터 클릭하여 모달 레이아웃 확인
- [ ] 게시글 제목, 내용, 작성자가 모달에 정상 표시되는지 확인

Closes #483