### PR TITLE
chore: 커뮤니티 목록/상세 페이지 UI 스타일링 개선(#535)

### DIFF
--- a/src/features/community/CommunityDetail.tsx
+++ b/src/features/community/CommunityDetail.tsx
@@ -13,6 +13,7 @@ const MdPreview = dynamic(() => import('./components/markdown/MdPreview'), {
 import { getBoardType } from '@/lib/utils/getBoardType'
 import Badge from '@/components/commons/badge/Badge'
 import { formatDate } from '@/lib/utils/formatDate'
+import { getTimeAgo } from '@/lib/utils/getTimeAgo'
 import { CommentList, type ReplyRequestFormValues } from './components/CommentList'
 import { CommentForm } from './components/CommentForm'
 import ProfileAvatar from '@/components/commons/ProfileAvatar'
@@ -263,18 +264,18 @@ export default function CommunityDetail({ initialPostData, initialCommentData }:
                   </div>
                 ) : null}
               </div>
-              <div className="flex items-baseline justify-between md:items-center">
+              <div className="flex items-end justify-between">
                 <div className="flex items-center gap-3.5">
-                  <ProfileAvatar imageUrl={data.authorProfileImageUrl} nickname={data.authorNickname} size="lg" />
+                  <ProfileAvatar imageUrl={data.authorProfileImageUrl} nickname={data.authorNickname} size="lg" className="h-10 w-10 md:h-12 md:w-12" />
                   {/* 유저 정보 */}
                   <div className="flex flex-col justify-center gap-0.5">
-                    <p>{data.authorNickname}</p>
-                    <p>{formatDate(data.createdAt)}</p>
+                    <p className="text-sm md:text-base font-semibold">{data.authorNickname}</p>
+                    <p className="text-sm text-gray-500">{getTimeAgo(data.createdAt)}</p>
                   </div>
                 </div>
-                <p>조회 {data.viewCount}</p>
+                <p className="text-sm text-gray-500">조회 {data.viewCount}</p>
               </div>
-              <h1 className="border-b border-gray-300 pb-3.5 text-lg font-semibold">{data.title}</h1>
+              <h1 className="border-b border-gray-300 pb-3.5 text-lg font-bold">{data.title}</h1>
               <MdPreview value={data.content} className="p-0" />
             </div>
 
@@ -282,9 +283,9 @@ export default function CommunityDetail({ initialPostData, initialCommentData }:
               aria-label="댓글"
               className="flex flex-col gap-3.5 rounded-lg border border-gray-400 bg-white px-6 py-5 shadow-xl"
             >
-              <div className="flex items-center gap-1">
+              <div className="flex items-center gap-1 text-sm font-semibold text-gray-500">
                 <span>댓글</span>
-                <span>{data.commentCount}</span>
+                <span className="font-normal">{data.commentCount}</span>
               </div>
 
               {commentData?.comments ? <CommentList comments={commentData.comments} postId={id!} /> : null}

--- a/src/features/community/CommunityPage.tsx
+++ b/src/features/community/CommunityPage.tsx
@@ -218,7 +218,7 @@ export default function CommunityPage({ initialQuestionData, initialInfoData }: 
                         value: sort.label,
                         label: sort.label,
                       }))}
-                      buttonClassName="border border-gray-300 bg-primary-50 text-gray-900 text-base px-3 py-2"
+                      buttonClassName="border border-gray-300 bg-primary-50 text-gray-900 text-[13px] px-3 py-2"
                     />
                   </div>
                   <SearchBar
