### PR TITLE
fix: 커뮤니티 검색 한글 IME 마지막 글자 중복 수정(#596)

### DIFF
--- a/src/components/header/components/SearchBar.tsx
+++ b/src/components/header/components/SearchBar.tsx
@@ -32,6 +32,7 @@ export default function SearchBar({
   const isHomePage = pathname === ROUTES.HOME
 
   function handleKeywordChange(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.nativeEvent.isComposing) return
     if (e.key === 'Enter') {
       const target = e.currentTarget
       target.blur()


### PR DESCRIPTION
## 📌 개요

- 커뮤니티 검색창에서 한글 입력 후 Enter 시 IME 조합 중 마지막 글자가 중복되는 버그 수정

## 🔧 작업 내용

- [ ] SearchBar 컴포넌트의 `handleKeywordChange`에 `e.nativeEvent.isComposing` 체크 추가

## 📎 관련 이슈

Closes #596

## 📋 QA 티켓

https://www.notion.so/32ef2b30796181d0b881e6a6c258eb53

## 💬 리뷰어 참고 사항

- 한글 IME 조합 중 Enter를 누르면 `compositionend` 이벤트와 `keydown` 이벤트가 동시에 발생하여 마지막 글자가 중복 입력되는 문제였습니다
- `e.nativeEvent.isComposing`이 `true`인 경우 Enter 핸들러를 무시하도록 처리했습니다