### PR TITLE
fix: 데스크톱 커뮤니티 댓글 입력폼 카드 안으로 복원(#557)

### DIFF
--- a/src/features/community/CommunityDetail.tsx
+++ b/src/features/community/CommunityDetail.tsx
@@ -275,12 +275,23 @@ export default function CommunityDetail({ initialPostData, initialCommentData }:
                   </InlineNotification>
                 ) : null}
               </AnimatePresence>
+
+              {/* 데스크톱용 댓글 입력: 카드 안에 배치 */}
+              <div className="hidden md:block">
+                <CommentForm
+                  id="comment-input-desktop"
+                  placeholder="댓글을 입력하세요"
+                  legendText="댓글 작성폼"
+                  register={register}
+                  onSubmit={handleSubmit(onSubmit)}
+                />
+              </div>
             </section>
 
-            {/* 댓글 입력: 모바일은 하단 고정, 데스크톱은 정상 위치 */}
-            <div className="fixed right-0 bottom-0 left-0 border-t border-gray-200 bg-white px-3 py-2 md:relative md:border-t-0 md:px-0 md:py-0" style={{ zIndex: 30 }}>
+            {/* 모바일용 댓글 입력: 하단 고정 */}
+            <div className="fixed right-0 bottom-0 left-0 border-t border-gray-200 bg-white px-3 py-2 md:hidden" style={{ zIndex: 30 }}>
               <CommentForm
-                id="comment-input"
+                id="comment-input-mobile"
                 placeholder="댓글을 입력하세요"
                 legendText="댓글 작성폼"
                 register={register}


### PR DESCRIPTION
## 📌 개요

- 데스크톱에서 댓글 입력폼을 댓글 카드 안으로 복원

## 🔧 작업 내용

- [x] 데스크톱용 CommentForm을 section 안에 hidden md:block으로 배치
- [x] 모바일용 CommentForm을 section 밖에 md:hidden fixed bottom-0으로 유지

## 📎 관련 이슈

Closes #557

## 📋 QA 티켓

https://www.notion.so/32cf2b307961813992eedbabd74e0a02

## 💬 리뷰어 참고 사항

- CommentForm이 두 곳에 렌더링되지만 CSS로 하나만 표시
- 모바일 textareaRef를 통한 포커스 기능 유지