### PR TITLE
chore: Home 필터 영역 스타일링 개선(#508)

### DIFF
--- a/src/features/home/components/filter/CategoryFilter.tsx
+++ b/src/features/home/components/filter/CategoryFilter.tsx
@@ -29,17 +29,17 @@ export function CategoryFilter({ headingClassName, selectedCategory }: CategoryF
   }
   return (
     <div className="flex flex-col gap-2.5">
-      <h2 id="category-filter-heading" className={cn('heading-h4', headingClassName)}>
+      <h2 id="category-filter-heading" className={headingClassName ?? 'heading-h4'}>
         상품 카테고리
       </h2>
-      <div className="flex flex-wrap gap-2.5" role="group" aria-labelledby="category-filter-heading">
+      <div className="flex flex-wrap gap-1.5" role="group" aria-labelledby="category-filter-heading">
         {PRODUCT_CATEGORIES?.map((category) => (
           <Button
             key={category.code}
             type="button"
             size="sm"
             className={cn(
-              'border-primary-200 cursor-pointer border',
+              'border-primary-200 cursor-pointer border px-2.5 py-0.75',
               selectedCategory === category.code
                 ? 'bg-primary-300 font-bold text-white'
                 : 'hover:bg-primary-300 text-gray-900 hover:text-white'

--- a/src/features/home/components/filter/DetailFilterButton.tsx
+++ b/src/features/home/components/filter/DetailFilterButton.tsx
@@ -32,16 +32,16 @@ export function DetailFilterButton({ isOpen, onClick, ariaControls, filterReset 
     >
       <div className={cn('flex items-center gap-2')}>
         <FilterIcon className={cn('h-4 w-4')} aria-hidden="true" />
-        <span className={cn('font-sm font-bold')}>세부 필터</span>
+        <span className={cn('text-sm font-bold')}>세부 필터</span>
         {isMd ? (
-          <p className={cn('bg-primary-50 items-center justify-center overflow-hidden rounded-md px-3 py-1 text-sm')} aria-hidden="true">
+          <p className={cn('bg-primary-50 items-center justify-center overflow-hidden rounded-md px-3 py-1 text-xs')} aria-hidden="true">
             상품상태 · 가격대 · 지역
           </p>
         ) : null}
       </div>
 
       <div className="flex items-center gap-4">
-        <Button size="xs" type="button" className="bg-primary-50 cursor-pointer" onClick={filterReset}>
+        <Button size="xs" type="button" className="bg-primary-50 cursor-pointer py-[3px]" onClick={filterReset}>
           필터 초기화
         </Button>
         <DownArrow className={cn('h-6 w-6 text-gray-900 transition-transform', isOpen && 'rotate-180')} strokeWidth={2} aria-hidden="true" />

--- a/src/features/home/components/filter/PetTypeFilter.tsx
+++ b/src/features/home/components/filter/PetTypeFilter.tsx
@@ -62,17 +62,17 @@ export function PetTypeFilter({ activeTab, headingClassName, selectedDetailPet, 
 
   return (
     <div className="flex flex-col gap-2.5">
-      <h2 className={cn('heading-h4', headingClassName)}>반려동물 종류</h2>
+      <h2 className={headingClassName ?? 'heading-h4'}>반려동물 종류</h2>
       <div className="flex flex-col gap-4">
         <ProductPetTypeTabs activeTab={activeTab} onTabChange={onTabChange} />
-        <div className="flex flex-wrap gap-2.5" role="tabpanel" id={`panel-${selectedPetTypeCode}`} aria-labelledby={activeTab}>
+        <div className="flex flex-wrap gap-1.5" role="tabpanel" id={`panel-${selectedPetTypeCode}`} aria-labelledby={activeTab}>
           {displayedPetDetails.map((pet) => (
             <Button
               key={pet.code}
               type="button"
               size="sm"
               className={cn(
-                'border-primary-200 cursor-pointer border',
+                'border-primary-200 cursor-pointer border px-2.5 py-0.75',
                 selectedDetailPet === pet.code
                   ? 'bg-primary-300 font-bold text-white'
                   : 'hover:bg-primary-300 text-gray-900 hover:text-white'

--- a/src/features/home/components/tab/ProductPetTypeTabs.tsx
+++ b/src/features/home/components/tab/ProductPetTypeTabs.tsx
@@ -39,7 +39,7 @@ export function ProductPetTypeTabs({ activeTab, onTabChange }: ProductPetTypeTab
         ref={scrollRef}
         role="tablist"
         aria-label="반려동물 타입 대분류"
-        className={cn('border-b-primary-200 scrollbar-hide flex gap-1.5 overflow-x-auto pb-1 md:gap-2.5 md:overflow-visible md:border-b-2')}
+        className={cn('border-b-primary-200 scrollbar-hide flex gap-1.5 overflow-x-auto pb-1 md:gap-2.5 md:overflow-visible md:border-b-[1.5px]')}
       >
         {PET_TYPE_TABS.map((tab) => (
           <Button
@@ -49,7 +49,7 @@ export function ProductPetTypeTabs({ activeTab, onTabChange }: ProductPetTypeTab
             type="button"
             onClick={() => onTabChange(tab.id)}
             className={cn(
-              'bg-primary-100 text-md flex-1 cursor-pointer rounded-full py-1.5 whitespace-nowrap xl:rounded-2xl xl:bg-white xl:whitespace-normal',
+              'bg-primary-100 text-base flex-1 cursor-pointer rounded-full py-1.5 whitespace-nowrap xl:rounded-2xl xl:bg-white',
               activeTab === tab.id ? 'bg-primary-500 xl:bg-primary-300 font-bold text-white' : 'hover:bg-primary-100 text-gray-900',
             )}
             role="tab"


### PR DESCRIPTION
📌 개요
Home 페이지 필터 영역(반려동물 종류, 카테고리, 세부 필터)의 스타일링 개선

🔧 작업 내용
- PetTypeFilter/CategoryFilter heading className 충돌 해결 (cn 합성 → 기본값 대체 방식)
- 반려동물 탭 폰트 크기 text-base(16px), 패딩 py-1.5(6px) 조정
- 필터 버튼 gap 1.5, 패딩 조정
- DetailFilterButton 폰트 크기 조정 (text-sm, text-xs)
- ProductPetTypeTabs xl:whitespace-normal 제거 (줄바꿈 방지)

📎 관련 이슈
Closes #508