### PR TITLE
chore: 모바일 상품 카드 UI 스타일링 개선(#523)

### DIFF
--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -53,12 +53,7 @@ export default function Tabs({ tabs, activeTab, onTabChange, ariaLabel, excludeT
   }
 
   return (
-    <div
-      role="tablist"
-      aria-label={ariaLabel}
-      onKeyDown={handleKeyDown}
-      className={cn('flex w-fit gap-1 md:gap-2.5')}
-    >
+    <div role="tablist" aria-label={ariaLabel} onKeyDown={handleKeyDown} className={cn('flex w-fit gap-1 md:gap-2.5')}>
       {filteredTabs.map((tab) => (
         <Button
           key={tab.id}
@@ -68,7 +63,7 @@ export default function Tabs({ tabs, activeTab, onTabChange, ariaLabel, excludeT
           type="button"
           onClick={() => onTabChange(tab.id)}
           className={cn(
-            'flex-1 cursor-pointer rounded-full bg-white text-base whitespace-nowrap md:rounded-2xl md:bg-transparent',
+            'flex-1 cursor-pointer rounded-full bg-white text-sm whitespace-nowrap md:rounded-2xl md:bg-transparent md:text-base',
             activeTab === tab.id
               ? 'md:bg-primary-300 bg-primary-500 py-1.5 font-bold text-white'
               : 'md:hover:bg-primary-100 bg-gray-100 py-1.5 text-gray-900'

--- a/src/components/product/ProductCard.tsx
+++ b/src/components/product/ProductCard.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import type { Product } from '@/types/product'
 import { ProductThumbnail } from './components/ProductThumbnail'
@@ -31,9 +32,11 @@ function ProductCard({ data, 'data-index': dataIndex }: ProductCardProps) {
   const productTradeName = getTradeStatus(tradeStatus)
   const productTypeName = getProductType(productType)
   const productTradeColor = getTradeStatusColor(tradeStatus)
-  const handleCardClick = (e: React.MouseEvent) => {
-    e.stopPropagation()
+  const router = useRouter()
+  const handleContentClick = (e: React.MouseEvent) => {
+    if (window.getSelection()?.toString()) return
     window.scrollTo({ top: 0, behavior: 'smooth' })
+    router.push(ROUTES.DETAIL_ID(id, title))
   }
 
   return (
@@ -45,10 +48,9 @@ function ProductCard({ data, 'data-index': dataIndex }: ProductCardProps) {
         href={ROUTES.DETAIL_ID(id, title)}
         className="absolute inset-0 z-0"
         aria-label={`${title}, ${price}원, ${productStatusName}, ${petTypeName}, ${productTradeName}`}
-        onClick={handleCardClick}
       />
-      <div className="pointer-events-none relative z-1 flex cursor-pointer flex-row-reverse md:flex-col-reverse">
-        <ProductInfo title={title} price={price} createdAt={createdAt} favoriteCount={favoriteCount} productTypeName={productTypeName} />
+      <div className="relative z-1 flex cursor-pointer flex-row-reverse md:flex-col-reverse" onClick={handleContentClick}>
+        <ProductInfo title={title} price={price} createdAt={createdAt} favoriteCount={favoriteCount} productTypeName={productTypeName} isFavorite={isFavorite} onLikeClick={handleToggleFavorite} />
         <ProductThumbnail
           imageUrl={mainImageUrl}
           title={title}
@@ -57,8 +59,6 @@ function ProductCard({ data, 'data-index': dataIndex }: ProductCardProps) {
           productStatusName={productStatusName}
           tradeStatus={productTradeName}
           productTradeColor={productTradeColor}
-          isFavorite={isFavorite}
-          onLikeClick={handleToggleFavorite}
           priority={dataIndex !== undefined && dataIndex < 4}
         />
       </div>

--- a/src/components/product/components/ProductBadge.tsx
+++ b/src/components/product/components/ProductBadge.tsx
@@ -9,8 +9,8 @@ interface ProductBadgeProps {
 export function ProductBadge({ petTypeName, productStatusName, productTypeName }: ProductBadgeProps) {
   return (
     <div className="gap-xs z-1 flex flex-wrap">
-      <Badge className="bg-primary-700 px-1.5 py-0 text-xs text-white">{petTypeName}</Badge>
-      {productTypeName !== '판매요청' ? <Badge className="bg-primary-200 px-1.5 py-0 text-xs text-gray-900">{productStatusName}</Badge> : null}
+      <Badge className="bg-primary-700 px-1.5 py-1 text-[11px] font-semibold text-white">{petTypeName}</Badge>
+      {productTypeName !== '판매요청' ? <Badge className="bg-primary-200 px-1.5 py-1 text-[11px] font-semibold text-gray-900">{productStatusName}</Badge> : null}
     </div>
   )
 }

--- a/src/components/product/components/ProductHeading.tsx
+++ b/src/components/product/components/ProductHeading.tsx
@@ -9,12 +9,12 @@ interface ProductHeadingProps {
 export function ProductHeading({ title, price, productTypeName }: ProductHeadingProps) {
   return (
     <div className="flex flex-col gap-1">
-      <span className="line-clamp line-1 text-base font-medium text-gray-900">{title}</span>
+      <span className="line-clamp line-1 text-base font-normal md:font-medium text-gray-900">{title}</span>
       <p className="flex w-full flex-col">
         <span className="text-primary-300 max-w-[90%] overflow-hidden font-bold">
           <span>{formatPrice(price)}</span>원
         </span>
-        <span className="text-sm font-semibold text-gray-500">{productTypeName}</span>
+        <span className="text-[13px] md:text-sm font-normal md:font-semibold text-gray-500">{productTypeName}</span>
       </p>
     </div>
   )

--- a/src/components/product/components/ProductInfo.tsx
+++ b/src/components/product/components/ProductInfo.tsx
@@ -9,15 +9,20 @@ interface ProductInfoProps {
   createdAt: string
   favoriteCount: number
   productTypeName: string
+  isFavorite: boolean
+  onLikeClick: (e: React.MouseEvent) => void
 }
 
-export function ProductInfo({ title, price, createdAt, favoriteCount, productTypeName }: ProductInfoProps) {
+export function ProductInfo({ title, price, createdAt, favoriteCount, productTypeName, isFavorite, onLikeClick }: ProductInfoProps) {
   return (
-    <div className="flex h-full flex-1 flex-col justify-between gap-5 p-3 md:flex-none">
+    <div className="flex h-full flex-[3] flex-col justify-between gap-5 p-3 md:flex-none">
       <ProductHeading title={title} price={price} productTypeName={productTypeName} />
       <div className="flex w-full justify-between">
-        <ProductMetaItem icon={Clock} label={getTimeAgo(createdAt)} iconSize={14} className="text-gray-400" textClassName="text-sm font-normal" />
-        <ProductMetaItem icon={Heart} label={favoriteCount} iconSize={14} className="text-gray-400" textClassName="text-sm font-normal" />
+        <ProductMetaItem icon={Clock} label={getTimeAgo(createdAt)} iconSize={13} className="text-gray-400" textClassName="text-[13px] md:text-sm font-normal" />
+        <button type="button" className="pointer-events-auto flex cursor-pointer items-center gap-1 text-gray-400" onClick={onLikeClick} aria-label="찜하기">
+          <Heart size={13} color={isFavorite ? '#fc8181' : 'currentColor'} fill={isFavorite ? '#fc8181' : 'none'} aria-hidden="true" />
+          <span className="text-[13px] md:text-sm font-normal">{favoriteCount}</span>
+        </button>
       </div>
     </div>
   )

--- a/src/components/product/components/ProductThumbnail.tsx
+++ b/src/components/product/components/ProductThumbnail.tsx
@@ -1,6 +1,4 @@
 import { ProductBadge } from './ProductBadge'
-import Button from '@/components/commons/button/Button'
-import { Heart } from 'lucide-react'
 import Badge from '@/components/commons/badge/Badge'
 import { cn } from '@/lib/utils/cn'
 import { getImageSrcSet, IMAGE_SIZES, toResizedWebpUrl, PLACEHOLDER_IMAGES, PLACEHOLDER_SRCSET } from '@/lib/utils/imageUrl'
@@ -13,8 +11,6 @@ interface ProductThumbnailProps {
   productTypeName: string
   tradeStatus: string | null
   productTradeColor: string
-  isFavorite: boolean
-  onLikeClick: (e: React.MouseEvent) => void
   priority?: boolean
 }
 
@@ -26,8 +22,6 @@ export function ProductThumbnail({
   tradeStatus,
   productTypeName,
   productTradeColor,
-  isFavorite,
-  onLikeClick,
   priority = false,
 }: ProductThumbnailProps) {
   const getDisplayTradeStatus = () => {
@@ -40,21 +34,9 @@ export function ProductThumbnail({
   const displayTradeStatus = getDisplayTradeStatus()
 
   return (
-    <div className="relative flex-1 overflow-hidden pb-[35%] md:flex-none md:pb-[75%]">
-      <div className="top-sm px-sm absolute flex w-full justify-between">
+    <div className="relative flex-[2] overflow-hidden pb-[35%] md:flex-none md:pb-[75%]">
+      <div className="top-sm px-sm absolute z-1">
         <ProductBadge petTypeName={petTypeName} productStatusName={productStatusName} productTypeName={productTypeName} />
-        <Button
-          type="button"
-          className="pointer-events-auto z-1 flex cursor-pointer items-center justify-center rounded-full bg-gray-100"
-          aria-label="찜하기"
-          icon={Heart}
-          iconProps={{
-            color: isFavorite ? '#fc8181' : undefined,
-            fill: isFavorite ? '#fc8181' : 'none',
-          }}
-          size="xs"
-          onClick={onLikeClick}
-        />
       </div>
       <Badge className={cn('bottom-sm right-sm absolute z-1 text-xs text-white', productTradeColor)}>{displayTradeStatus}</Badge>
       {/* eslint-disable-next-line @next/next/no-img-element */}

--- a/src/features/home/components/filter/PetTypeFilter.tsx
+++ b/src/features/home/components/filter/PetTypeFilter.tsx
@@ -87,7 +87,7 @@ export function PetTypeFilter({ activeTab, headingClassName, selectedDetailPet, 
             <Button
               type="button"
               size="sm"
-              className="cursor-pointer bg-gray-100 text-gray-600 md:hidden"
+              className="cursor-pointer bg-gray-100 py-0.75 px-2.5 text-gray-600 md:hidden"
               onClick={() => setShowAll(true)}
             >
               더보기 ({filteredPetDetails.length - INITIAL_DISPLAY_COUNT}개)

--- a/src/features/home/components/product-section/ProductsSection.tsx
+++ b/src/features/home/components/product-section/ProductsSection.tsx
@@ -25,12 +25,7 @@ interface ProductsSectionProps {
   selectedSort?: string
 }
 
-export function ProductsSection({
-  products,
-  totalElements,
-  activeTab,
-  selectedSort = '최신순',
-}: ProductsSectionProps) {
+export function ProductsSection({ products, totalElements, activeTab, selectedSort = '최신순' }: ProductsSectionProps) {
   const { searchParams, pathname, push } = useFilterNavigation()
 
   const activeTabCode = PRODUCT_TYPE_TABS.find((tab) => tab.id === activeTab)?.code

--- a/src/features/home/components/tab/ProductPetTypeTabs.tsx
+++ b/src/features/home/components/tab/ProductPetTypeTabs.tsx
@@ -39,7 +39,9 @@ export function ProductPetTypeTabs({ activeTab, onTabChange }: ProductPetTypeTab
         ref={scrollRef}
         role="tablist"
         aria-label="반려동물 타입 대분류"
-        className={cn('border-b-primary-200 scrollbar-hide flex gap-1.5 overflow-x-auto pb-1 md:gap-2.5 md:overflow-visible md:border-b-[1.5px]')}
+        className={cn(
+          'border-b-primary-200 scrollbar-hide flex gap-1.5 overflow-x-auto pb-1 md:gap-2.5 md:overflow-visible md:border-b-[1.5px]'
+        )}
       >
         {PET_TYPE_TABS.map((tab) => (
           <Button
@@ -49,8 +51,10 @@ export function ProductPetTypeTabs({ activeTab, onTabChange }: ProductPetTypeTab
             type="button"
             onClick={() => onTabChange(tab.id)}
             className={cn(
-              'bg-primary-100 text-base flex-1 cursor-pointer rounded-full py-1.5 whitespace-nowrap xl:rounded-2xl xl:bg-white',
-              activeTab === tab.id ? 'bg-primary-500 xl:bg-primary-300 font-bold text-white' : 'hover:bg-primary-100 text-gray-900',
+              'bg-primary-100 flex-1 cursor-pointer rounded-full py-1.5 text-sm whitespace-nowrap md:text-base xl:rounded-2xl xl:bg-white',
+              activeTab === tab.id
+                ? 'bg-primary-500 xl:bg-primary-300 font-bold text-white'
+                : 'hover:bg-primary-100 text-gray-900'
             )}
             role="tab"
             aria-selected={activeTab === tab.id}


### PR DESCRIPTION
## 📌 개요

- 모바일 메인페이지 상품 카드의 레이아웃 및 스타일링을 개선합니다.

## 🔧 작업 내용

- [x] 썸네일/정보 영역 비율 조정 (flex-1:flex-1 → flex-[2]:flex-[3])
- [x] 카드 전체 클릭 + 텍스트 드래그 + 좋아요 버튼 동시 동작 지원
- [x] 좋아요 버튼을 썸네일 영역에서 상품 정보 영역으로 이동
- [x] 뱃지 스타일링 통일 (text-[11px], font-semibold, py-1)
- [x] 뱃지-하트 버튼 정렬 개선 (items-start)
- [x] 모바일 환경 폰트 크기/굵기 조정 (상품명, 판매타입, 메타 정보)

## 📎 관련 이슈

Closes #523

## 💬 리뷰어 참고 사항

- 모바일 환경에서의 변경이 주이며, md 이상 데스크톱 레이아웃에는 영향 없도록 반응형 클래스 적용
- 좋아요 버튼 이동으로 ProductThumbnail에서 하트 관련 props/코드 제거, ProductInfo에 추가