@@ -323,21 +323,22 @@ export default function CommunityPage({ initialQuestionData, initialInfoData }: 
                     >
                       <Link href={ROUTES.COMMUNITY_DETAIL_ID(post.id, post.title)} className="flex flex-col gap-1">
                         <p className="font-semibold">{post.title}</p>
-                        <div className="flex items-center gap-2.5">
-                          <div className="flex items-center gap-1 text-gray-500">
-                            <UserRound size={16} className="text-gray-500" strokeWidth={2.3} />
+                        <p className="line-clamp-1 text-gray-600">{post.contentPreview}</p>
+                        <div className="mt-3 flex items-center gap-2.5 text-sm">
+                          <div className="flex items-center gap-1 text-gray-400">
+                            <UserRound size={14} className="text-gray-400" strokeWidth={2.3} />
                             <p>{post.authorNickname}</p>
                           </div>
-                          <div className="flex items-center gap-1 text-gray-500">
-                            <Clock size={16} className="text-gray-500" strokeWidth={2.3} />
+                          <div className="flex items-center gap-1 text-gray-400">
+                            <Clock size={14} className="text-gray-400" strokeWidth={2.3} />
                             <p>{getTimeAgo(post.createdAt)}</p>
                           </div>
-                          <div className="flex items-center gap-1 text-gray-500">
-                            <MessageSquare size={16} className="text-gray-500" strokeWidth={2.3} />
+                          <div className="flex items-center gap-1 text-gray-400">
+                            <MessageSquare size={14} className="text-gray-400" strokeWidth={2.3} />
                             <p>{post.commentCount}</p>
                           </div>
-                          <div className="flex items-center gap-1 text-gray-500">
-                            <Eye size={16} className="text-gray-500" strokeWidth={2.3} />
+                          <div className="flex items-center gap-1 text-gray-400">
+                            <Eye size={14} className="text-gray-400" strokeWidth={2.3} />
                             <span>조회</span>
                             <span>{post.viewCount}</span>
                           </div>
@@ -347,27 +348,27 @@ export default function CommunityPage({ initialQuestionData, initialInfoData }: 
                   ) : (
                     <li
                       key={post.id}
-                      className="flex flex-col justify-center gap-2.5 rounded-lg border border-gray-400 bg-white px-3.5 pt-3.5 pb-5 shadow-xl"
+                      className="flex flex-col justify-center gap-2.5 rounded-lg border border-gray-400 bg-white px-3.5 pt-3.5 pb-3.5 shadow-xl"
                     >
                       <Link href={ROUTES.COMMUNITY_DETAIL_ID(post.id, post.title)} className="flex flex-col gap-4">
-                        <div className="flex flex-col gap-2">
-                          <p className="text-lg font-semibold">{post.title}</p>
+                        <div className="flex flex-col gap-1 md:gap-2">
+                          <p className="line-clamp-1 text-base md:text-lg font-bold md:font-semibold">{post.title}</p>
 
                           <p className="line-clamp-1">{post.contentPreview}</p>
                         </div>
-                        <div className="flex items-center justify-between gap-2.5">
-                          <div className="flex items-center text-gray-500">
+                        <div className="flex items-center justify-between gap-2.5 text-sm">
+                          <div className="flex items-center text-gray-400">
                             <p>{post.authorNickname}</p>
                             <Dot size={12} />
                             <p>{getTimeAgo(post.createdAt)}</p>
                           </div>
                           <div className="flex items-center gap-2.5">
-                            <div className="flex items-center gap-1 text-gray-500">
-                              <MessageSquare size={16} className="text-gray-500" strokeWidth={2.3} />
+                            <div className="flex items-center gap-1 text-gray-400">
+                              <MessageSquare size={14} className="text-gray-400" strokeWidth={2.3} />
                               <p>{post.commentCount}</p>
                             </div>
-                            <div className="flex items-center gap-1 text-gray-500">
-                              <Eye size={16} className="text-gray-500" strokeWidth={2.3} />
+                            <div className="flex items-center gap-1 text-gray-400">
+                              <Eye size={14} className="text-gray-400" strokeWidth={2.3} />
                               <span>{post.viewCount}</span>
                             </div>
                           </div>
@@ -381,9 +382,9 @@ export default function CommunityPage({ initialQuestionData, initialInfoData }: 
           </div>
           {hasNextPage ? (
             isMd ? (
-              <LoadMoreButton onClick={() => fetchNextPage()} isLoading={isFetchingNextPage} className="border-0" />
+              <LoadMoreButton onClick={() => fetchNextPage()} isLoading={isFetchingNextPage} className="mt-4 border-0" />
             ) : (
-              <div className="px-3.5">
+              <div className="mt-4 px-3.5">
                 <LoadMoreButton onClick={() => fetchNextPage()} isLoading={isFetchingNextPage} className="border-0" />
               </div>
             )

--- a/src/features/community/components/CommentItem.tsx
+++ b/src/features/community/components/CommentItem.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { formatDate } from '@/lib/utils/formatDate'
+import { getTimeAgo } from '@/lib/utils/getTimeAgo'
 import { cn } from '@/lib/utils/cn'
 import type { Comment } from '@/types'
 import { EllipsisVertical } from 'lucide-react'
@@ -65,14 +66,14 @@ export function CommentItem({
 
         {/* 유저 정보 및 내용 */}
         <div className="flex flex-col justify-center gap-1">
-          <div className="flex items-center gap-3.5">
+          <div className="flex flex-col gap-0.5">
             <div className="flex items-center gap-1.5">
-              <p>{comment.authorNickname}</p>
+              <p className="text-sm md:text-base font-semibold">{comment.authorNickname}</p>
               {Number(comment.authorId) === user?.id ? (
                 <p className="bg-primary-200 rounded-full px-2.5 py-1 text-xs font-semibold text-white">작성자</p>
               ) : null}
             </div>
-            <p className="text-sm text-gray-400">{formatDate(comment.createdAt)}</p>
+            <p className="text-xs md:text-sm text-gray-500">{getTimeAgo(comment.createdAt)}</p>
           </div>
           <p>{comment.content}</p>
 


### PR DESCRIPTION
## 📌 개요

- 커뮤니티 목록 및 상세 페이지의 UI 스타일링을 개선합니다.

## 🔧 작업 내용

- [x] 커뮤니티 목록: 데스크톱에 내용 미리보기(contentPreview) 추가
- [x] 커뮤니티 목록: 모바일 제목 폰트 크기/굵기 조정, 말줄임표 적용
- [x] 커뮤니티 목록: 메타데이터 폰트 크기 text-sm, 색상 gray-400 적용
- [x] 커뮤니티 목록: 더보기 버튼과 목록 사이 간격 추가
- [x] 커뮤니티 목록: 모바일 드롭다운 폰트 크기 text-[13px] 적용
- [x] 커뮤니티 상세: 작성자 닉네임/작성일/조회수 폰트 크기/색상 조정
- [x] 커뮤니티 상세: 모바일 아바타 크기 축소 (48px → 40px)
- [x] 커뮤니티 상세: 작성일시 formatDate → getTimeAgo 변경
- [x] 커뮤니티 상세: 댓글 영역 텍스트 스타일링 개선
- [x] 댓글: 닉네임 폰트 크기/굵기 조정, 작성일시 닉네임 아래로 이동

## 📎 관련 이슈

Closes #535

## 💬 리뷰어 참고 사항

- 댓글 작성일시를 formatDate → getTimeAgo로 변경하여 목록/상세 일관성 확보
- 모바일 드롭다운 "제목 + 내용" 텍스트 넘침 해결을 위해 폰트 크기 축소