### PR TITLE
fix: 커뮤니티 댓글 등록 후 댓글 갯수 미갱신 수정(#553)

### DIFF
--- a/src/features/community/CommunityDetail.tsx
+++ b/src/features/community/CommunityDetail.tsx
@@ -99,6 +99,7 @@ export default function CommunityDetail({ initialPostData, initialCommentData }:
       api.post(`/community/posts/${id}/comments`, { content: requestData.content }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['community', id, 'comments'] })
+      queryClient.invalidateQueries({ queryKey: ['community', id] })
       reset()
     },
     onError: () => {


### PR DESCRIPTION
## 📌 개요

- 댓글 등록 성공 시 게시글 데이터 쿼리도 invalidate하여 commentCount 즉시 갱신

## 🔧 작업 내용

- [x] replyMutation onSuccess에 게시글 데이터 쿼리 invalidate 추가

## 📎 관련 이슈

Closes #553

## 💬 리뷰어 참고 사항

- 이전 PR #555가 머지되지 않고 닫혀 동일한 수정을 새 PR로 생성
- 기존에는 ['community', id, 'comments']만 invalidate하여 댓글 목록만 갱신. ['community', id]도 추가하여 commentCount도 갱신