### PR TITLE
chore: 어드민 커뮤니티 신고 테이블 컬럼 및 모달 백엔드 신규 필드 반영(#485)

### DIFF
--- a/src/features/admin/components/reports/CommunityReportDetailModal.tsx
+++ b/src/features/admin/components/reports/CommunityReportDetailModal.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { X } from 'lucide-react'
 import type { AdminReport } from '../../types/adminApi'
-import { COMMUNITY_REPORT_REASON_EN_TO_KO, TARGET_TYPE_EN_TO_KO } from '../../configs/communityReportTableConfig'
+import { COMMUNITY_REPORT_REASON_EN_TO_KO, BOARD_TYPE_EN_TO_KO } from '../../configs/communityReportTableConfig'
 import { formatDate } from '../common/formatDate'
 import Field from '../common/Field'
 import DeleteConfirmDialog from '../common/DeleteConfirmDialog'
@@ -18,7 +18,7 @@ interface CommunityReportDetailModalProps {
 export default function CommunityReportDetailModal({ isOpen, report, onClose }: CommunityReportDetailModalProps) {
   const dialogRef = useRef<HTMLDialogElement>(null)
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
-  const [postDetail, setPostDetail] = useState<{ title: string; content: string; authorNickname: string; boardType: string } | null>(null)
+  const [postContent, setPostContent] = useState<string | null>(null)
 
   useEffect(() => {
     const dialog = dialogRef.current
@@ -32,10 +32,10 @@ export default function CommunityReportDetailModal({ isOpen, report, onClose }: 
   useEffect(() => {
     if (isOpen && report?.targetId) {
       api.get(`/community/posts/${report.targetId}`)
-        .then((res) => setPostDetail(res.data.data))
-        .catch(() => setPostDetail(null))
+        .then((res) => setPostContent(res.data.data.content))
+        .catch(() => setPostContent(null))
     } else {
-      setPostDetail(null)
+      setPostContent(null)
     }
   }, [isOpen, report])
 
@@ -71,20 +71,20 @@ export default function CommunityReportDetailModal({ isOpen, report, onClose }: 
           <div className="max-h-[60vh] overflow-y-auto px-6 py-5">
             <div className="grid grid-cols-2 gap-x-5 gap-y-4">
               <Field label="신고 ID" value={String(report.id)} />
-              <Field label="신고자" value={String(report.reporterId)} />
-              <Field label="작성자" value={postDetail?.authorNickname ?? '-'} />
+              <Field label="신고자" value={report.reporterNickname ?? '-'} />
+              <Field label="작성자" value={report.targetNickname ?? '-'} />
               <Field
                 label="신고항목"
                 value={report.reasonCodes.map((c) => COMMUNITY_REPORT_REASON_EN_TO_KO[c] || c).join(', ')}
               />
               <Field label="신고일자" value={formatDate(report.createdAt)} />
-              <Field label="게시글 유형" value={TARGET_TYPE_EN_TO_KO[report.targetType] || report.targetType} />
+              <Field label="게시글 유형" value={report.boardType ? (BOARD_TYPE_EN_TO_KO[report.boardType] || report.boardType) : '-'} />
 
               {/* 게시글 제목 */}
               <div className="col-span-2">
                 <p className="mb-1.5 text-sm font-medium text-gray-500">게시글 제목</p>
                 <div className="max-h-30 overflow-y-auto rounded-lg border border-gray-200 bg-gray-50/50 px-3 py-2.5 text-sm leading-relaxed whitespace-pre-line text-gray-900">
-                  {postDetail?.title ?? '-'}
+                  {report.title ?? '-'}
                 </div>
               </div>
 
@@ -92,7 +92,7 @@ export default function CommunityReportDetailModal({ isOpen, report, onClose }: 
               <div className="col-span-2">
                 <p className="mb-1.5 text-sm font-medium text-gray-500">게시글 내용</p>
                 <div className="max-h-30 overflow-y-auto rounded-lg border border-gray-200 bg-gray-50/50 px-3 py-2.5 text-sm leading-relaxed whitespace-pre-line text-gray-900">
-                  {postDetail?.content ?? '-'}
+                  {postContent ?? '-'}
                 </div>
               </div>
 

--- a/src/features/admin/configs/communityReportTableConfig.ts
+++ b/src/features/admin/configs/communityReportTableConfig.ts
@@ -14,7 +14,12 @@ const TARGET_TYPE_EN_TO_KO: Record<string, string> = {
   COMMUNITY_POST: '커뮤니티 게시글',
 }
 
-export { COMMUNITY_REPORT_REASON_EN_TO_KO, TARGET_TYPE_EN_TO_KO }
+const BOARD_TYPE_EN_TO_KO: Record<string, string> = {
+  QUESTION: '질문있어요',
+  INFO: '정보 공유',
+}
+
+export { COMMUNITY_REPORT_REASON_EN_TO_KO, TARGET_TYPE_EN_TO_KO, BOARD_TYPE_EN_TO_KO }
 
 export const communityReportTableConfig: TableConfig<AdminReport> = {
   title: '커뮤니티 신고 관리',
@@ -23,14 +28,15 @@ export const communityReportTableConfig: TableConfig<AdminReport> = {
   columns: [
     { key: 'id', label: '신고 ID', type: 'number', sortable: true, width: '90px' },
     {
-      key: 'targetType',
+      key: 'boardType',
       label: '게시글 유형',
       type: 'text',
       width: '110px',
-      format: (v) => TARGET_TYPE_EN_TO_KO[v as string] || (v as string),
+      format: (v) => BOARD_TYPE_EN_TO_KO[v as string] || (v as string),
     },
-    { key: 'reporterId', label: '신고자', type: 'number', width: '80px' },
-    { key: 'targetId', label: '게시글 ID', type: 'number', width: '100px' },
+    { key: 'reporterNickname', label: '신고자', type: 'text', width: '100px' },
+    { key: 'title', label: '게시글 제목', type: 'text' },
+    { key: 'targetNickname', label: '작성자', type: 'text', width: '100px' },
     {
       key: 'reasonCodes',
       label: '신고항목',

--- a/src/features/admin/mocks/mockCommunityReports.ts
+++ b/src/features/admin/mocks/mockCommunityReports.ts
@@ -17,8 +17,12 @@ function generateCommunityReports(count: number): AdminReport[] {
   return Array.from({ length: count }, (_, i) => ({
     id: i + 1,
     reporterId: 100 + i,
+    reporterNickname: `신고자${100 + i}`,
     targetType: 'COMMUNITY_POST' as const,
     targetId: 500 + i,
+    targetNickname: `작성자${500 + i}`,
+    title: `테스트 게시글 제목 ${i + 1}`,
+    boardType: i % 2 === 0 ? 'QUESTION' : 'INFO',
     reasonCodes: [REASON_CODES[i % REASON_CODES.length]],
     detailReason: i % 3 === 0 ? '커뮤니티 게시글 신고 상세 사유입니다.' : null,
     imageUrls: i % 4 === 0 ? [`https://picsum.photos/seed/creport${i + 1}/200/200`] : null,

--- a/src/features/admin/mocks/mockProductRequestReports.ts
+++ b/src/features/admin/mocks/mockProductRequestReports.ts
@@ -18,8 +18,12 @@ function generateProductRequestReports(count: number): AdminReport[] {
   return Array.from({ length: count }, (_, i) => ({
     id: i + 1,
     reporterId: 100 + i,
+    reporterNickname: `신고자${100 + i}`,
     targetType: 'PRODUCT' as const,
     targetId: 400 + i,
+    targetNickname: `판매자${400 + i}`,
+    title: null,
+    boardType: null,
     reasonCodes: [REASON_CODES[i % REASON_CODES.length]],
     detailReason: i % 3 === 0 ? '판매요청 상품 신고 상세 사유입니다.' : null,
     imageUrls: i % 4 === 0 ? [`https://picsum.photos/seed/prreport${i + 1}/200/200`] : null,

--- a/src/features/admin/mocks/mockProductSellReports.ts
+++ b/src/features/admin/mocks/mockProductSellReports.ts
@@ -18,8 +18,12 @@ function generateProductSellReports(count: number): AdminReport[] {
   return Array.from({ length: count }, (_, i) => ({
     id: i + 1,
     reporterId: 100 + i,
+    reporterNickname: `신고자${100 + i}`,
     targetType: 'PRODUCT' as const,
     targetId: 300 + i,
+    targetNickname: `판매자${300 + i}`,
+    title: null,
+    boardType: null,
     reasonCodes: [REASON_CODES[i % REASON_CODES.length]],
     detailReason: i % 3 === 0 ? '상품 신고 상세 사유입니다.' : null,
     imageUrls: i % 4 === 0 ? [`https://picsum.photos/seed/preport${i + 1}/200/200`] : null,

--- a/src/features/admin/mocks/mockUserReports.ts
+++ b/src/features/admin/mocks/mockUserReports.ts
@@ -17,8 +17,12 @@ function generateUserReports(count: number): AdminReport[] {
   return Array.from({ length: count }, (_, i) => ({
     id: i + 1,
     reporterId: 100 + i,
+    reporterNickname: `신고자${100 + i}`,
     targetType: 'USER' as const,
     targetId: 200 + i,
+    targetNickname: `피신고자${200 + i}`,
+    title: null,
+    boardType: null,
     reasonCodes: [REASON_CODES[i % REASON_CODES.length]],
     detailReason: i % 3 === 0 ? '신고 상세 사유입니다.' : null,
     imageUrls: i % 4 === 0 ? [`https://picsum.photos/seed/ureport${i + 1}/200/200`] : null,

--- a/src/features/admin/types/adminApi.ts
+++ b/src/features/admin/types/adminApi.ts
@@ -51,8 +51,12 @@ export interface AdminProduct {
 export interface AdminReport {
   id: number
   reporterId: number
+  reporterNickname: string | null
   targetType: 'USER' | 'PRODUCT' | 'COMMUNITY_POST'
   targetId: number
+  targetNickname: string | null
+  title: string | null
+  boardType: string | null
   reasonCodes: string[]
   detailReason: string | null
   imageUrls: string[] | null


### PR DESCRIPTION
## 📌 개요

- 백엔드 API 응답에 추가된 신규 필드(`reporterNickname`, `targetNickname`, `title`, `boardType`)를 어드민 커뮤니티 신고 테이블 및 모달에 반영

## 🔧 작업 내용

- [ ] `AdminReport` 타입에 `reporterNickname`, `targetNickname`, `title`, `boardType` 필드 추가
- [ ] 테이블 컬럼 순서 변경: 신고 ID → 게시글 유형(boardType) → 신고자(reporterNickname) → 게시글 제목(title) → 작성자(targetNickname) → 신고항목 → 신고일자
- [ ] 게시글 ID 컬럼 제거, `BOARD_TYPE_EN_TO_KO` 매핑 추가
- [ ] 모달에서 `reporterNickname`, `targetNickname`, `title`, `boardType` 직접 사용 (게시글 내용만 별도 API 조회 유지)
- [ ] mock 파일 4개에 신규 필드 추가

## 📎 관련 이슈

Closes #485

## 💬 리뷰어 참고 사항

- 게시글 내용(`content`)은 신고 API 응답에 포함되지 않아 기존처럼 `/community/posts/{targetId}`로 별도 조회 유지