### PR TITLE
chore: 푸터 스타일링 개선 및 페이지별 적용(#531)

### DIFF
--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -4,18 +4,18 @@ import Link from 'next/link'
 
 export default function Footer() {
   return (
-    <footer className="border-border bg-light border-t">
+    <footer className="hidden border-border bg-light border-t md:block">
       <div className="px-lg mx-auto max-w-7xl py-12">
         <div className="flex flex-wrap justify-baseline gap-x-10 gap-y-5 md:justify-between md:gap-0">
           <div className="flex flex-col gap-2">
             <Logo logoClassname="h-12" textClassname="text-gray-400" />
-            <p className="text-gray-500">반려동물과 함께하는 행복한 반려동물 용품 거래를 경험하세요.</p>
+            <p className="text-sm text-gray-500">반려동물과 함께하는 행복한 반려동물 용품 거래를 경험하세요.</p>
           </div>
 
           <nav aria-label="푸터 링크" className="flex flex-wrap gap-x-10 gap-y-5">
             <div className="flex flex-col gap-4">
               <strong className="font-semibold text-gray-500">커뮤니티</strong>
-              <ul className="flex flex-col gap-3 text-gray-500">
+              <ul className="flex flex-col gap-2 text-sm text-gray-500">
                 <li>
                   <Link href={`${ROUTES.COMMUNITY}?tab=tab-info`}>정보 공유해요</Link>
                 </li>
@@ -27,7 +27,7 @@ export default function Footer() {
 
             <div className="flex flex-col gap-4">
               <strong className="font-semibold text-gray-500">고객센터</strong>
-              <ul className="flex flex-col gap-3 text-gray-500">
+              <ul className="flex flex-col gap-2 text-sm text-gray-500">
                 <li>
                   <a href="mailto:support@cuddlemarket.com?subject=커들마켓 1:1 문의" aria-label="고객센터 이메일로 1:1 문의하기">
                     1:1 문의
@@ -39,7 +39,7 @@ export default function Footer() {
         </div>
 
         <div className="mt-6 border-t border-gray-300 pt-6">
-          <p className="text-center text-gray-500">© 2025 커들마켓. All rights reserved.</p>
+          <p className="text-center text-sm text-gray-500">© 2026 커들마켓. All rights reserved.</p>
         </div>
       </div>
     </footer>

--- a/src/features/UserPage.tsx
+++ b/src/features/UserPage.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import ProfileData from '@/components/profile/ProfileData'
+import Footer from '@/components/footer/Footer'
 import { useState } from 'react'
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useRouter, useParams } from 'next/navigation'
@@ -152,6 +153,7 @@ function UserPage() {
       </div>
       <UserReportModal isOpen={isReportModalOpen} onCancel={() => setIsReportModalOpen(false)} userNickname={userData.nickname} userId={Number(id)} />
       <BlockModal isOpen={isBlockModalOpen} onCancel={() => setIsBlockModalOpen(false)} userNickname={userData.nickname} userId={Number(id)} />
+      <Footer />
     </>
   )
 }

--- a/src/features/community/CommunityDetail.tsx
+++ b/src/features/community/CommunityDetail.tsx
@@ -3,6 +3,7 @@
 import { useRouter, useParams, usePathname, useSearchParams } from 'next/navigation'
 import { useMutation, useQueryClient, useQuery } from '@tanstack/react-query'
 import { api } from '@/lib/api/api'
+import Footer from '@/components/footer/Footer'
 import dynamic from 'next/dynamic'
 
 const MdPreview = dynamic(() => import('./components/markdown/MdPreview'), {
@@ -321,6 +322,7 @@ export default function CommunityDetail({ initialPostData, initialCommentData }:
         error={postDeleteError}
         onClearError={() => setIsPostDeleteError(null)}
       />
+      <Footer />
     </>
   )
 }


### PR DESCRIPTION
## 📌 개요

- 푸터를 데스크톱에서만 표시하고, 스타일링을 개선하며, 커뮤니티 상세/타사용자 프로필에 푸터를 추가합니다.

## 🔧 작업 내용

- [x] 푸터 모바일 숨김 처리 (hidden md:block)
- [x] 푸터 텍스트 폰트 크기 text-sm 적용
- [x] 푸터 하위 메뉴 간격 조정 (gap-3 → gap-2)
- [x] 저작권 연도 2025 → 2026 업데이트
- [x] 커뮤니티 상세 페이지에 푸터 추가
- [x] 타사용자 프로필 페이지에 푸터 추가

## 📎 관련 이슈

Closes #531

## 💬 리뷰어 참고 사항

- 모바일에서는 헤더+사이드바로 네비게이션이 충분하므로 푸터를 숨기고, 데스크톱에서만 표시
- 기존 상품 상세페이지의 푸터도 동일하게 모바일에서 자동으로 숨겨짐