### PR TITLE
fix: 커뮤니티 목록 내용 미리보기 줄바꿈 미적용 수정(#545)

### DIFF
--- a/src/features/community/CommunityPage.tsx
+++ b/src/features/community/CommunityPage.tsx
@@ -310,7 +310,7 @@ export default function CommunityPage({ initialQuestionData, initialInfoData }: 
                       <div className="flex flex-col justify-center gap-2.5 rounded-lg border border-gray-400 bg-white px-3.5 pt-3.5 pb-3.5 shadow-xl">
                         <Link href={ROUTES.COMMUNITY_DETAIL_ID(post.id, post.title)} className="flex flex-col gap-1">
                           <p className="font-semibold">{post.title}</p>
-                          <p className="line-clamp-1 text-gray-600">{post.contentPreview}</p>
+                          <p className="line-clamp-1 whitespace-pre-line text-gray-600">{post.contentPreview}</p>
                           <div className="mt-3 flex items-center gap-2.5 text-sm">
                             <div className="flex items-center gap-1 text-gray-400">
                               <UserRound size={14} className="text-gray-400" strokeWidth={2.3} />
@@ -339,7 +339,7 @@ export default function CommunityPage({ initialQuestionData, initialInfoData }: 
                         <Link href={ROUTES.COMMUNITY_DETAIL_ID(post.id, post.title)} className="flex flex-col gap-4">
                           <div className="flex flex-col gap-1">
                             <p className="line-clamp-1 text-base font-bold">{post.title}</p>
-                            <p className="line-clamp-1">{post.contentPreview}</p>
+                            <p className="line-clamp-1 whitespace-pre-line">{post.contentPreview}</p>
                           </div>
                           <div className="flex items-center justify-between gap-2.5 text-sm">
                             <div className="flex items-center text-gray-400">


### PR DESCRIPTION
## 📌 개요

- 커뮤니티 목록의 내용 미리보기에 whitespace-pre-line을 추가하여 줄바꿈 적용

## 🔧 작업 내용

- [x] 데스크톱 카드 contentPreview에 whitespace-pre-line 추가
- [x] 모바일 카드 contentPreview에 whitespace-pre-line 추가

## 📎 관련 이슈

Closes #545

## 📋 QA 티켓

https://www.notion.so/32cf2b3079618123b625e48e43edf770

## 💬 리뷰어 참고 사항

- line-clamp-1과 whitespace-pre-line을 함께 사용하면 첫 줄만 표시되면서도 줄바꿈이 적용됨