### PR TITLE
chore: Home 상품 목록 grid 열 수 조정(#517)

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -111,13 +111,13 @@ export default function Header() {
                 <>
                   <Link
                     href={ROUTES.HOME}
-                    className={cn('text-md font-medium', isMarketActive ? 'border-white text-white' : 'text-gray-700')}
+                    className={cn('text-md font-extrabold', isMarketActive ? 'border-white text-white' : 'text-gray-700')}
                   >
                     마켓
                   </Link>
                   <Link
                     href={ROUTES.COMMUNITY}
-                    className={cn('text-md font-medium', isCommunityActive ? 'border-white text-white' : 'text-gray-700')}
+                    className={cn('text-md font-extrabold', isCommunityActive ? 'border-white text-white' : 'text-gray-700')}
                   >
                     커뮤니티
                   </Link>


### PR DESCRIPTION
📌 개요
Home 상품 목록의 grid 열 수 조정

🔧 작업 내용
- md 브레이크포인트: 3열 → 4열
- lg 브레이크포인트: 4열 → 5열

📎 관련 이슈
Closes #517