### PR TITLE
fix: 커뮤니티 모바일 필터 영역 배경 투명 및 접힘 시 공백 수정(#541)

### DIFF
--- a/src/features/community/CommunityPage.tsx
+++ b/src/features/community/CommunityPage.tsx
@@ -190,7 +190,7 @@ export default function CommunityPage({ initialQuestionData, initialInfoData }: 
       <div className="pb-4xl mx-auto max-w-7xl px-0 md:px-4">
         <div className="flex w-full flex-col">
           {/* 모바일: 필터 영역 */}
-          <div className={cn('md:hidden', !isFilterCollapsed && `sticky top-16 ${Z_INDEX.DROPDOWN}`)}>
+          <div className={cn('md:hidden sticky top-16 bg-white', Z_INDEX.DROPDOWN)}>
             {/* 접히는 필터 영역 */}
             <div
               className={cn(
@@ -298,11 +298,11 @@ export default function CommunityPage({ initialQuestionData, initialInfoData }: 
             aria-labelledby={activeCommunityTypeTab}
           >
             {communityPosts.length === 0 ? (
-              <div className={cn('px-3.5 md:px-0', isFilterCollapsed ? 'mt-20 md:mt-0' : 'mt-4 md:mt-0')}>
+              <div className={cn('px-3.5 md:px-0', 'mt-4 md:mt-0')}>
                 <EmptyState icon={MessageSquareText} title="아직 게시글이 없어요" description="첫 번째 이야기를 나눠보세요!" />
               </div>
             ) : (
-              <ul className={cn('flex flex-col gap-2.5 px-3.5 md:p-0', isFilterCollapsed ? 'mt-20 md:mt-0' : 'mt-4 md:mt-0')}>
+              <ul className={cn('flex flex-col gap-2.5 px-3.5 md:p-0', 'mt-4 md:mt-0')}>
                 {communityPosts.map((post) => (
                   <li key={post.id}>
                     {/* 데스크탑 카드 */}


### PR DESCRIPTION
## 📌 개요

- 모바일 커뮤니티 페이지에서 필터 영역 배경 투명 및 접힘 시 공백 발생 버그 수정

## 🔧 작업 내용

- [x] 필터 영역에 bg-white, z-20, sticky top-16 항상 적용
- [x] 게시글 목록의 mt-20 조건부 마진을 mt-4로 통일

## 📎 관련 이슈

Closes #541

## 📋 QA 티켓

https://www.notion.so/32cf2b30796181719167dcd1f3311e93

## 💬 리뷰어 참고 사항

- sticky를 항상 적용해도 필터가 접히면 내부 콘텐츠가 max-h-0으로 0 높이가 되어 공백 없음
- bg-white + z-20으로 뒤 콘텐츠가 비치는 문제 해결