### PR TITLE
chore: PWA manifest 및 메타데이터 설정 추가(#493)

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,22 @@
+{
+  "name": "커들마켓",
+  "short_name": "커들마켓",
+  "description": "반려동물 용품을 사고팔 수 있는 커들마켓",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#FF6F0F",
+  "icons": [
+    {
+      "src": "/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,13 @@ export const metadata: Metadata = {
   metadataBase: new URL('https://cuddle-market.vercel.app'),
   title: '커들마켓',
   description: '반려동물 용품을 사고팔 수 있는 커들마켓',
+  manifest: '/manifest.json',
+  themeColor: '#FF6F0F',
+  appleWebApp: {
+    capable: true,
+    statusBarStyle: 'black-translucent',
+    title: '커들마켓',
+  },
   verification: {
     google: 'QwSeEYXUKCcLgTD8CtBEEpERKpp34sHBD_6r8dvKM2Q',
   },


### PR DESCRIPTION
## 📌 개요

- 모바일에서 "홈 화면에 추가"로 앱처럼 사용할 수 있도록 PWA manifest 및 관련 메타데이터 추가

## 🔧 작업 내용

- [x] `public/manifest.json` 생성 (앱 이름, 아이콘, 테마 색상, standalone 모드)
- [x] `src/app/layout.tsx`에 manifest, themeColor, appleWebApp 메타데이터 추가

## 📎 관련 이슈

Closes #493

## 💬 리뷰어 참고 사항

- PWA 기본 설정만 추가 (Service Worker/오프라인 지원은 미포함)
- 아이콘 파일(`android-chrome-192x192.png`, `android-chrome-512x512.png`)은 public 디렉토리에 이미 존재하는 것으로 가정