### PR TITLE
chore: 모바일 검색 실행 후 키보드 자동 닫힘 처리(#592)

### DIFF
--- a/src/components/header/components/SearchBar.tsx
+++ b/src/components/header/components/SearchBar.tsx
@@ -34,6 +34,7 @@ export default function SearchBar({
   function handleKeywordChange(e: React.KeyboardEvent<HTMLInputElement>) {
     if (e.key === 'Enter') {
       const target = e.currentTarget
+      target.blur()
       const searchKeyword = target.value.trim()
       const isCurrentPageSearch = isHomePage || paramName !== 'keyword'
 


### PR DESCRIPTION
## 📌 개요

- 모바일에서 검색 실행 후 키보드가 자동으로 내려가도록 blur 처리 추가

## 🔧 작업 내용

- [x] SearchBar handleKeywordChange에서 Enter 시 target.blur() 추가

## 📎 관련 이슈

Closes #592

## 💬 리뷰어 참고 사항

- 검색 실행 후 input 포커스가 남아 키보드가 유지되던 문제를 blur()로 해제