### PR TITLE
fix: 모바일 키보드 올라올 때 댓글 입력바 위치 수정(#551)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,11 @@
-import type { Metadata } from 'next'
+import type { Metadata, Viewport } from 'next'
 import Providers from './providers'
 import ClientComponents from '@/components/ClientComponents'
 import './globals.css'
+
+export const viewport: Viewport = {
+  interactiveWidget: 'resizes-content',
+}
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://cuddle-market.vercel.app'),


### PR DESCRIPTION
## 📌 개요

- 모바일에서 키보드가 올라올 때 댓글 입력바가 키보드 바로 위에 붙도록 수정

## 🔧 작업 내용

- [x] layout.tsx에 viewport interactiveWidget: 'resizes-content' 추가

## 📎 관련 이슈

Closes #551

## 💬 리뷰어 참고 사항

- interactiveWidget: 'resizes-content'는 키보드가 올라올 때 레이아웃 뷰포트를 함께 줄여주어 fixed bottom-0 요소가 키보드 위에 위치하도록 함
- 전체 앱에 적용되는 설정이므로 다른 페이지의 fixed 요소 동작에도 영향을 줄 수 있음