### PR TITLE
refactor: 메인 페이지 필터 결과 없을 때 빈 상태 표시 추가(#571)

### DIFF
--- a/src/features/home/components/product-section/ProductsSection.tsx
+++ b/src/features/home/components/product-section/ProductsSection.tsx
@@ -5,6 +5,7 @@ import SelectDropdown from '@/components/commons/select/SelectDropdown'
 import { PRODUCT_TYPE_TABS, SORT_TYPE, type ProductTypeTabId } from '@/constants/constants'
 import type { Product } from '@/types/product'
 import { useFilterNavigation } from '@/hooks/useFilterNavigation'
+import { SearchX } from 'lucide-react'
 
 interface ProductListHeaderProps {
   totalElements: number
@@ -68,7 +69,19 @@ export function ProductsSection({ products, totalElements, activeTab, selectedSo
           />
         </div>
       </div>
-      <ProductList products={products} />
+      {products.length > 0 ? (
+        <ProductList products={products} />
+      ) : (
+        <div className="flex flex-col items-center justify-center gap-4 rounded-lg border-2 border-dashed border-gray-300 bg-white px-7 py-12 md:gap-6 md:py-16">
+          <div className="bg-primary-50 flex h-16 w-16 items-center justify-center rounded-full md:h-25 md:w-25">
+            <SearchX size={32} strokeWidth={1} className="text-primary-300 md:size-[50px]" />
+          </div>
+          <div className="flex flex-col items-center gap-1 md:gap-2">
+            <p className="text-base font-semibold md:heading-h5">검색 결과가 없습니다</p>
+            <p className="text-sm text-gray-500">다른 필터 조건으로 검색해보세요</p>
+          </div>
+        </div>
+      )}
     </section>
   )
 }


### PR DESCRIPTION
## 📌 개요

- 메인 페이지에서 필터 적용 후 상품이 없을 때 빈 상태 안내를 표시합니다.

## 🔧 작업 내용

- [x] ProductsSection에서 products가 빈 배열일 때 "검색 결과가 없습니다" + "다른 필터 조건으로 검색해보세요" 표시
- [x] 모바일/데스크톱 반응형 아이콘 영역 크기 (모바일 64px, 데스크톱 100px)

## 📎 관련 이슈

Closes #571

## 💬 리뷰어 참고 사항

- EmptyState 공용 컴포넌트 대신 직접 렌더링하여 모바일에서 아이콘 영역 크기를 반응형으로 제어