### PR TITLE
fix: 답글 작성 후 댓글 갯수 미갱신(#583)

### DIFF
--- a/src/features/community/components/CommentList.tsx
+++ b/src/features/community/components/CommentList.tsx
@@ -62,6 +62,8 @@ export function CommentList({ comments, postId }: CommentListProps) {
       queryClient.invalidateQueries({ queryKey: ['community', postId, 'replies', parentId] })
       // 댓글 목록도 refetch (childrenCount 업데이트를 위해)
       queryClient.invalidateQueries({ queryKey: ['community', postId, 'comments'] })
+      // 게시글 상세 refetch (commentCount 업데이트를 위해)
+      queryClient.invalidateQueries({ queryKey: ['community', postId] })
       // 폼 초기화 및 닫기
       reset()
       setReplyingToId(null)


### PR DESCRIPTION
## 📌 개요
답글(대댓글) 작성 후 게시글의 댓글 갯수(commentCount)가 즉시 갱신되지 않는 버그 수정

## 🔧 작업 내용
- CommentList.tsx의 replyMutation.onSuccess 콜백에서 게시글 상세 데이터 invalidate 추가
- 기존: 댓글 목록 + 대댓글 목록만 refetch
- 수정: 게시글 상세(['community', postId])도 함께 invalidate하여 commentCount 즉시 반영

## 📎 관련 이슈
Closes #583

## 📋 QA 티켓
https://www.notion.so/32df2b307961816d876df61da0621d9e

## 💬 리뷰어 참고 사항
1줄 추가로 해결되는 단순 invalidation 누락 버그입니다.