### PR TITLE
chore: 어드민 신고 관리 모달 첨부 이미지 영역 항상 표시(#491)

### DIFF
--- a/src/features/admin/components/reports/CommunityReportDetailModal.tsx
+++ b/src/features/admin/components/reports/CommunityReportDetailModal.tsx
@@ -106,9 +106,9 @@ export default function CommunityReportDetailModal({ isOpen, report, onClose }: 
             </div>
 
             {/* 첨부 이미지 */}
-            {report.imageUrls && report.imageUrls.length > 0 ? (
-              <div className="mt-4">
-                <p className="mb-1.5 text-sm font-medium text-gray-500">첨부 이미지</p>
+            <div className="mt-4">
+              <p className="mb-1.5 text-sm font-medium text-gray-500">첨부 이미지</p>
+              {report.imageUrls && report.imageUrls.length > 0 ? (
                 <div className="grid grid-cols-3 gap-3">
                   {report.imageUrls.map((src, idx) => (
                     /* eslint-disable-next-line @next/next/no-img-element */
@@ -116,12 +116,14 @@ export default function CommunityReportDetailModal({ isOpen, report, onClose }: 
                       key={idx}
                       src={src}
                       alt={`첨부 이미지 ${idx + 1}`}
-                      className="aspect-square w-full rounded-lg border border-gray-200 object-cover"
+                      className="aspect-square w-full rounded-lg border border-gray-200 bg-gray-100 object-cover"
                     />
                   ))}
                 </div>
-              </div>
-            ) : null}
+              ) : (
+                <p className="text-sm text-gray-400">첨부된 이미지가 없습니다.</p>
+              )}
+            </div>
           </div>
 
           {/* Footer */}

--- a/src/features/admin/components/reports/ProductRequestReportDetailModal.tsx
+++ b/src/features/admin/components/reports/ProductRequestReportDetailModal.tsx
@@ -75,9 +75,9 @@ export default function ProductRequestReportDetailModal({ isOpen, report, onClos
             </div>
 
             {/* 첨부 이미지 */}
-            {report.imageUrls && report.imageUrls.length > 0 ? (
-              <div className="mt-4">
-                <p className="mb-1.5 text-sm font-medium text-gray-500">첨부 이미지</p>
+            <div className="mt-4">
+              <p className="mb-1.5 text-sm font-medium text-gray-500">첨부 이미지</p>
+              {report.imageUrls && report.imageUrls.length > 0 ? (
                 <div className="grid grid-cols-3 gap-3">
                   {report.imageUrls.map((src, idx) => (
                     /* eslint-disable-next-line @next/next/no-img-element */
@@ -85,12 +85,14 @@ export default function ProductRequestReportDetailModal({ isOpen, report, onClos
                       key={idx}
                       src={src}
                       alt={`첨부 이미지 ${idx + 1}`}
-                      className="aspect-square w-full rounded-lg border border-gray-200 object-cover"
+                      className="aspect-square w-full rounded-lg border border-gray-200 bg-gray-100 object-cover"
                     />
                   ))}
                 </div>
-              </div>
-            ) : null}
+              ) : (
+                <p className="text-sm text-gray-400">첨부된 이미지가 없습니다.</p>
+              )}
+            </div>
           </div>
 
           {/* Footer */}

--- a/src/features/admin/components/reports/ProductSellReportDetailModal.tsx
+++ b/src/features/admin/components/reports/ProductSellReportDetailModal.tsx
@@ -75,9 +75,9 @@ export default function ProductSellReportDetailModal({ isOpen, report, onClose }
             </div>
 
             {/* 첨부 이미지 */}
-            {report.imageUrls && report.imageUrls.length > 0 ? (
-              <div className="mt-4">
-                <p className="mb-1.5 text-sm font-medium text-gray-500">첨부 이미지</p>
+            <div className="mt-4">
+              <p className="mb-1.5 text-sm font-medium text-gray-500">첨부 이미지</p>
+              {report.imageUrls && report.imageUrls.length > 0 ? (
                 <div className="grid grid-cols-3 gap-3">
                   {report.imageUrls.map((src, idx) => (
                     /* eslint-disable-next-line @next/next/no-img-element */
@@ -85,12 +85,14 @@ export default function ProductSellReportDetailModal({ isOpen, report, onClose }
                       key={idx}
                       src={src}
                       alt={`첨부 이미지 ${idx + 1}`}
-                      className="aspect-square w-full rounded-lg border border-gray-200 object-cover"
+                      className="aspect-square w-full rounded-lg border border-gray-200 bg-gray-100 object-cover"
                     />
                   ))}
                 </div>
-              </div>
-            ) : null}
+              ) : (
+                <p className="text-sm text-gray-400">첨부된 이미지가 없습니다.</p>
+              )}
+            </div>
           </div>
 
           {/* Footer */}

--- a/src/features/admin/components/reports/UserReportDetailModal.tsx
+++ b/src/features/admin/components/reports/UserReportDetailModal.tsx
@@ -83,9 +83,9 @@ export default function UserReportDetailModal({ isOpen, report, onClose }: UserR
             </div>
 
             {/* 첨부 이미지 */}
-            {report.imageUrls && report.imageUrls.length > 0 ? (
-              <div className="mt-4">
-                <p className="mb-1.5 text-sm font-medium text-gray-500">첨부 이미지</p>
+            <div className="mt-4">
+              <p className="mb-1.5 text-sm font-medium text-gray-500">첨부 이미지</p>
+              {report.imageUrls && report.imageUrls.length > 0 ? (
                 <div className="grid grid-cols-3 gap-3">
                   {report.imageUrls.map((src, idx) => (
                     /* eslint-disable-next-line @next/next/no-img-element */
@@ -93,12 +93,14 @@ export default function UserReportDetailModal({ isOpen, report, onClose }: UserR
                       key={idx}
                       src={src}
                       alt={`첨부 이미지 ${idx + 1}`}
-                      className="aspect-square w-full rounded-lg border border-gray-200 object-cover"
+                      className="aspect-square w-full rounded-lg border border-gray-200 bg-gray-100 object-cover"
                     />
                   ))}
                 </div>
-              </div>
-            ) : null}
+              ) : (
+                <p className="text-sm text-gray-400">첨부된 이미지가 없습니다.</p>
+              )}
+            </div>
           </div>
 
           {/* Footer */}


### PR DESCRIPTION
## 📌 개요

- 어드민 신고 관리 4개 모달에서 첨부 이미지 영역이 `imageUrls`가 없을 때 숨겨지던 문제 수정

## 🔧 작업 내용

- [x] UserReportDetailModal 첨부 이미지 영역 항상 표시
- [x] ProductSellReportDetailModal 첨부 이미지 영역 항상 표시
- [x] ProductRequestReportDetailModal 첨부 이미지 영역 항상 표시
- [x] CommunityReportDetailModal 첨부 이미지 영역 항상 표시

## 📎 관련 이슈

Closes #491

## 💬 리뷰어 참고 사항

- 이미지가 있으면 3열 그리드로 표시, 없으면 "첨부된 이미지가 없습니다." 텍스트 표시
- 이미지 로드 실패 시 `bg-gray-100` 배경으로 플레이스홀더 역할