### PR TITLE
refactor: Vercel React Best Practice 규칙 기반 조건부 렌더링 리팩토링(#497)

### DIFF
--- a/src/features/admin/components/auth/AdminLogin.tsx
+++ b/src/features/admin/components/auth/AdminLogin.tsx
@@ -86,7 +86,7 @@ export default function AdminLogin() {
               className="w-full rounded border border-gray-300 px-4 py-2 text-sm transition-colors outline-none focus:border-blue-400 focus:ring-1 focus:ring-blue-400"
               {...register('email', authValidationRules.email)}
             />
-            {errors.email && <p className="mt-1 text-xs text-red-500">{errors.email.message}</p>}
+            {errors.email ? <p className="mt-1 text-xs text-red-500">{errors.email.message}</p> : null}
           </div>
 
           <div>
@@ -97,10 +97,10 @@ export default function AdminLogin() {
               className="w-full rounded border border-gray-300 px-4 py-2 text-sm transition-colors outline-none focus:border-blue-400 focus:ring-1 focus:ring-blue-400"
               {...register('password', { required: '비밀번호를 입력해주세요' })}
             />
-            {errors.password && <p className="mt-1 text-xs text-red-500">{errors.password.message}</p>}
+            {errors.password ? <p className="mt-1 text-xs text-red-500">{errors.password.message}</p> : null}
           </div>
 
-          {error && <p className="text-left text-sm text-red-500">{error}</p>}
+          {error ? <p className="text-left text-sm text-red-500">{error}</p> : null}
 
           <button
             type="submit"

--- a/src/features/chatting-page/components/ChatLog.tsx
+++ b/src/features/chatting-page/components/ChatLog.tsx
@@ -213,7 +213,7 @@ export function ChatLog({
                   key={message.messageId}
                   className={cn('flex max-w-64 min-w-60 flex-col gap-1 rounded-lg px-3 py-2', isMine ? 'ml-auto' : 'mr-auto')}
                 >
-                  {!isMine && <p className="text-sm text-gray-600">{message.senderNickname}</p>}
+                  {!isMine ? <p className="text-sm text-gray-600">{message.senderNickname}</p> : null}
                   {message.messageType === 'IMAGE' ? (
                     <ChatImageMessage imageUrl={message.imageUrl ?? undefined} alt={message.senderNickname} />
                   ) : (


### PR DESCRIPTION
## 📌 개요

- Vercel React Best Practice Skill(58개 규칙)로 최근 변경 파일을 스캔하여 발견된 `&&` 조건부 렌더링 위반 4건을 삼항 연산자로 수정

## 🔧 작업 내용

- [ ] AdminLogin.tsx: `errors.email &&` → 삼항 연산자 (L89)
- [ ] AdminLogin.tsx: `errors.password &&` → 삼항 연산자 (L100)
- [ ] AdminLogin.tsx: `error &&` → 삼항 연산자 (L103)
- [ ] ChatLog.tsx: `!isMine &&` → 삼항 연산자 (L216)

## 📎 관련 이슈

Closes #497

## 💬 리뷰어 참고 사항

- `rendering-conditional-render` 규칙: `&&` 조건부 렌더링은 좌항이 falsy(0, '')일 때 의도치 않은 값이 렌더링될 수 있어 삼항 연산자로 통일