### PR TITLE
chore: EmptyState 및 모바일 검색창 UI 스타일링 개선(#529)

### DIFF
--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -15,9 +15,9 @@ export default function EmptyState({ icon: Icon, title, description, className =
       <div className="bg-primary-50 flex h-25 w-25 items-center justify-center rounded-full">
         <Icon size={50} strokeWidth={1} className="text-primary-300" />
       </div>
-      <div className="flex flex-col items-center gap-2">
-        <p className="heading-h4">{title}</p>
-        {description ? <p className="text-gray-500">{description}</p> : null}
+      <div className="flex flex-col items-center gap-1 md:gap-2">
+        <p className="text-base font-semibold md:heading-h5">{title}</p>
+        {description ? <p className="text-sm text-gray-500">{description}</p> : null}
       </div>
     </div>
   )

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -50,7 +50,7 @@ export default function Header() {
   const [isSideOpen, setIsSideOpen] = useState(false)
   const [isSearchOpen, setIsSearchOpen] = useState(false)
   // 검색바 높이: h-8(32px) 고정 디자인이므로 상수 사용 (scrollHeight 접근에 의한 강제 리플로우 방지)
-  const searchBarHeight = 32
+  const searchBarHeight = 40
   const pathname = usePathname()
 
   // 가시성 계산
@@ -149,7 +149,7 @@ export default function Header() {
               }}
             >
               <Suspense>
-                <SearchBar id="search-mobile" className="h-8 xl:hidden" inputClass="py-1 text-sm" />
+                <SearchBar id="search-mobile" className="h-10 xl:hidden" inputClass="py-1 text-[15px]" />
               </Suspense>
             </div>
           ) : null}


### PR DESCRIPTION
## 📌 개요

- EmptyState 컴포넌트와 모바일 검색창의 UI 스타일링을 개선합니다.

## 🔧 작업 내용

- [x] EmptyState: 모바일 제목 폰트 크기 축소 (heading-h5 → text-base font-semibold)
- [x] EmptyState: 설명 폰트 크기 text-sm 적용
- [x] EmptyState: 모바일 제목/설명 간격 조정 (gap-1)
- [x] 모바일 검색창: 높이 h-8 → h-10 으로 확대
- [x] 모바일 검색창: 폰트 크기 text-[15px] 적용

## 📎 관련 이슈

Closes #529

## 💬 리뷰어 참고 사항

- EmptyState는 공용 컴포넌트로 다른 페이지에서도 사용되므로 모바일 반응형 클래스로 적용
- 검색창 높이 변경에 따라 헤더 높이 계산 상수(searchBarHeight)도 32 → 40으로 업데이트