### PR TITLE
fix: SSR 하이드레이션 전 이미지 로드 실패 시 fallback 미동작 수정(#604)

### DIFF
--- a/src/components/product/components/ProductThumbnail.tsx
+++ b/src/components/product/components/ProductThumbnail.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import { ProductBadge } from './ProductBadge'
 import Badge from '@/components/commons/badge/Badge'
 import { cn } from '@/lib/utils/cn'
@@ -59,6 +59,11 @@ export function ProductThumbnail({
       <Badge className={cn('bottom-sm right-sm absolute z-1 text-xs text-white', productTradeColor)}>{displayTradeStatus}</Badge>
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
+        ref={useCallback((img: HTMLImageElement | null) => {
+          if (img && img.complete && img.naturalWidth === 0 && imgErrorStep < 2) {
+            setImgErrorStep((prev) => prev + 1)
+          }
+        }, [imgErrorStep])}
         alt={title}
         src={getSrc()}
         srcSet={getSrcSet()}

--- a/src/features/home/components/FallbackImage.tsx
+++ b/src/features/home/components/FallbackImage.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 import { getImageSrcSet, toResizedWebpUrl, PLACEHOLDER_IMAGES } from '@/lib/utils/imageUrl'
 
 interface FallbackImageProps {
@@ -28,6 +28,11 @@ export function FallbackImage({ imageUrl, alt, sizes, priority, className }: Fal
   return (
     // eslint-disable-next-line @next/next/no-img-element
     <img
+      ref={useCallback((img: HTMLImageElement | null) => {
+        if (img && img.complete && img.naturalWidth === 0 && imgErrorStep < 2) {
+          setImgErrorStep((prev) => prev + 1)
+        }
+      }, [imgErrorStep])}
       alt={alt}
       src={getSrc()}
       srcSet={getSrcSet()}

--- a/src/features/product-detail/components/MainImage.tsx
+++ b/src/features/product-detail/components/MainImage.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 import { getImageSrcSet, IMAGE_SIZES, toResizedWebpUrl, PLACEHOLDER_IMAGES } from '@/lib/utils/imageUrl'
 
 interface MainImageProps {
@@ -26,6 +26,11 @@ export default function MainImage({ mainImageUrl, title }: MainImageProps) {
     <div className="relative overflow-hidden rounded-xl pb-[100%]">
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
+        ref={useCallback((img: HTMLImageElement | null) => {
+          if (img && img.complete && img.naturalWidth === 0 && imgErrorStep < 2) {
+            setImgErrorStep((prev) => prev + 1)
+          }
+        }, [imgErrorStep])}
         src={getSrc()}
         srcSet={getSrcSet()}
         sizes={IMAGE_SIZES.mainImage}


### PR DESCRIPTION
## 📌 개요

- SSR에서 렌더링된 이미지가 하이드레이션 전에 로드 실패하면 React `onError` 핸들러가 연결되지 않아 fallback이 동작하지 않는 버그 수정

## 🔧 작업 내용

- [ ] ProductThumbnail, MainImage, FallbackImage에 ref callback 추가
- [ ] 하이드레이션 후 `img.complete && img.naturalWidth === 0` 체크로 이미 실패한 이미지 감지

## 📎 관련 이슈

Closes #604

## 📋 QA 티켓

https://www.notion.so/32ef2b3079618152a4eff764dccc9afd

## 💬 리뷰어 참고 사항

- 새로고침 시 이미지가 안 보이고, 클라이언트 네비게이션 시에만 보이던 문제 해결
- `useCallback` ref로 마운트 시점에 이미 실패한 이미지를 감지하여 fallback 트리거