### PR TITLE
fix: 데스크톱 커뮤니티 댓글 등록 버튼 무반응(#582)

### DIFF
--- a/src/features/community/CommunityDetail.tsx
+++ b/src/features/community/CommunityDetail.tsx
@@ -40,7 +40,8 @@ interface CommunityDetailProps {
 export default function CommunityDetail({ initialPostData, initialCommentData }: CommunityDetailProps) {
   const {
     handleSubmit,
-    register,
+    watch,
+    setValue,
     reset,
   } = useForm<ReplyRequestFormValues>({
     mode: 'onChange',
@@ -48,6 +49,8 @@ export default function CommunityDetail({ initialPostData, initialCommentData }:
       content: '',
     },
   })
+
+  const commentContent = watch('content')
 
   const user = useUserStore((state) => state.user)
   const setRedirectUrl = useUserStore((state) => state.setRedirectUrl)
@@ -283,7 +286,8 @@ export default function CommunityDetail({ initialPostData, initialCommentData }:
                   id="comment-input-desktop"
                   placeholder="댓글을 입력하세요"
                   legendText="댓글 작성폼"
-                  register={register}
+                  value={commentContent}
+                  onChangeValue={(v) => setValue('content', v)}
                   onSubmit={handleSubmit(onSubmit)}
                 />
               </div>
@@ -295,7 +299,8 @@ export default function CommunityDetail({ initialPostData, initialCommentData }:
                 id="comment-input-mobile"
                 placeholder="댓글을 입력하세요"
                 legendText="댓글 작성폼"
-                register={register}
+                value={commentContent}
+                onChangeValue={(v) => setValue('content', v)}
                 onSubmit={handleSubmit(onSubmit)}
                 textareaRef={mobileInputRef}
               />

--- a/src/features/community/components/CommentForm.tsx
+++ b/src/features/community/components/CommentForm.tsx
@@ -10,7 +10,9 @@ interface CommentFormProps {
   id: string
   placeholder: string
   legendText: string
-  register: UseFormRegister<CommentFormValues>
+  register?: UseFormRegister<CommentFormValues>
+  value?: string
+  onChangeValue?: (value: string) => void
   onSubmit: () => void
   onCancel?: () => void
   textareaRef?: RefObject<HTMLTextAreaElement | null>
@@ -22,10 +24,11 @@ const PADDING_Y = 16
 const BASE_HEIGHT = LINE_HEIGHT + PADDING_Y
 const MAX_HEIGHT = LINE_HEIGHT * MAX_ROWS + PADDING_Y
 
-export function CommentForm({ id, placeholder, legendText, register, onSubmit, onCancel, textareaRef: externalRef }: CommentFormProps) {
+export function CommentForm({ id, placeholder, legendText, register, value, onChangeValue, onSubmit, onCancel, textareaRef: externalRef }: CommentFormProps) {
   const internalRef = useRef<HTMLTextAreaElement | null>(null)
   const textareaRef = externalRef || internalRef
-  const { ref, onChange, ...rest } = register('content')
+  const registerProps = register ? register('content') : null
+  const { ref, onChange, ...rest } = registerProps ?? { ref: undefined, onChange: undefined }
 
   const handleAutoResize = useCallback(() => {
     const textarea = textareaRef.current
@@ -45,11 +48,13 @@ export function CommentForm({ id, placeholder, legendText, register, onSubmit, o
           className="flex-1 rounded-lg bg-[#f0f4ff] px-3 py-2 leading-tight scrollbar-hide md:h-auto md:leading-normal md:bg-primary-50 md:rounded-none md:px-0 md:py-0 w-full resize-none focus:outline-none"
           style={{ height: `${BASE_HEIGHT}px`, maxHeight: `${MAX_HEIGHT}px`, overflowY: 'auto' }}
           ref={(e) => {
-            ref(e)
+            if (ref) ref(e)
             textareaRef.current = e
           }}
+          value={onChangeValue ? value : undefined}
           onChange={(e) => {
-            onChange(e)
+            if (onChange) onChange(e)
+            if (onChangeValue) onChangeValue(e.target.value)
             handleAutoResize()
           }}
           {...rest}


### PR DESCRIPTION
## 📌 개요
데스크톱 환경에서 커뮤니티 댓글 등록 버튼을 눌러도 아무런 반응이 없는 버그 수정

## 🔧 작업 내용
- CommentForm에 `value`/`onChangeValue` controlled 모드 추가 (기존 `register` 방식도 유지)
- CommunityDetail에서 `register` 대신 `watch`/`setValue`로 데스크톱/모바일 폼이 같은 값을 공유
- 원인: 두 폼이 같은 react-hook-form `register`를 공유하여 모바일 textarea ref가 데스크톱 것을 덮어씀

## 📎 관련 이슈
Closes #582

## 📋 QA 티켓
https://www.notion.so/32df2b30796181cc8d97d2386fd6ad0c

## 💬 리뷰어 참고 사항
CommentForm은 CommentList(답글 폼)에서도 사용되며, 그쪽은 기존 `register` 방식 그대로 유지됩니다. controlled 모드는 CommunityDetail의 메인 댓글 폼에서만 사용됩니다.