### PR TITLE
fix: 커뮤니티 검색 X 버튼 클릭 시 검색 결과 초기화 수정(#594)

### DIFF
--- a/src/components/header/components/SearchBar.tsx
+++ b/src/components/header/components/SearchBar.tsx
@@ -59,8 +59,9 @@ export default function SearchBar({
 
   function handleClearKeyword() {
     setKeyword('')
+    const isCurrentPageSearch = isHomePage || paramName !== 'keyword'
 
-    if (isHomePage) {
+    if (isCurrentPageSearch) {
       const params = new URLSearchParams(searchParams.toString())
       params.delete(paramName)
       const query = params.toString()


### PR DESCRIPTION
## 📌 개요

- 커뮤니티 검색 X 버튼 클릭 시 URL 파라미터도 함께 삭제하여 검색 결과 초기화

## 🔧 작업 내용

- [x] handleClearKeyword에서 isHomePage 대신 isCurrentPageSearch 조건 적용

## 📎 관련 이슈

Closes #594

## 📋 QA 티켓

https://www.notion.so/32ef2b30796181f895a1f1fab3fbc3ba

## 💬 리뷰어 참고 사항

- handleKeywordChange에서 이미 적용된 isCurrentPageSearch 패턴을 handleClearKeyword에도 동일 적용