### PR TITLE
fix: getTimeAgo 타임존 처리 재수정(#561)

### DIFF
--- a/src/lib/utils/getTimeAgo.ts
+++ b/src/lib/utils/getTimeAgo.ts
@@ -2,9 +2,9 @@ import { TIME_UNITS } from '@/constants/constants'
 
 export const getTimeAgo = (createdAt: string): string => {
   const now = new Date()
-  // 서버가 KST 시간을 타임존 정보 없이 반환하므로, 타임존이 없는 경우 +09:00을 명시
-  const hasTimezone = /Z|[+-]\d{2}:\d{2}$/.test(createdAt)
-  const dateString = hasTimezone ? createdAt : `${createdAt}+09:00`
+  // 서버가 UTC 시간을 타임존 정보 없이 반환하므로, 타임존이 없는 경우 Z(UTC)를 명시
+  const hasTimezone = /Z|[+-]\d{2}:\d{2}/.test(createdAt)
+  const dateString = hasTimezone ? createdAt : `${createdAt}Z`
   const created = new Date(dateString)
   const diffMs = now.getTime() - created.getTime()
 


### PR DESCRIPTION
## 📌 개요

- getTimeAgo 타임존 처리를 서버 UTC 반환에 맞게 재수정

## 🔧 작업 내용

- [x] 타임존 없는 서버 응답에 +09:00 대신 Z(UTC) 추가
- [x] 정규식에서 $ 제거하여 밀리초 포함 형식도 감지

## 📎 관련 이슈

Closes #561

## 💬 리뷰어 참고 사항

- 이전 수정(#554)에서 서버가 KST 반환이라 판단했으나 실제로는 UTC 반환 확인
- 서버 응답 예: 2026-03-24T07:12:05.978352 (UTC, 타임존 없음)