### PR TITLE
fix: 모바일 커뮤니티 검색창 키보드 이동 버튼 수정(#570)

### DIFF
--- a/src/components/header/components/SearchBar.tsx
+++ b/src/components/header/components/SearchBar.tsx
@@ -86,6 +86,7 @@ export default function SearchBar({
         border
         borderColor={borderColor}
         backgroundColor="bg-white"
+        enterKeyHint="search"
         inputClass={inputClass}
         onClear={handleClearKeyword}
       />


### PR DESCRIPTION
## 📌 개요

- 모바일 커뮤니티 검색창 키보드에 돋보기(검색) 아이콘이 표시되도록 수정

## 🔧 작업 내용

- [x] SearchBar의 Input에 enterKeyHint="search" 추가

## 📎 관련 이슈

Closes #570

## 📋 QA 티켓

https://www.notion.so/32df2b30796181ed8890f37700990b17

## 💬 리뷰어 참고 사항

- enterKeyHint는 모바일 브라우저의 가상 키보드 Enter 키 표시를 제어하는 HTML 속성
- SearchBar 컴포넌트에 추가하여 모든 검색바에 적용됨