### PR TITLE
chore: 상품 카드 UI 개선(#511)

### DIFF
--- a/src/components/product/ProductMetaItem.tsx
+++ b/src/components/product/ProductMetaItem.tsx
@@ -11,7 +11,7 @@ export function ProductMetaItem({ icon: Icon, label, iconSize = 16, className = 
   return (
     <div className={`flex items-center gap-1 ${className}`}>
       <Icon size={iconSize} aria-hidden="true" />
-      <span className="font-medium whitespace-nowrap lg:text-sm">{label}</span>
+      <span className="text-xs font-semibold whitespace-nowrap">{label}</span>
     </div>
   )
 }

--- a/src/components/product/components/ProductBadge.tsx
+++ b/src/components/product/components/ProductBadge.tsx
@@ -9,8 +9,8 @@ interface ProductBadgeProps {
 export function ProductBadge({ petTypeName, productStatusName, productTypeName }: ProductBadgeProps) {
   return (
     <div className="gap-xs z-1 flex flex-wrap">
-      <Badge className="bg-primary-700 text-white">{petTypeName}</Badge>
-      {productTypeName !== '판매요청' ? <Badge className="bg-primary-200 text-gray-900">{productStatusName}</Badge> : null}
+      <Badge className="bg-primary-700 px-1.5 py-0 text-xs text-white">{petTypeName}</Badge>
+      {productTypeName !== '판매요청' ? <Badge className="bg-primary-200 px-1.5 py-0 text-xs text-gray-900">{productStatusName}</Badge> : null}
     </div>
   )
 }

--- a/src/components/product/components/ProductHeading.tsx
+++ b/src/components/product/components/ProductHeading.tsx
@@ -8,13 +8,13 @@ interface ProductHeadingProps {
 
 export function ProductHeading({ title, price, productTypeName }: ProductHeadingProps) {
   return (
-    <div className="flex flex-col gap-2">
-      <span className="heading-h5 line-clamp line-1 text-gray-900">{title}</span>
+    <div className="flex flex-col gap-1">
+      <span className="line-clamp line-1 text-base font-medium text-gray-900">{title}</span>
       <p className="flex w-full flex-col">
-        <span className="font-semibold text-gray-500">{productTypeName}</span>
         <span className="text-primary-300 max-w-[90%] overflow-hidden font-bold">
           <span>{formatPrice(price)}</span>원
         </span>
+        <span className="text-sm font-semibold text-gray-500">{productTypeName}</span>
       </p>
     </div>
   )

--- a/src/components/product/components/ProductInfo.tsx
+++ b/src/components/product/components/ProductInfo.tsx
@@ -16,8 +16,8 @@ export function ProductInfo({ title, price, createdAt, favoriteCount, productTyp
     <div className="flex h-full flex-1 flex-col justify-between gap-5 p-3 md:flex-none">
       <ProductHeading title={title} price={price} productTypeName={productTypeName} />
       <div className="flex w-full justify-between">
-        <ProductMetaItem icon={Clock} label={getTimeAgo(createdAt)} className="text-gray-400" />
-        <ProductMetaItem icon={Heart} label={favoriteCount} className="text-gray-400" />
+        <ProductMetaItem icon={Clock} label={getTimeAgo(createdAt)} iconSize={14} className="text-gray-400" />
+        <ProductMetaItem icon={Heart} label={favoriteCount} iconSize={14} className="text-gray-400" />
       </div>
     </div>
   )

--- a/src/components/product/components/ProductThumbnail.tsx
+++ b/src/components/product/components/ProductThumbnail.tsx
@@ -56,7 +56,7 @@ export function ProductThumbnail({
           onClick={onLikeClick}
         />
       </div>
-      <Badge className={cn('bottom-sm right-sm absolute z-1 text-white', productTradeColor)}>{displayTradeStatus}</Badge>
+      <Badge className={cn('bottom-sm right-sm absolute z-1 text-xs text-white', productTradeColor)}>{displayTradeStatus}</Badge>
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
         alt={title}


### PR DESCRIPTION
📌 개요
상품 카드의 텍스트 크기, 순서, 뱃지 스타일 개선

🔧 작업 내용
- 상품명 폰트: heading-h5 → text-base font-medium (16px)
- 가격/판매종류 순서 변경 (가격 먼저, 판매종류 아래)
- 판매종류 텍스트 text-sm(14px), 상품명-가격 간격 gap-1
- ProductBadge(열대어, 새 상품 등) 크기 축소 (text-xs, px-1.5, py-0)
- 썸네일 뱃지(판매중/판매완료) text-xs
- 시계/하트 아이콘 및 텍스트 크기 축소 (iconSize=14, text-xs, font-semibold)

📎 관련 이슈
Closes #511