### PR TITLE
chore: 상세페이지 UI 스타일링 및 배경색 개선(#533)

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -6,7 +6,7 @@ export default function MainLayout({ children }: { children: ReactNode }) {
     <div className="flex min-h-screen flex-col">
       <Header />
       <main
-        className="w-full flex-1 transition-[padding-top] duration-300"
+        className="w-full flex-1 bg-white transition-[padding-top] duration-300"
         style={{ paddingTop: 'var(--header-height, 72px)' }}
       >
         {children}

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -10,7 +10,7 @@ interface EmptyStateProps {
 export default function EmptyState({ icon: Icon, title, description, className = '' }: EmptyStateProps) {
   return (
     <div
-      className={`flex flex-col items-center justify-center gap-6 rounded-lg border-2 border-dashed border-gray-300 bg-gray-50 px-7 py-16 ${className}`}
+      className={`flex flex-col items-center justify-center gap-6 rounded-lg border-2 border-dashed border-gray-300 bg-white px-7 py-16 ${className}`}
     >
       <div className="bg-primary-50 flex h-25 w-25 items-center justify-center rounded-full">
         <Icon size={50} strokeWidth={1} className="text-primary-300" />

--- a/src/components/product/components/ProductInfo.tsx
+++ b/src/components/product/components/ProductInfo.tsx
@@ -15,7 +15,7 @@ interface ProductInfoProps {
 
 export function ProductInfo({ title, price, createdAt, favoriteCount, productTypeName, isFavorite, onLikeClick }: ProductInfoProps) {
   return (
-    <div className="flex flex-[3] flex-col justify-between gap-5 p-3 md:flex-none">
+    <div className="flex flex-[3] flex-col justify-between gap-5 bg-white p-3 md:flex-none">
       <ProductHeading title={title} price={price} productTypeName={productTypeName} />
       <div className="flex w-full justify-between">
         <ProductMetaItem icon={Clock} label={getTimeAgo(createdAt)} iconSize={13} className="text-gray-400" textClassName="text-[13px] md:text-sm font-normal" />

--- a/src/components/profile/ProfileData.tsx
+++ b/src/components/profile/ProfileData.tsx
@@ -60,7 +60,7 @@ export default function ProfileData({
   const provider = getProvider(user?.email)
 
   return (
-    <aside aria-label="프로필" className="flex h-fit flex-col rounded-none border-b border-gray-200 px-5 py-0 pt-5 md:max-w-72 md:min-w-72 md:rounded-xl md:border md:py-5">
+    <aside aria-label="프로필" className="flex h-fit flex-col rounded-none border-b border-gray-200 bg-white px-5 py-0 pt-5 md:max-w-72 md:min-w-72 md:rounded-xl md:border md:py-5">
       <div className="text-text-primary sticky top-24 flex flex-col rounded-xl">
         <div className="flex flex-col gap-3 md:gap-6">
           <div className="flex flex-row items-center gap-3.5 md:flex-col">

--- a/src/features/UserPage.tsx
+++ b/src/features/UserPage.tsx
@@ -105,7 +105,7 @@ function UserPage() {
 
   return (
     <>
-      <div className="pb-4xl relative bg-white pt-0 md:pt-8">
+      <div className="pb-4xl relative pt-0 md:pt-8">
         <div className="mx-auto max-w-7xl">
           <AnimatePresence>
             {unblockError ? (

--- a/src/features/chatting-page/ChattingPage.tsx
+++ b/src/features/chatting-page/ChattingPage.tsx
@@ -224,7 +224,7 @@ export default function ChattingPage() {
   }
 
   return (
-    <div className="md:pb-4xl bg-white md:h-auto md:pt-8">
+    <div className="md:pb-4xl md:h-auto md:pt-8">
       <h1 className="sr-only">채팅 페이지</h1>
       <div className="mx-auto flex h-full max-w-7xl flex-col md:h-[80vh] md:flex-row">
         <div className={cn('md:flex', isChatOpen ? 'hidden' : 'block')}>

--- a/src/features/home/Home.tsx
+++ b/src/features/home/Home.tsx
@@ -213,7 +213,7 @@ function Home() {
 
   return (
     <>
-      <div className="pb-4xl bg-white pt-6">
+      <div className="pb-4xl pt-6">
         <h1 className="sr-only">커들마켓</h1>
         <div className="px-lg mx-auto max-w-7xl">
           <div className="flex flex-col gap-12">

--- a/src/features/home/components/StaticHomeFallback.tsx
+++ b/src/features/home/components/StaticHomeFallback.tsx
@@ -37,7 +37,7 @@ interface StaticHomeFallbackProps {
 
 export default function StaticHomeFallback({ products, totalElements }: StaticHomeFallbackProps) {
   return (
-    <div className="pb-4xl bg-white pt-6">
+    <div className="pb-4xl pt-6">
       <div className="px-lg mx-auto max-w-7xl">
         <div className="flex flex-col gap-12">
           {/* 필터 영역 플레이스홀더 (Home의 PetTypeFilter + CategoryFilter + DetailFilter 자리) */}

--- a/src/features/my-page/MyPage.tsx
+++ b/src/features/my-page/MyPage.tsx
@@ -262,7 +262,7 @@ function MyPage() {
 
   return (
     <>
-      <div className="pb-4xl bg-white pt-0 md:pt-8">
+      <div className="pb-4xl pt-0 md:pt-8">
         <h1 className="sr-only">마이페이지</h1>
         <div className="mx-auto flex max-w-7xl flex-col gap-3.5 md:flex-row md:gap-8">
           <ProfileData setIsWithdrawModalOpen={setIsWithdrawModalOpen} data={myData!} isMyProfile />

--- a/src/features/product-detail/ProductDetail.tsx
+++ b/src/features/product-detail/ProductDetail.tsx
@@ -41,7 +41,7 @@ function ProductDetail({ initialData }: ProductDetailProps) {
 
   return (
     <>
-      <div className="px-lg pb-4xl mx-auto max-w-7xl bg-white pt-8">
+      <div className="px-lg pb-4xl mx-auto max-w-7xl pt-8">
         <div className="flex flex-col gap-20">
           <div className="flex flex-col justify-center gap-8 md:flex-row">
             <div className="flex flex-1 flex-col gap-4 md:max-w-150">

--- a/src/features/product-detail/components/ProductBadges.tsx
+++ b/src/features/product-detail/components/ProductBadges.tsx
@@ -3,6 +3,7 @@ import { getTradeStatusColor } from '@/lib/utils/getTradeStatusColor'
 import { getPetTypeName } from '@/lib/utils/getPetTypeName'
 import { getCategory } from '@/lib/utils/getCategory'
 import { getProductStatus } from '@/lib/utils/getProductStatus'
+import { getProductType } from '@/lib/utils/getProductType'
 import Badge from '@/components/commons/badge/Badge'
 import { cn } from '@/lib/utils/cn'
 
@@ -11,21 +12,34 @@ interface ProductBadgesProps {
   petDetailType: string
   category: string
   productStatus: string
+  productType: string
 }
 
-export default function ProductBadges({ tradeStatus, petDetailType, category, productStatus }: ProductBadgesProps) {
+export default function ProductBadges({ tradeStatus, petDetailType, category, productStatus, productType }: ProductBadgesProps) {
+  const productTypeName = getProductType(productType)
   const productTradeName = getTradeStatus(tradeStatus)
   const productTradeColor = getTradeStatusColor(tradeStatus)
   const petTypeName = getPetTypeName(petDetailType)
   const categoryName = getCategory(category)
   const productStatusName = getProductStatus(productStatus)
 
+  const getDisplayTradeStatus = () => {
+    if (productTypeName === '판매요청') {
+      if (productTradeName === '판매완료') return '요청완료'
+      if (tradeStatus === null || tradeStatus === '') return '요청중'
+    }
+    return productTradeName || ''
+  }
+  const displayTradeStatus = getDisplayTradeStatus()
+
   return (
-    <div className="flex items-center gap-2 md:gap-1">
-      {tradeStatus ? <Badge className={cn('px-2 py-1.5 text-[13px] font-semibold leading-none text-white', productTradeColor)}>{productTradeName}</Badge> : null}
-      <Badge className={cn('bg-primary-700 px-2 py-1.5 text-[13px] font-semibold leading-none text-white')}>{petTypeName}</Badge>
-      <Badge className={cn('border bg-white px-2 py-1.5 text-[13px] font-semibold leading-none text-gray-900')}>{categoryName}</Badge>
-      <Badge className={cn('bg-primary-200 px-2 py-1.5 text-[13px] font-semibold leading-none')}>{productStatusName}</Badge>
+    <div className="flex flex-col gap-2">
+      {displayTradeStatus ? <Badge className={cn('w-fit px-[15px] py-[10px] text-base font-semibold leading-none text-white', productTradeColor)}>{displayTradeStatus}</Badge> : null}
+      <div className="flex items-center gap-2 md:gap-1">
+        <Badge className={cn('bg-primary-700 px-2 py-1.5 text-[13px] font-semibold leading-none text-white')}>{petTypeName}</Badge>
+        <Badge className={cn('border bg-white px-2 py-1.5 text-[13px] font-semibold leading-none text-gray-900')}>{categoryName}</Badge>
+        <Badge className={cn('bg-primary-200 px-2 py-1.5 text-[13px] font-semibold leading-none')}>{productStatusName}</Badge>
+      </div>
     </div>
   )
 }

--- a/src/features/product-detail/components/ProductDescription.tsx
+++ b/src/features/product-detail/components/ProductDescription.tsx
@@ -3,7 +3,7 @@ interface ProductDescriptionProps {
 }
 export default function ProductDescription({ description }: ProductDescriptionProps) {
   return (
-    <section aria-label="상품 설명" className="h-64 overflow-y-auto rounded-lg border border-gray-300 p-3.5 whitespace-pre-line text-gray-900 md:min-h-[22vh]">
+    <section aria-label="상품 설명" className="h-64 overflow-y-auto rounded-lg border border-gray-200 bg-white p-3.5 text-sm whitespace-pre-line text-gray-900 md:min-h-[22vh]">
       {description}
     </section>
   )

--- a/src/features/product-detail/components/ProductDetailMobileMeta.tsx
+++ b/src/features/product-detail/components/ProductDetailMobileMeta.tsx
@@ -19,13 +19,13 @@ export default function ProductDetailMobileMeta({ productId, productTitle, viewC
     <>
       <div className="flex items-center justify-between md:hidden">
         <div className="flex items-center gap-2">
-          <ProductMetaItem icon={Eye} iconSize={14} label={`조회 ${viewCount}`} textClassName="text-sm font-normal" />
-          <ProductMetaItem icon={Heart} iconSize={14} label={`찜 ${favoriteCount}`} textClassName="text-sm font-normal" />
+          <ProductMetaItem icon={Eye} iconSize={14} label={`조회 ${viewCount}`} textClassName="text-xs font-normal" />
+          <ProductMetaItem icon={Heart} iconSize={14} label={`찜 ${favoriteCount}`} textClassName="text-xs font-normal" />
         </div>
         <button
           type="button"
           onClick={() => setIsReportOpen(true)}
-          className="flex cursor-pointer items-center gap-1 text-sm text-gray-400 hover:text-red-500"
+          className="flex cursor-pointer items-center gap-1 text-xs text-gray-400 hover:text-red-500"
         >
           <Flag size={14} />
           <span>신고하기</span>

--- a/src/features/product-detail/components/ProductMetadataList.tsx
+++ b/src/features/product-detail/components/ProductMetadataList.tsx
@@ -19,10 +19,10 @@ export default function ProductMetadataList({
 }: ProductMetadataListProps) {
   return (
     <div className="flex flex-wrap items-center gap-2 md:gap-3">
-      <ProductMetaItem icon={MapPin} iconSize={14} label={`${addressSido} ${addressGugun}`} textClassName="text-sm font-normal" />
-      <ProductMetaItem icon={Clock} iconSize={14} label={getTimeAgo(createdAt)} textClassName="text-sm font-normal" />
-      <span className="hidden md:flex"><ProductMetaItem icon={Eye} iconSize={14} label={`조회 ${viewCount}`} textClassName="text-sm font-normal" /></span>
-      <span className="hidden md:flex"><ProductMetaItem icon={Heart} iconSize={14} label={`찜 ${favoriteCount}`} textClassName="text-sm font-normal" /></span>
+      <ProductMetaItem icon={MapPin} iconSize={14} label={`${addressSido} ${addressGugun}`} textClassName="text-xs md:text-sm font-normal" />
+      <ProductMetaItem icon={Clock} iconSize={14} label={getTimeAgo(createdAt)} textClassName="text-xs md:text-sm font-normal" />
+      <span className="hidden md:flex"><ProductMetaItem icon={Eye} iconSize={14} label={`조회 ${viewCount}`} textClassName="text-xs md:text-sm font-normal" /></span>
+      <span className="hidden md:flex"><ProductMetaItem icon={Heart} iconSize={14} label={`찜 ${favoriteCount}`} textClassName="text-xs md:text-sm font-normal" /></span>
     </div>
   )
 }

--- a/src/features/product-detail/components/SellerProfileCard.tsx
+++ b/src/features/product-detail/components/SellerProfileCard.tsx
@@ -33,7 +33,7 @@ export default function SellerProfileCard({ sellerInfo }: SellerProfileCardProps
 
   return (
     sellerInfo?.sellerId !== user?.id && (
-      <div className="flex items-center justify-between rounded-lg border border-gray-300 p-3">
+      <div className="flex items-center justify-between rounded-lg border border-gray-200 bg-white p-3">
         <div className="flex items-center gap-2">
           <div className="bg-primary-50 relative flex h-10 w-10 items-center justify-center overflow-hidden rounded-full">
             {sellerInfo.sellerProfileImageUrl ? (
@@ -55,7 +55,7 @@ export default function SellerProfileCard({ sellerInfo }: SellerProfileCardProps
         </div>
         <Button
           size="sm"
-          className="h-fit cursor-pointer border border-gray-300 bg-white text-xs md:text-sm text-gray-900"
+          className="h-fit cursor-pointer border border-gray-200 bg-white text-xs md:text-sm text-gray-900"
           onClick={() => goToUserPage(sellerInfo.sellerId)}
         >
           판매자 프로필 보기

--- a/src/features/profile-update/ProfileUpdate.tsx
+++ b/src/features/profile-update/ProfileUpdate.tsx
@@ -106,7 +106,7 @@ function ProfileUpdate() {
 
   return (
     <>
-      <div className="pb-4xl bg-[#F3F4F6] pt-0 md:bg-white md:pt-8">
+      <div className="pb-4xl bg-[#F3F4F6] pt-0 md:pt-8">
         <h1 className="sr-only">프로필 수정</h1>
         <div className="mx-auto flex max-w-7xl flex-col gap-0 md:flex-row md:gap-8 md:p-0">
           {isMd ? <ProfileData setIsWithdrawModalOpen={setIsWithdrawModalOpen} data={myData!} isMyProfile /> : null}

--- a/src/styles/tokens.colors.css
+++ b/src/styles/tokens.colors.css
@@ -61,7 +61,7 @@
   --color-gray-900: #171923;
 
   /* 시스템 컬러 */
-  --color-onsale: #48bb78;
+  --color-onsale: #00c951;
   --color-complete: #a0aec0;
   --color-reserved: #ed8936;
   --color-requesting: #4299e1;


### PR DESCRIPTION
## 📌 개요

- 상세페이지 및 공통 컴포넌트의 UI 스타일링을 개선합니다.

## 🔧 작업 내용

- [x] 각 페이지 컨테이너에서 bg-white 제거 (레이아웃 배경색 통일)
- [x] 상세페이지 판매상태 뱃지 별도 행 분리 및 판매요청 변환 로직 추가
- [x] 상세페이지 판매상태 뱃지 하드코딩 색상 제거 (productTradeColor 사용)
- [x] 판매자 프로필 카드 bg-white, border gray-200 적용
- [x] 상품 설명 영역 border gray-200, bg-white, text-sm 적용
- [x] 모바일 메타데이터/신고하기 폰트 크기 text-xs 적용
- [x] onsale 색상 #48bb78 → #00c951 변경
- [x] EmptyState 배경색 bg-white 적용
- [x] ProfileData bg-white 추가
- [x] 상품 카드 정보 영역 bg-white 추가

## 📎 관련 이슈

Closes #533

## 💬 리뷰어 참고 사항

- 판매상태 뱃지에 판매요청 상품의 거래상태 변환 로직 추가 (판매완료→요청완료, null→요청중)
- 각 페이지 컨테이너의 bg-white 제거는 레이아웃 bg-white와 중복되어 불필요했기 때문
- ProductBadges에 productType prop 추가 (기존 {...data} spread로 자동 전달)