### PR TITLE
chore: 어드민 판매상품/판매요청 상품 신고 테이블 컬럼 업데이트(#487)

### DIFF
--- a/src/features/admin/configs/productRequestReportTableConfig.ts
+++ b/src/features/admin/configs/productRequestReportTableConfig.ts
@@ -1,8 +1,52 @@
-import { productSellReportTableConfig } from './productSellReportTableConfig'
+import { PRODUCT_REPORT_REASON_EN_TO_KO } from './productSellReportTableConfig'
 import type { TableConfig } from '../types/adminTable'
 import type { AdminReport } from '../types/adminApi'
 
 export const productRequestReportTableConfig: TableConfig<AdminReport> = {
-  ...productSellReportTableConfig,
   title: '판매요청 상품 신고 관리',
+  rowKey: 'id',
+  searchable: false,
+  columns: [
+    { key: 'id', label: '신고 ID', type: 'number', sortable: true, width: '90px' },
+    { key: 'reporterNickname', label: '신고자', type: 'text', width: '100px' },
+    { key: 'title', label: '상품명', type: 'text' },
+    { key: 'targetNickname', label: '요청자', type: 'text', width: '100px' },
+    {
+      key: 'reasonCodes',
+      label: '신고항목',
+      type: 'text',
+      format: (v) => {
+        const codes = v as string[]
+        return codes.map((c) => PRODUCT_REPORT_REASON_EN_TO_KO[c] || c).join(', ')
+      },
+    },
+    {
+      key: 'createdAt',
+      label: '신고일자',
+      type: 'date',
+      sortable: true,
+      width: '120px',
+      format: (v) => {
+        const d = new Date(v as string)
+        return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+      },
+    },
+  ],
+  filters: [
+    {
+      key: 'status',
+      label: '처리 상태',
+      options: [
+        { value: '대기중', label: '대기중' },
+        { value: '검토완료', label: '검토완료' },
+        { value: '거절', label: '거절' },
+        { value: '조치완료', label: '조치완료' },
+      ],
+    },
+  ],
+  actions: [],
+  pagination: {
+    defaultPageSize: 10,
+    pageSizeOptions: [5, 10, 20, 50],
+  },
 }

--- a/src/features/admin/configs/productSellReportTableConfig.ts
+++ b/src/features/admin/configs/productSellReportTableConfig.ts
@@ -20,29 +20,17 @@ export const productSellReportTableConfig: TableConfig<AdminReport> = {
   searchable: false,
   columns: [
     { key: 'id', label: '신고 ID', type: 'number', sortable: true, width: '90px' },
-    { key: 'reporterId', label: '신고자 ID', type: 'number', width: '100px' },
-    { key: 'targetId', label: '상품 ID', type: 'number', width: '100px' },
+    { key: 'title', label: '상품명', type: 'text' },
+    { key: 'reporterNickname', label: '신고자', type: 'text', width: '100px' },
+    { key: 'targetNickname', label: '판매자', type: 'text', width: '100px' },
     {
       key: 'reasonCodes',
-      label: '신고 사유',
+      label: '신고항목',
       type: 'text',
       format: (v) => {
         const codes = v as string[]
         return codes.map((c) => PRODUCT_REPORT_REASON_EN_TO_KO[c] || c).join(', ')
       },
-    },
-    {
-      key: 'status',
-      label: '처리 상태',
-      type: 'badge',
-      sortable: true,
-      width: '110px',
-      badgeOptions: [
-        { value: 'PENDING', label: '대기중', color: 'bg-yellow-100 text-yellow-800' },
-        { value: 'REVIEWED', label: '검토완료', color: 'bg-green-100 text-green-800' },
-        { value: 'REJECTED', label: '거절', color: 'bg-gray-100 text-gray-800' },
-        { value: 'ACTION_TAKEN', label: '조치완료', color: 'bg-blue-100 text-blue-800' },
-      ],
     },
     {
       key: 'createdAt',


### PR DESCRIPTION
## 📌 개요

- 어드민 상품 신고 테이블의 컬럼을 백엔드 API 신규 필드에 맞춰 업데이트

## 🔧 작업 내용

- [ ] 판매상품 신고 테이블: 신고 ID → 상품명 → 신고자 → 판매자 → 신고항목 → 신고일자
- [ ] 판매요청 상품 신고 테이블: 신고 ID → 신고자 → 상품명 → 요청자 → 신고항목 → 신고일자
- [ ] 기존 신고자 ID, 상품 ID, 처리 상태 컬럼 제거
- [ ] 판매요청 테이블은 컬럼 순서가 달라 별도 columns 정의

## 📎 관련 이슈

Closes #487

## 💬 리뷰어 참고 사항

- 판매요청은 기존 spread 방식에서 별도 정의로 변경 (컬럼 순서 및 라벨이 다르므로)