### PR TITLE
chore: 상품 카드 및 상세페이지 UI 스타일링 개선(#521)

### DIFF
--- a/src/components/product/ProductMetaItem.tsx
+++ b/src/components/product/ProductMetaItem.tsx
@@ -1,17 +1,19 @@
 import type { LucideIcon } from 'lucide-react'
+import { cn } from '@/lib/utils/cn'
 
 interface ProductMetaItemProps {
   icon: LucideIcon
   iconSize?: number
   label: string | number
   className?: string // 색상 커스터마이징
+  textClassName?: string
 }
 
-export function ProductMetaItem({ icon: Icon, label, iconSize = 16, className = 'text-gray-500' }: ProductMetaItemProps) {
+export function ProductMetaItem({ icon: Icon, label, iconSize = 16, className = 'text-gray-500', textClassName }: ProductMetaItemProps) {
   return (
     <div className={`flex items-center gap-1 ${className}`}>
       <Icon size={iconSize} aria-hidden="true" />
-      <span className="text-xs font-semibold whitespace-nowrap">{label}</span>
+      <span className={cn('text-xs font-semibold whitespace-nowrap', textClassName)}>{label}</span>
     </div>
   )
 }

--- a/src/components/product/components/ProductInfo.tsx
+++ b/src/components/product/components/ProductInfo.tsx
@@ -16,8 +16,8 @@ export function ProductInfo({ title, price, createdAt, favoriteCount, productTyp
     <div className="flex h-full flex-1 flex-col justify-between gap-5 p-3 md:flex-none">
       <ProductHeading title={title} price={price} productTypeName={productTypeName} />
       <div className="flex w-full justify-between">
-        <ProductMetaItem icon={Clock} label={getTimeAgo(createdAt)} iconSize={14} className="text-gray-400" />
-        <ProductMetaItem icon={Heart} label={favoriteCount} iconSize={14} className="text-gray-400" />
+        <ProductMetaItem icon={Clock} label={getTimeAgo(createdAt)} iconSize={14} className="text-gray-400" textClassName="text-sm font-normal" />
+        <ProductMetaItem icon={Heart} label={favoriteCount} iconSize={14} className="text-gray-400" textClassName="text-sm font-normal" />
       </div>
     </div>
   )

--- a/src/features/home/components/filter/DetailFilterButton.tsx
+++ b/src/features/home/components/filter/DetailFilterButton.tsx
@@ -34,17 +34,24 @@ export function DetailFilterButton({ isOpen, onClick, ariaControls, filterReset 
         <FilterIcon className={cn('h-4 w-4')} aria-hidden="true" />
         <span className={cn('text-sm font-bold')}>세부 필터</span>
         {isMd ? (
-          <p className={cn('bg-primary-50 items-center justify-center overflow-hidden rounded-md px-3 py-1 text-xs')} aria-hidden="true">
+          <p
+            className={cn('bg-primary-50 items-center justify-center overflow-hidden rounded-md px-3 py-1 text-xs')}
+            aria-hidden="true"
+          >
             상품상태 · 가격대 · 지역
           </p>
         ) : null}
       </div>
 
       <div className="flex items-center gap-4">
-        <Button size="xs" type="button" className="bg-primary-50 cursor-pointer py-[3px]" onClick={filterReset}>
+        <Button size="xs" type="button" className="bg-primary-50 cursor-pointer py-0.75" onClick={filterReset}>
           필터 초기화
         </Button>
-        <DownArrow className={cn('h-6 w-6 text-gray-900 transition-transform', isOpen && 'rotate-180')} strokeWidth={2} aria-hidden="true" />
+        <DownArrow
+          className={cn('h-6 w-6 text-gray-900 transition-transform', isOpen && 'rotate-180')}
+          strokeWidth={2}
+          aria-hidden="true"
+        />
       </div>
     </div>
   )

--- a/src/features/product-detail/ProductDetail.tsx
+++ b/src/features/product-detail/ProductDetail.tsx
@@ -43,7 +43,7 @@ function ProductDetail({ initialData }: ProductDetailProps) {
       <div className="px-lg pb-4xl mx-auto max-w-7xl bg-white pt-8">
         <div className="flex flex-col gap-20">
           <div className="flex flex-col justify-center gap-8 md:flex-row">
-            <div className="flex flex-1 flex-col gap-4">
+            <div className="flex flex-1 flex-col gap-4 md:max-w-150">
               <MainImage {...data} />
               <SubImages {...data} />
               <SellerProfileCard sellerInfo={data.sellerInfo} />

--- a/src/features/product-detail/components/ProductBadges.tsx
+++ b/src/features/product-detail/components/ProductBadges.tsx
@@ -22,10 +22,10 @@ export default function ProductBadges({ tradeStatus, petDetailType, category, pr
 
   return (
     <div className="flex items-center gap-2 md:gap-1">
-      {tradeStatus ? <Badge className={cn('px-2.5 py-1.5 text-sm font-semibold text-white', productTradeColor)}>{productTradeName}</Badge> : null}
-      <Badge className={cn('bg-primary-700 px-2.5 py-1.5 text-sm font-semibold text-white')}>{petTypeName}</Badge>
-      <Badge className={cn('border bg-white px-2.5 py-1.5 text-sm font-semibold text-gray-900')}>{categoryName}</Badge>
-      <Badge className={cn('bg-primary-200 px-2.5 py-1.5 text-sm font-semibold')}>{productStatusName}</Badge>
+      {tradeStatus ? <Badge className={cn('px-2 py-1.5 text-[13px] font-semibold leading-none text-white', productTradeColor)}>{productTradeName}</Badge> : null}
+      <Badge className={cn('bg-primary-700 px-2 py-1.5 text-[13px] font-semibold leading-none text-white')}>{petTypeName}</Badge>
+      <Badge className={cn('border bg-white px-2 py-1.5 text-[13px] font-semibold leading-none text-gray-900')}>{categoryName}</Badge>
+      <Badge className={cn('bg-primary-200 px-2 py-1.5 text-[13px] font-semibold leading-none')}>{productStatusName}</Badge>
     </div>
   )
 }

--- a/src/features/product-detail/components/ProductMetadataList.tsx
+++ b/src/features/product-detail/components/ProductMetadataList.tsx
@@ -10,13 +10,19 @@ interface ProductMetadataListProps {
   favoriteCount: number
 }
 
-export default function ProductMetadataList({ addressSido, addressGugun, createdAt, viewCount, favoriteCount }: ProductMetadataListProps) {
+export default function ProductMetadataList({
+  addressSido,
+  addressGugun,
+  createdAt,
+  viewCount,
+  favoriteCount,
+}: ProductMetadataListProps) {
   return (
-    <div className="flex flex-wrap items-center gap-2 md:gap-5">
-      <ProductMetaItem icon={MapPin} label={`${addressSido} ${addressGugun}`} />
-      <ProductMetaItem icon={Clock} label={getTimeAgo(createdAt)} />
-      <ProductMetaItem icon={Eye} label={`조회 ${viewCount}`} />
-      <ProductMetaItem icon={Heart} label={`찜 ${favoriteCount}`} />
+    <div className="flex flex-wrap items-center gap-2 md:gap-3">
+      <ProductMetaItem icon={MapPin} iconSize={14} label={`${addressSido} ${addressGugun}`} textClassName="text-sm font-normal" />
+      <ProductMetaItem icon={Clock} iconSize={14} label={getTimeAgo(createdAt)} textClassName="text-sm font-normal" />
+      <ProductMetaItem icon={Eye} iconSize={14} label={`조회 ${viewCount}`} textClassName="text-sm font-normal" />
+      <ProductMetaItem icon={Heart} iconSize={14} label={`찜 ${favoriteCount}`} textClassName="text-sm font-normal" />
     </div>
   )
 }

--- a/src/features/product-detail/components/ProductTitle.tsx
+++ b/src/features/product-detail/components/ProductTitle.tsx
@@ -13,7 +13,7 @@ export default function ProductTitle({ title, productType, price }: ProductTitle
     <div className="flex flex-col gap-3.5">
       <h1 className="heading-h2_5 text-gray-900">{title}</h1>
       <div className="flex flex-col">
-        <span className="text-lg font-semibold text-gray-500">{productTypeName}</span>
+        <span className="text-base font-semibold text-gray-500">{productTypeName}</span>
         <strong className="text-primary-300 heading-h3 max-w-[90%] overflow-hidden">
           <span>{formatPrice(price)}</span>원
         </strong>

--- a/src/styles/tokens.typography.css
+++ b/src/styles/tokens.typography.css
@@ -14,10 +14,16 @@
   --text-h2--tracking: 0;
 
   /* H2.5 */
-  --text-h2_5: 28px;
-  --text-h2_5--line-height: 38px;
+  --text-h2_5: 26px;
+  --text-h2_5--line-height: 30px;
   --text-h2_5--weight: 700;
   --text-h2_5--tracking: 0;
+
+  /* H2.7 */
+  --text-h2_7: 28px;
+  --text-h2_7--line-height: 38px;
+  --text-h2_7--weight: 700;
+  --text-h2_7--tracking: 0;
 
   /* H3 */
   --text-h3: 24px;

--- a/src/styles/utilities/typography.css
+++ b/src/styles/utilities/typography.css
@@ -21,6 +21,13 @@
     letter-spacing: var(--text-h2_5--tracking);
   }
 
+  .heading-h2_7 {
+    font-size: var(--text-h2_7);
+    line-height: var(--text-h2_7--line-height);
+    font-weight: var(--text-h2_7--weight);
+    letter-spacing: var(--text-h2_7--tracking);
+  }
+
   .heading-h3 {
     font-size: var(--text-h3);
     line-height: var(--text-h3--line-height);


### PR DESCRIPTION
## 📌 개요

- 상품 카드 및 상세페이지의 메타정보, 뱃지, 폰트 크기 등 UI 스타일링 개선

## 🔧 작업 내용

- [x] ProductMetaItem에 textClassName prop 추가로 호출처별 스타일 커스터마이징 지원
- [x] 상품 카드/상세페이지 메타정보 폰트 크기(text-sm) 및 굵기(font-normal) 조정
- [x] 상품 상세페이지 대표 이미지 영역 md:max-w-150 제한
- [x] 상품 상세페이지 뱃지 스타일링 조정 (text-[13px], leading-none, px-2, py-1.5)
- [x] 상품 상세페이지 판매/판매요청 폰트 크기 text-base(16px) 변경
- [x] typography CSS 토큰 업데이트

## 📎 관련 이슈

Closes #521

## 💬 리뷰어 참고 사항

- ProductMetaItem은 공통 컴포넌트로 상품 카드와 상세페이지에서 모두 사용되며, textClassName prop으로 각 호출처에서 폰트 스타일을 개별 지정 가능