### PR TITLE
feat: 모바일 커뮤니티 댓글 하단 고정 입력바 및 UX 개선(#549)

### DIFF
--- a/src/features/community/CommunityDetail.tsx
+++ b/src/features/community/CommunityDetail.tsx
@@ -40,16 +40,14 @@ interface CommunityDetailProps {
 export default function CommunityDetail({ initialPostData, initialCommentData }: CommunityDetailProps) {
   const {
     handleSubmit,
+    register,
     reset,
-    watch,
-    setValue,
   } = useForm<ReplyRequestFormValues>({
     mode: 'onChange',
     defaultValues: {
       content: '',
     },
   })
-  const commentValue = watch('content')
 
   const user = useUserStore((state) => state.user)
   const setRedirectUrl = useUserStore((state) => state.setRedirectUrl)
@@ -277,31 +275,15 @@ export default function CommunityDetail({ initialPostData, initialCommentData }:
                   </InlineNotification>
                 ) : null}
               </AnimatePresence>
-
-              {/* 데스크톱: 기존 위치에 CommentForm */}
-              <div className="hidden md:block">
-                <CommentForm
-                  id="comment-input-desktop"
-                  placeholder="댓글을 입력하세요"
-                  legendText="댓글 작성폼"
-                  value={commentValue}
-                  onChange={(val) => setValue('content', val)}
-                  onSubmit={handleSubmit(onSubmit)}
-                />
-              </div>
             </section>
 
-            {/* 모바일: 하단 고정 입력바 */}
-            <div
-              className="fixed right-0 bottom-0 left-0 border-t border-gray-200 bg-white px-3 py-2 md:hidden"
-              style={{ zIndex: 30 }}
-            >
+            {/* 댓글 입력: 모바일은 하단 고정, 데스크톱은 정상 위치 */}
+            <div className="fixed right-0 bottom-0 left-0 border-t border-gray-200 bg-white px-3 py-2 md:relative md:border-t-0 md:px-0 md:py-0" style={{ zIndex: 30 }}>
               <CommentForm
-                id="comment-input-mobile"
+                id="comment-input"
                 placeholder="댓글을 입력하세요"
                 legendText="댓글 작성폼"
-                value={commentValue}
-                onChange={(val) => setValue('content', val)}
+                register={register}
                 onSubmit={handleSubmit(onSubmit)}
                 textareaRef={mobileInputRef}
               />

--- a/src/features/community/components/CommentForm.tsx
+++ b/src/features/community/components/CommentForm.tsx
@@ -6,28 +6,15 @@ interface CommentFormValues {
   content: string
 }
 
-interface CommentFormPropsBase {
+interface CommentFormProps {
   id: string
   placeholder: string
   legendText: string
+  register: UseFormRegister<CommentFormValues>
   onSubmit: () => void
   onCancel?: () => void
   textareaRef?: RefObject<HTMLTextAreaElement | null>
 }
-
-interface RegisterProps extends CommentFormPropsBase {
-  register: UseFormRegister<CommentFormValues>
-  value?: never
-  onChange?: never
-}
-
-interface ControlledProps extends CommentFormPropsBase {
-  register?: never
-  value: string
-  onChange: (value: string) => void
-}
-
-type CommentFormProps = RegisterProps | ControlledProps
 
 const MAX_ROWS = 4
 const LINE_HEIGHT = 20
@@ -35,12 +22,10 @@ const PADDING_Y = 16
 const BASE_HEIGHT = LINE_HEIGHT + PADDING_Y
 const MAX_HEIGHT = LINE_HEIGHT * MAX_ROWS + PADDING_Y
 
-export function CommentForm({ id, placeholder, legendText, onSubmit, onCancel, textareaRef: externalRef, ...props }: CommentFormProps) {
+export function CommentForm({ id, placeholder, legendText, register, onSubmit, onCancel, textareaRef: externalRef }: CommentFormProps) {
   const internalRef = useRef<HTMLTextAreaElement | null>(null)
   const textareaRef = externalRef || internalRef
-
-  const isControlled = 'value' in props && props.value !== undefined
-  const registerResult = !isControlled && props.register ? props.register('content') : null
+  const { ref, onChange, ...rest } = register('content')
 
   const handleAutoResize = useCallback(() => {
     const textarea = textareaRef.current
@@ -60,19 +45,14 @@ export function CommentForm({ id, placeholder, legendText, onSubmit, onCancel, t
           className="flex-1 rounded-lg bg-[#f0f4ff] px-3 py-2 leading-tight scrollbar-hide md:h-auto md:leading-normal md:bg-primary-50 md:rounded-none md:px-0 md:py-0 w-full resize-none focus:outline-none"
           style={{ height: `${BASE_HEIGHT}px`, maxHeight: `${MAX_HEIGHT}px`, overflowY: 'auto' }}
           ref={(e) => {
-            if (registerResult) registerResult.ref(e)
+            ref(e)
             textareaRef.current = e
           }}
-          value={isControlled ? props.value : undefined}
           onChange={(e) => {
-            if (isControlled) {
-              props.onChange(e.target.value)
-            } else if (registerResult) {
-              registerResult.onChange(e)
-            }
+            onChange(e)
             handleAutoResize()
           }}
-          {...(registerResult ? { name: registerResult.name, onBlur: registerResult.onBlur } : {})}
+          {...rest}
         />
         <div className="flex items-center justify-end gap-3.5">
           {onCancel ? (


### PR DESCRIPTION
## 📌 개요

- 모바일 환경에서 커뮤니티 댓글 영역을 당근 앱 스타일로 개선합니다.

## 🔧 작업 내용

- [x] 모바일에서 댓글 입력창+등록 버튼을 화면 하단에 고정 (fixed bottom-0)
- [x] 댓글이 없을 때: "첫 댓글을 남겨보세요" 문구 + "댓글 쓰기" 버튼 표시
- [x] "댓글 쓰기" 버튼 클릭 시 하단 입력바의 textarea에 포커스
- [x] 댓글이 있을 때: 댓글 목록 표시 + 하단 고정 입력바 항상 표시
- [x] 데스크톱은 기존 레이아웃 유지
- [x] CommentForm에 textareaRef prop 추가 (외부에서 포커스 제어 가능)
- [x] 하단 고정 바에 가려지지 않도록 pb-16 여백 추가

## 📎 관련 이슈

Closes #549

## 💬 리뷰어 참고 사항

- 모바일에서 CommentForm이 두 곳에 렌더링됨: 데스크톱용(hidden md:block)과 모바일 하단 고정바(md:hidden)
- react-hook-form의 register를 두 개의 textarea에 공유하므로, 모바일 입력 시 데스크톱 textarea와 값이 동기화됨
- 키보드 올라올 때 fixed bottom-0가 자동으로 키보드 위에 위치 (Android Chrome 기준)