### PR TITLE
fix: 댓글 삭제 후 댓글 갯수 미갱신(#586)

### DIFF
--- a/src/features/community/components/CommentList.tsx
+++ b/src/features/community/components/CommentList.tsx
@@ -87,6 +87,8 @@ export function CommentList({ comments, postId }: CommentListProps) {
       queryClient.invalidateQueries({ queryKey: ['community', postId, 'comments'] })
       // 대댓글 목록도 refetch
       queryClient.invalidateQueries({ queryKey: ['community', postId, 'replies'] })
+      // 게시글 상세 refetch (commentCount 업데이트를 위해)
+      queryClient.invalidateQueries({ queryKey: ['community', postId] })
     },
   })
 


### PR DESCRIPTION
## 📌 개요
댓글 삭제 후 게시글의 댓글 갯수(commentCount)가 갱신되지 않는 버그 수정

## 🔧 작업 내용
- CommentList.tsx의 deleteMutation.onSuccess 콜백에서 게시글 상세 데이터 invalidate 추가
- 기존: 댓글 목록 + 대댓글 목록만 refetch
- 수정: 게시글 상세(['community', postId])도 함께 invalidate하여 commentCount 즉시 반영

## 📎 관련 이슈
Closes #586

## 📋 QA 티켓
https://www.notion.so/32df2b307961819e8ec4c631696797b7

## 💬 리뷰어 참고 사항
1줄 추가로 해결되는 단순 invalidation 누락 버그입니다.