### PR TITLE
chore: 모바일 사이드바 및 상세페이지 UI 스타일링 개선(#527)

### DIFF
--- a/src/components/header/components/MobileNavigation.tsx
+++ b/src/components/header/components/MobileNavigation.tsx
@@ -62,7 +62,7 @@ export default function MobileNavigation({ isOpen, onClose }: MobileNavigationPr
       />
       <nav
         className={cn(
-          'fixed top-0 left-0 h-full w-9/12 -translate-x-full overflow-y-auto bg-white px-4 py-5 transition-transform data-[open=true]:translate-x-0',
+          'fixed top-0 right-0 h-full w-full translate-x-full overflow-y-auto bg-white px-4 py-5 transition-transform duration-300 data-[open=true]:translate-x-0',
           Z_INDEX.SIDEBAR,
         )}
         data-open={isOpen}
@@ -80,7 +80,7 @@ export default function MobileNavigation({ isOpen, onClose }: MobileNavigationPr
               <button
                 type="button"
                 onClick={openLogoutConfirm}
-                className="border-primary-200 text-primary-200 flex-1 cursor-pointer rounded-sm border py-2 text-center text-sm font-bold"
+                className="border-primary-200 text-primary-200 flex-1 cursor-pointer rounded-sm border py-2 text-center text-sm font-semibold"
               >
                 로그아웃
               </button>
@@ -88,7 +88,7 @@ export default function MobileNavigation({ isOpen, onClose }: MobileNavigationPr
               <Link
                 href={ROUTES.LOGIN}
                 onClick={onClose}
-                className="border-primary-200 text-primary-200 flex-1 rounded-sm border py-2 text-center text-sm font-bold"
+                className="border-primary-200 text-primary-200 flex-1 rounded-sm border py-2 text-center text-sm font-semibold"
               >
                 로그인
               </Link>
@@ -96,7 +96,7 @@ export default function MobileNavigation({ isOpen, onClose }: MobileNavigationPr
             <Link
               href={hasHydrated && isLogin() ? ROUTES.MYPAGE : ROUTES.SIGNUP}
               onClick={onClose}
-              className="border-primary-200 bg-primary-200 flex-1 rounded-sm border py-2 text-center text-sm font-bold text-white"
+              className="border-primary-200 bg-primary-200 flex-1 rounded-sm border py-2 text-center text-sm font-normal text-white"
             >
               {hasHydrated && isLogin() ? '마이페이지' : '회원가입'}
             </Link>
@@ -104,7 +104,7 @@ export default function MobileNavigation({ isOpen, onClose }: MobileNavigationPr
         </div>
         <div className="pt-5">
           <Link href={ROUTES.HOME} onClick={onClose} className="flex w-full items-center justify-between py-2">
-            <span className="font-bold">마켓</span>
+            <span className="font-normal">마켓</span>
           </Link>
           <div>
             <button
@@ -112,7 +112,7 @@ export default function MobileNavigation({ isOpen, onClose }: MobileNavigationPr
               onClick={() => setIsCommunityOpen((prev) => !prev)}
               className="flex w-full cursor-pointer items-center justify-between py-2"
             >
-              <span className="font-bold">커뮤니티</span>
+              <span className="font-normal">커뮤니티</span>
               <ChevronDown className={cn('h-5 w-5 transition-transform', isCommunityOpen && 'rotate-180')} />
             </button>
             <div
@@ -120,7 +120,7 @@ export default function MobileNavigation({ isOpen, onClose }: MobileNavigationPr
               className="overflow-hidden transition-[height] duration-300"
               style={{ height: isCommunityOpen ? `${communityHeight}px` : '0' }}
             >
-              <div className="flex flex-col gap-2 pt-2 pl-4">
+              <div className="flex flex-col gap-2 pl-4">
                 <Link href={`${ROUTES.COMMUNITY}?tab=tab-question`} onClick={onClose}>
                   질문 있어요
                 </Link>
@@ -132,7 +132,7 @@ export default function MobileNavigation({ isOpen, onClose }: MobileNavigationPr
           </div>
           <div>
             <button type="button" onClick={() => setIsCustomerOpen((prev) => !prev)} className="flex w-full items-center justify-between py-2">
-              <span className="font-bold">고객센터</span>
+              <span className="font-normal">고객센터</span>
               <ChevronDown className={cn('h-5 w-5 transition-transform', isCustomerOpen && 'rotate-180')} />
             </button>
             <div
@@ -140,7 +140,7 @@ export default function MobileNavigation({ isOpen, onClose }: MobileNavigationPr
               className="overflow-hidden transition-[height] duration-300"
               style={{ height: isCustomerOpen ? `${customerHeight}px` : '0' }}
             >
-              <div className="flex flex-col gap-2 pt-2 pl-4">
+              <div className="flex flex-col gap-2 pl-4">
                 <a href="mailto:support@cuddlemarket.com?subject=허들마켓 1:1 문의">1:1 문의</a>
               </div>
             </div>

--- a/src/components/product/components/ProductHeading.tsx
+++ b/src/components/product/components/ProductHeading.tsx
@@ -14,7 +14,7 @@ export function ProductHeading({ title, price, productTypeName }: ProductHeading
         <span className="text-primary-300 max-w-[90%] overflow-hidden font-bold">
           <span>{formatPrice(price)}</span>원
         </span>
-        <span className="text-[13px] md:text-sm font-normal md:font-semibold text-gray-500">{productTypeName}</span>
+        {productTypeName ? <span className="text-[13px] md:text-sm font-normal md:font-semibold text-gray-500">{productTypeName}</span> : null}
       </p>
     </div>
   )

--- a/src/components/product/components/ProductInfo.tsx
+++ b/src/components/product/components/ProductInfo.tsx
@@ -15,7 +15,7 @@ interface ProductInfoProps {
 
 export function ProductInfo({ title, price, createdAt, favoriteCount, productTypeName, isFavorite, onLikeClick }: ProductInfoProps) {
   return (
-    <div className="flex h-full flex-[3] flex-col justify-between gap-5 p-3 md:flex-none">
+    <div className="flex flex-[3] flex-col justify-between gap-5 p-3 md:flex-none">
       <ProductHeading title={title} price={price} productTypeName={productTypeName} />
       <div className="flex w-full justify-between">
         <ProductMetaItem icon={Clock} label={getTimeAgo(createdAt)} iconSize={13} className="text-gray-400" textClassName="text-[13px] md:text-sm font-normal" />

--- a/src/features/product-detail/ProductDetail.tsx
+++ b/src/features/product-detail/ProductDetail.tsx
@@ -4,6 +4,7 @@ import { useParams } from 'next/navigation'
 import { useQuery } from '@tanstack/react-query'
 import { api } from '@/lib/api/api'
 import Footer from '@/components/footer/Footer'
+import ProductDetailMobileMeta from './components/ProductDetailMobileMeta'
 import MainImage from './components/MainImage'
 import SubImages from './components/SubImages'
 import SellerProfileCard from './components/SellerProfileCard'
@@ -49,13 +50,14 @@ function ProductDetail({ initialData }: ProductDetailProps) {
               <SellerProfileCard sellerInfo={data.sellerInfo} />
             </div>
 
-            <div className="flex flex-1 flex-col gap-3.5">
-              <div className="flex flex-col gap-6">
+            <div className="flex flex-1 flex-col gap-5">
+              <div className="flex flex-col gap-3 md:gap-6">
                 <div className="flex flex-col gap-3.5">
                   <ProductBadges {...data} />
                   <ProductSummary data={data} />
                 </div>
                 <ProductDescription description={data.description} />
+                <ProductDetailMobileMeta productId={data.id} productTitle={data.title} viewCount={data.viewCount} favoriteCount={data.favoriteCount} />
               </div>
               <ProductActions {...data} />
             </div>

--- a/src/features/product-detail/components/ProductDetailMobileMeta.tsx
+++ b/src/features/product-detail/components/ProductDetailMobileMeta.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { useState } from 'react'
+import { Eye, Heart, Flag } from 'lucide-react'
+import { ProductMetaItem } from '@/components/product/ProductMetaItem'
+import ProductReportModal from '@/components/modal/ProductReportModal'
+
+interface ProductDetailMobileMetaProps {
+  productId: number
+  productTitle: string
+  viewCount: number
+  favoriteCount: number
+}
+
+export default function ProductDetailMobileMeta({ productId, productTitle, viewCount, favoriteCount }: ProductDetailMobileMetaProps) {
+  const [isReportOpen, setIsReportOpen] = useState(false)
+
+  return (
+    <>
+      <div className="flex items-center justify-between md:hidden">
+        <div className="flex items-center gap-2">
+          <ProductMetaItem icon={Eye} iconSize={14} label={`조회 ${viewCount}`} textClassName="text-sm font-normal" />
+          <ProductMetaItem icon={Heart} iconSize={14} label={`찜 ${favoriteCount}`} textClassName="text-sm font-normal" />
+        </div>
+        <button
+          type="button"
+          onClick={() => setIsReportOpen(true)}
+          className="flex cursor-pointer items-center gap-1 text-sm text-gray-400 hover:text-red-500"
+        >
+          <Flag size={14} />
+          <span>신고하기</span>
+        </button>
+      </div>
+      <ProductReportModal
+        isOpen={isReportOpen}
+        productId={productId}
+        productTitle={productTitle}
+        onCancel={() => setIsReportOpen(false)}
+      />
+    </>
+  )
+}

--- a/src/features/product-detail/components/ProductMetadataList.tsx
+++ b/src/features/product-detail/components/ProductMetadataList.tsx
@@ -21,8 +21,8 @@ export default function ProductMetadataList({
     <div className="flex flex-wrap items-center gap-2 md:gap-3">
       <ProductMetaItem icon={MapPin} iconSize={14} label={`${addressSido} ${addressGugun}`} textClassName="text-sm font-normal" />
       <ProductMetaItem icon={Clock} iconSize={14} label={getTimeAgo(createdAt)} textClassName="text-sm font-normal" />
-      <ProductMetaItem icon={Eye} iconSize={14} label={`조회 ${viewCount}`} textClassName="text-sm font-normal" />
-      <ProductMetaItem icon={Heart} iconSize={14} label={`찜 ${favoriteCount}`} textClassName="text-sm font-normal" />
+      <span className="hidden md:flex"><ProductMetaItem icon={Eye} iconSize={14} label={`조회 ${viewCount}`} textClassName="text-sm font-normal" /></span>
+      <span className="hidden md:flex"><ProductMetaItem icon={Heart} iconSize={14} label={`찜 ${favoriteCount}`} textClassName="text-sm font-normal" /></span>
     </div>
   )
 }

--- a/src/features/product-detail/components/ProductSummary.tsx
+++ b/src/features/product-detail/components/ProductSummary.tsx
@@ -37,7 +37,7 @@ export default function ProductSummary({ data }: ProductHeaderProps) {
         <button
           type="button"
           onClick={() => setIsReportOpen(true)}
-          className="flex cursor-pointer items-center gap-1 text-sm text-gray-400 hover:text-red-500"
+          className="hidden cursor-pointer items-center gap-1 text-sm text-gray-400 hover:text-red-500 md:flex"
         >
           <Flag size={14} />
           <span>신고하기</span>

--- a/src/features/product-detail/components/ProductTitle.tsx
+++ b/src/features/product-detail/components/ProductTitle.tsx
@@ -11,7 +11,7 @@ export default function ProductTitle({ title, productType, price }: ProductTitle
   const productTypeName = getProductType(productType)
   return (
     <div className="flex flex-col gap-3.5">
-      <h1 className="heading-h2_5 text-gray-900">{title}</h1>
+      <h1 className="heading-h3 text-gray-900">{title}</h1>
       <div className="flex flex-col">
         <span className="text-base font-semibold text-gray-500">{productTypeName}</span>
         <strong className="text-primary-300 heading-h3 max-w-[90%] overflow-hidden">

--- a/src/features/product-detail/components/SellerOtherProducts.tsx
+++ b/src/features/product-detail/components/SellerOtherProducts.tsx
@@ -15,7 +15,7 @@ interface SellerOtherProductsProps {
 export default function SellerOtherProducts({ sellerInfo, sellerOtherProducts }: SellerOtherProductsProps) {
   return (
     <div className="pb-4xl">
-      <h2 className="heading-h4 text-text-primary mb-lg">{sellerInfo?.sellerNickname}님의 다른 판매 상품</h2>
+      <h2 className="mb-lg text-[18px] leading-[26px] font-bold">{sellerInfo?.sellerNickname}님의 다른 판매 상품</h2>
 
       {sellerOtherProducts?.length !== 0 ? (
         <ProductList products={sellerOtherProducts.slice(0, 3)} showMoreButton sellerId={sellerInfo.sellerId} />

--- a/src/features/product-detail/components/SellerProfileCard.tsx
+++ b/src/features/product-detail/components/SellerProfileCard.tsx
@@ -33,7 +33,7 @@ export default function SellerProfileCard({ sellerInfo }: SellerProfileCardProps
 
   return (
     sellerInfo?.sellerId !== user?.id && (
-      <div className="flex justify-between rounded-lg border border-gray-300 p-5">
+      <div className="flex items-center justify-between rounded-lg border border-gray-300 p-3">
         <div className="flex items-center gap-2">
           <div className="bg-primary-50 relative flex h-10 w-10 items-center justify-center overflow-hidden rounded-full">
             {sellerInfo.sellerProfileImageUrl ? (
@@ -51,11 +51,11 @@ export default function SellerProfileCard({ sellerInfo }: SellerProfileCardProps
               <div className="heading-h5 font-normal!">{sellerInfo?.sellerNickname.charAt(0).toUpperCase()}</div>
             )}
           </div>
-          <h2 className="text-gray-900">{sellerInfo?.sellerNickname}</h2>
+          <h2 className="font-medium text-gray-900">{sellerInfo?.sellerNickname}</h2>
         </div>
         <Button
           size="sm"
-          className="h-fit cursor-pointer border border-gray-300 bg-white text-sm text-gray-900"
+          className="h-fit cursor-pointer border border-gray-300 bg-white text-xs md:text-sm text-gray-900"
           onClick={() => goToUserPage(sellerInfo.sellerId)}
         >
           판매자 프로필 보기

--- a/src/styles/tokens.typography.css
+++ b/src/styles/tokens.typography.css
@@ -13,17 +13,17 @@
   --text-h2--weight: 700;
   --text-h2--tracking: 0;
 
-  /* H2.5 */
-  --text-h2_5: 26px;
-  --text-h2_5--line-height: 30px;
-  --text-h2_5--weight: 700;
-  --text-h2_5--tracking: 0;
-
   /* H2.7 */
   --text-h2_7: 28px;
   --text-h2_7--line-height: 38px;
   --text-h2_7--weight: 700;
   --text-h2_7--tracking: 0;
+
+  /* H2.5 */
+  --text-h2_5: 26px;
+  --text-h2_5--line-height: 30px;
+  --text-h2_5--weight: 700;
+  --text-h2_5--tracking: 0;
 
   /* H3 */
   --text-h3: 24px;


### PR DESCRIPTION
## 📌 개요

- 모바일 환경에서의 사이드바 및 상세페이지 UI 스타일링을 개선합니다.

## 🔧 작업 내용

- [x] 모바일 사이드바: 오른쪽에서 열리도록 변경, 전체 너비 적용, 애니메이션 속도 조정 (duration-300)
- [x] 모바일 사이드바: 메뉴/버튼 폰트 굵기 및 하위메뉴 간격 조정
- [x] 상세페이지: 상품명 크기 조정 (heading-h2_5 → heading-h3)
- [x] 상세페이지: 판매자 프로필 카드 패딩 축소, 수직 가운데 정렬, 닉네임 font-medium 적용
- [x] 상세페이지: 모바일에서 조회/찜 메타정보를 상세설명 아래로 이동 (ProductDetailMobileMeta 신규)
- [x] 상품 카드: productTypeName 빈 값일 때 렌더링 제거
- [x] 다른 판매 상품 제목: heading 커스텀 클래스를 Tailwind 유틸리티로 변경

## 📎 관련 이슈

Closes #527

## 💬 리뷰어 참고 사항

- 모바일 환경 중심의 스타일링 변경이며, 데스크톱에서는 기존 스타일 유지
- ProductDetailMobileMeta는 모바일 전용 컴포넌트 (md:hidden)로 조회/찜 + 신고하기를 상세설명 아래에 배치
- 상세페이지의 ProductSummary에서 모바일 시 신고하기 버튼과 조회/찜 메타정보를 숨기고 ProductDetailMobileMeta에서 대신 표시