### PR TITLE
fix: 커뮤니티 검색창에서 검색 시 메인 페이지 이동 수정(#574)

### DIFF
--- a/src/components/header/components/SearchBar.tsx
+++ b/src/components/header/components/SearchBar.tsx
@@ -35,9 +35,10 @@ export default function SearchBar({
     if (e.key === 'Enter') {
       const target = e.currentTarget
       const searchKeyword = target.value.trim()
+      const isCurrentPageSearch = isHomePage || paramName !== 'keyword'
 
-      if (isHomePage) {
-        // 메인페이지에서는 현재 URL에 쿼리 파라미터만 추가
+      if (isCurrentPageSearch) {
+        // 현재 페이지에서 검색 (메인페이지 또는 커스텀 paramName 사용 시)
         const params = new URLSearchParams(searchParams.toString())
         if (searchKeyword) {
           params.set(paramName, searchKeyword)


### PR DESCRIPTION
## 📌 개요

- 커뮤니티 검색창에서 검색 시 현재 페이지에서 검색 결과를 표시하도록 수정

## 🔧 작업 내용

- [x] SearchBar에서 paramName이 기본값이 아닌 경우 현재 페이지에서 검색하도록 변경

## 📎 관련 이슈

Closes #574

## 📋 QA 티켓

https://www.notion.so/32df2b30796181f4914df2167bc4cf4f

## 💬 리뷰어 참고 사항

- paramName이 'keyword'(기본값)가 아닌 경우(예: 커뮤니티의 'communityKeyword')는 해당 페이지 전용 검색이므로 현재 페이지에서 검색
- 메인 페이지 이외의 페이지에서 기본 paramName('keyword')으로 검색할 경우에만 메인 페이지로 이동 (헤더 검색바)