### PR TITLE
fix: 커뮤니티 댓글 작성 시간 타임존 처리 수정(#554)

### DIFF
--- a/src/lib/utils/getTimeAgo.ts
+++ b/src/lib/utils/getTimeAgo.ts
@@ -2,7 +2,10 @@ import { TIME_UNITS } from '@/constants/constants'
 
 export const getTimeAgo = (createdAt: string): string => {
   const now = new Date()
-  const created = new Date(createdAt)
+  // 서버가 KST 시간을 타임존 정보 없이 반환하므로, 타임존이 없는 경우 +09:00을 명시
+  const hasTimezone = /Z|[+-]\d{2}:\d{2}$/.test(createdAt)
+  const dateString = hasTimezone ? createdAt : `${createdAt}+09:00`
+  const created = new Date(dateString)
   const diffMs = now.getTime() - created.getTime()
 
   if (diffMs < 0) {


### PR DESCRIPTION
## 📌 개요

- 댓글 작성 시간이 9시간 차이나는 타임존 처리 버그 수정

## 🔧 작업 내용

- [x] getTimeAgo 함수에서 타임존 정보가 없는 서버 응답에 KST(+09:00) 오프셋 명시 추가

## 📎 관련 이슈

Closes #554

## 📋 QA 티켓

https://www.notion.so/32cf2b3079618130922cc0d60ba13f90

## 💬 리뷰어 참고 사항

- 서버가 KST 시간을 타임존 정보 없이 반환 (예: 2026-03-23T14:00:00)하여 JS Date가 UTC로 해석하는 문제
- 이미 타임존 정보가 포함된 문자열은 기존 동작 그대로 유지
- getTimeAgo를 사용하는 모든 곳에 동일하게 적용됨