### PR TITLE
fix: 모바일 답글 오버레이 뒤로가기 수정(#567)

### DIFF
--- a/src/features/community/components/ReplyOverlay.tsx
+++ b/src/features/community/components/ReplyOverlay.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { ArrowLeft } from 'lucide-react'
 import type { Comment } from '@/types'
 import type { UseFormRegister } from 'react-hook-form'
@@ -19,10 +19,25 @@ interface ReplyOverlayProps {
 export function ReplyOverlay({ comment, replies, register, onSubmit, onClose }: ReplyOverlayProps) {
   const totalCount = 1 + (replies?.length ?? 0)
 
+  const onCloseRef = useRef(onClose)
+  onCloseRef.current = onClose
+
   useEffect(() => {
     document.body.classList.add('overflow-hidden')
+
+    // 히스토리에 오버레이 상태 추가
+    history.pushState({ replyOverlay: true }, '')
+
+    // 뒤로가기 감지
+    const handlePopState = () => {
+      onCloseRef.current()
+    }
+
+    window.addEventListener('popstate', handlePopState)
+
     return () => {
       document.body.classList.remove('overflow-hidden')
+      window.removeEventListener('popstate', handlePopState)
     }
   }, [])
 
@@ -30,7 +45,7 @@ export function ReplyOverlay({ comment, replies, register, onSubmit, onClose }: 
     <div className="fixed inset-0 z-50 flex flex-col bg-white">
       {/* 헤더 */}
       <div className="flex items-center gap-3 border-b border-gray-200 px-4 py-3">
-        <button type="button" onClick={onClose} className="cursor-pointer">
+        <button type="button" onClick={() => history.back()} className="cursor-pointer">
           <ArrowLeft size={20} />
         </button>
         <span className="text-base font-bold">댓글 {totalCount}</span>


### PR DESCRIPTION
## 📌 개요

- 모바일 답글 오버레이에서 기기 뒤로가기 시 오버레이가 닫히도록 수정

## 🔧 작업 내용

- [x] 오버레이 열림 시 history.pushState로 히스토리 추가
- [x] popstate 이벤트 감지하여 오버레이 닫기
- [x] 헤더 뒤로가기 버튼 history.back() 사용

## 📎 관련 이슈

Closes #567

## 📋 QA 티켓

https://www.notion.so/32df2b307961811388e7df34225b0545

## 💬 리뷰어 참고 사항

- history.pushState/popstate 패턴으로 모바일 기기 뒤로가기 대응
- onCloseRef로 useEffect 의존성 배열 문제 방지
- 오버레이 ← 버튼도 history.back()으로 통일하여 히스토리 정합성 유지