### PR TITLE
chore: GraphQL 알림 스키마를 REST API 스펙에 맞게 수정(#600)

### DIFF
--- a/src/components/header/components/notification-section/NotificationsDropdown.tsx
+++ b/src/components/header/components/notification-section/NotificationsDropdown.tsx
@@ -41,7 +41,7 @@ export default function NotificationsDropdown({ isNotificationOpen, setIsNotific
       const data = await fetchGraphQL<{ notifications: any }>(`
         query Notifications($page: Int!, $size: Int!) {
           notifications(page: $page, size: $size) {
-            content { notificationId type message isRead relatedEntityType relatedEntityId createdAt senderNickname senderProfileImageUrl }
+            content { notificationId notificationType title content relatedEntityType relatedEntityId isRead readAt createdAt }
             page hasNext
           }
         }

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -207,14 +207,14 @@ export const typeDefs = gql`
 
   type Notification {
     notificationId: Int!
-    type: String
-    message: String
+    notificationType: String!
+    title: String!
+    content: String!
+    relatedEntityType: String!
+    relatedEntityId: Int!
     isRead: Boolean!
-    relatedEntityType: String
-    relatedEntityId: Int
+    readAt: String
     createdAt: String!
-    senderNickname: String
-    senderProfileImageUrl: String
   }
 
   type NotificationConnection {


### PR DESCRIPTION
## Summary

- GraphQL Notification 타입을 REST API 스펙에 맞게 필드명 수정
- NotificationsDropdown GraphQL 쿼리 필드명 동기화

## Changed Files

- `src/graphql/schema.ts`: `type`→`notificationType`, `message`→`content`, `title`/`readAt` 추가, `senderNickname`/`senderProfileImageUrl` 제거
- `src/components/header/components/notification-section/NotificationsDropdown.tsx`: 쿼리 필드명 수정

## Test plan

- [ ] TypeScript 빌드 에러 없음 확인
- [ ] 알림 드롭다운 정상 렌더링 확인

Closes #600