### PR TITLE
fix: 긴 댓글 작성 시 아바타 찌그러짐 수정(#566)

### DIFF
--- a/src/features/community/components/CommentItem.tsx
+++ b/src/features/community/components/CommentItem.tsx
@@ -62,7 +62,7 @@ export function CommentItem({
   return (
     <>
       <div className={cn('flex items-start gap-3.5', showBorder && 'border-t border-gray-300 pt-3.5', !isReply && !isRepliesOpen && 'pb-3.5')}>
-        <ProfileAvatar imageUrl={comment.authorProfileImageUrl} nickname={comment.authorNickname} size="sm" />
+        <ProfileAvatar imageUrl={comment.authorProfileImageUrl} nickname={comment.authorNickname} size="sm" className="shrink-0" />
 
         {/* 유저 정보 및 내용 */}
         <div className="flex flex-col justify-center gap-1">


### PR DESCRIPTION
## 📌 개요

- 긴 댓글에서 아바타가 flex 압축되는 버그 수정

## 🔧 작업 내용

- [x] CommentItem의 ProfileAvatar에 shrink-0 추가

## 📎 관련 이슈

Closes #566

## 📋 QA 티켓

https://www.notion.so/32df2b307961810ca191e2065dc3a65b

## 💬 리뷰어 참고 사항

- flex items-start 컨테이너에서 아바타가 긴 텍스트에 의해 압축되는 것을 shrink-0으로 방지