### PR TITLE
chore: 헤더 마켓/커뮤니티 링크 폰트 굵기 조정(#519)

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -111,13 +111,13 @@ export default function Header() {
                 <>
                   <Link
                     href={ROUTES.HOME}
-                    className={cn('text-md font-extrabold', isMarketActive ? 'border-white text-white' : 'text-gray-700')}
+                    className={cn('text-md font-medium', isMarketActive ? 'border-white text-white' : 'text-gray-700')}
                   >
                     마켓
                   </Link>
                   <Link
                     href={ROUTES.COMMUNITY}
-                    className={cn('text-md font-extrabold', isCommunityActive ? 'border-white text-white' : 'text-gray-700')}
+                    className={cn('text-md font-medium', isCommunityActive ? 'border-white text-white' : 'text-gray-700')}
                   >
                     커뮤니티
                   </Link>


### PR DESCRIPTION
📌 개요
헤더 마켓/커뮤니티 링크의 폰트 굵기 조정

🔧 작업 내용
- font-extrabold → font-medium 변경

📎 관련 이슈
Closes #519