### PR TITLE
fix: 데스크톱 커뮤니티 답글 등록 버튼 무반응(#598)

### DIFF
--- a/src/features/community/components/CommentList.tsx
+++ b/src/features/community/components/CommentList.tsx
@@ -32,7 +32,8 @@ export function CommentList({ comments, postId }: CommentListProps) {
   const searchParams = useSearchParams()
   const {
     handleSubmit, // form onSubmit에 들어가는 함수 : 제출 시 실행할 함수를 감싸주는 함수
-    register, // onChange 등의 이벤트 객체 생성 : input에 "이 필드는 폼의 어떤 이름이다"라고 연결해주는 함수
+    watch, // 필드 값을 구독하여 실시간으로 가져오는 함수
+    setValue, // 필드 값을 수동으로 설정하는 함수
     reset,
   } = useForm<ReplyRequestFormValues>({
     mode: 'onChange',
@@ -40,6 +41,7 @@ export function CommentList({ comments, postId }: CommentListProps) {
       content: '',
     },
   })
+  const replyContent = watch('content')
   const [openRepliesCommentId, setOpenRepliesCommentId] = useState<number | null>(null)
   const [replyingToId, setReplyingToId] = useState<number | null>(null)
   const [replyPostError, setReplyPostError] = useState<React.ReactNode | null>(null)
@@ -179,7 +181,8 @@ export function CommentList({ comments, postId }: CommentListProps) {
                 id={String(comment.id)}
                 placeholder="답글을 입력하세요"
                 legendText="대댓글 작성폼"
-                register={register}
+                value={replyContent}
+                onChangeValue={(v) => setValue('content', v)}
                 onSubmit={handleSubmit(onSubmit)}
                 onCancel={() => handleOpenReplyForm(comment.id)}
               />
@@ -199,7 +202,8 @@ export function CommentList({ comments, postId }: CommentListProps) {
           <ReplyOverlay
             comment={targetComment}
             replies={openRepliesCommentId === replyingToId ? repliesData?.comments : undefined}
-            register={register}
+            value={replyContent}
+            onChangeValue={(v) => setValue('content', v)}
             onSubmit={handleSubmit(onSubmit)}
             onClose={() => handleOpenReplyForm(replyingToId)}
           />

--- a/src/features/community/components/ReplyOverlay.tsx
+++ b/src/features/community/components/ReplyOverlay.tsx
@@ -3,20 +3,19 @@
 import { useEffect, useRef } from 'react'
 import { ArrowLeft } from 'lucide-react'
 import type { Comment } from '@/types'
-import type { UseFormRegister } from 'react-hook-form'
 import { CommentItem } from './CommentItem'
 import { CommentForm } from './CommentForm'
-import type { ReplyRequestFormValues } from './CommentList'
 
 interface ReplyOverlayProps {
   comment: Comment
   replies?: Comment[]
-  register: UseFormRegister<ReplyRequestFormValues>
+  value: string
+  onChangeValue: (value: string) => void
   onSubmit: () => void
   onClose: () => void
 }
 
-export function ReplyOverlay({ comment, replies, register, onSubmit, onClose }: ReplyOverlayProps) {
+export function ReplyOverlay({ comment, replies, value, onChangeValue, onSubmit, onClose }: ReplyOverlayProps) {
   const totalCount = 1 + (replies?.length ?? 0)
 
   const onCloseRef = useRef(onClose)
@@ -71,7 +70,8 @@ export function ReplyOverlay({ comment, replies, register, onSubmit, onClose }: 
           id={`reply-overlay-${comment.id}`}
           placeholder="답글을 입력하세요"
           legendText="답글 작성폼"
-          register={register}
+          value={value}
+          onChangeValue={onChangeValue}
           onSubmit={onSubmit}
         />
       </div>


### PR DESCRIPTION
## 📌 개요

- 데스크톱 환경에서 커뮤니티 답글 등록 버튼이 동작하지 않는 버그 수정
- 이전 댓글 등록 버그(#582)와 동일한 원인으로, `register` 방식을 `watch` + `setValue` 방식으로 전환

## 🔧 작업 내용

- [x] CommentList.tsx 답글 폼에서 `register` → `watch` + `setValue` + `onChangeValue` 방식으로 전환
- [x] ReplyOverlay.tsx도 동일하게 `register` → `value` + `onChangeValue` 방식으로 수정

## 📎 관련 이슈

Closes #598

## 📋 QA 티켓

https://www.notion.so/32ef2b307961812780cdc5eafe223ac4

## 💬 리뷰어 참고 사항

- 이전 댓글 등록 버그(#582) 수정 시 CommunityDetail.tsx만 적용하고 CommentList.tsx의 답글 폼은 미적용이었음
- 동일한 패턴을 답글 폼에도 적용하여 수정