### PR TITLE
fix: 데스크톱 메인페이지 새로고침 시 모바일 레이아웃 깜빡임 수정(#607)

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -46,6 +46,8 @@ const HIDE_SEARCHBAR_MOBILE_PATTERNS = [/^\/user-profile\/\d+$/]
 const HIDE_SEARCHBAR_ALWAYS_PATTERNS = [COMMUNITY_DETAIL, COMMUNITY_EDIT, /^\/products\/\d+\/edit$/, /^\/chat\/\d+$/]
 
 export default function Header() {
+  const [isHydrated, setIsHydrated] = useState(false)
+  useEffect(() => { setIsHydrated(true) }, [])
   const isXl = useMediaQuery('(min-width: 1280px)')
   const [isSideOpen, setIsSideOpen] = useState(false)
   const [isSearchOpen, setIsSearchOpen] = useState(false)
@@ -93,6 +95,18 @@ export default function Header() {
   }, [showHeader, isSearchOpen, isXl])
 
   if (!showHeader) return null
+
+  if (!isHydrated) {
+    return (
+      <header className={cn('bg-primary-200 fixed top-0 flex w-full items-center justify-center pt-3 pb-3', Z_INDEX.HEADER)}>
+        <div className="flex w-full flex-col px-4 xl:block xl:max-w-7xl xl:px-3.5">
+          <div className="flex h-12 items-center">
+            <Logo />
+          </div>
+        </div>
+      </header>
+    )
+  }
 
   return (
     <>

--- a/src/features/home/Home.tsx
+++ b/src/features/home/Home.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useInfiniteQuery } from '@tanstack/react-query'
-import { useState, useCallback, useMemo } from 'react'
+import { useState, useCallback, useMemo, useEffect } from 'react'
 import Tabs from '@/components/Tabs'
 import { DetailFilter } from '@/features/home/components/filter/DetailFilter'
 import { ProductsSection } from '@/features/home/components/product-section/ProductsSection'
@@ -24,6 +24,8 @@ function Home() {
   const { isLogin } = useUserStore()
   const hasHydrated = useUserStore((state) => state._hasHydrated)
   const isLoggedIn = hasHydrated && isLogin()
+  const [isHydrated, setIsHydrated] = useState(false)
+  useEffect(() => { setIsHydrated(true) }, [])
   const isMd = useMediaQuery('(min-width: 768px)')
   const { searchParams, pathname, push } = useFilterNavigation()
   const router = useRouter()
@@ -197,6 +199,40 @@ function Home() {
   }
 
   const totalElements = data?.pages?.[0]?.totalElements || 0
+
+  if (!isHydrated) {
+    return (
+      <div className="pb-4xl pt-6">
+        <h1 className="sr-only">커들마켓</h1>
+        <div className="px-lg mx-auto max-w-7xl">
+          <div className="flex flex-col gap-12">
+            <section className="flex flex-col gap-7">
+              {/* 필터 스켈레톤 */}
+              <div className="flex flex-col gap-3">
+                <div className="h-5 w-20 animate-pulse rounded bg-gray-200" />
+                <div className="flex gap-2">
+                  {[...Array(6)].map((_, i) => (
+                    <div key={i} className="h-10 w-16 animate-pulse rounded-full bg-gray-200" />
+                  ))}
+                </div>
+              </div>
+              <div className="flex flex-col gap-3">
+                <div className="h-5 w-20 animate-pulse rounded bg-gray-200" />
+                <div className="flex gap-2">
+                  {[...Array(5)].map((_, i) => (
+                    <div key={i} className="h-10 w-20 animate-pulse rounded-full bg-gray-200" />
+                  ))}
+                </div>
+              </div>
+            </section>
+            <section className="flex flex-col gap-2.5">
+              <HomeSkeleton />
+            </section>
+          </div>
+        </div>
+      </div>
+    )
+  }
 
   if (error && !isLoading) {
     return (


### PR DESCRIPTION
## 📌 개요

- 데스크톱에서 메인페이지 새로고침 시 모바일 헤더/필터/탭 레이아웃이 잠시 보이는 FOUC 현상 수정
- 하이드레이션 완료 전까지 스켈레톤을 표시하여 깜빡임 방지

## 🔧 작업 내용

- [ ] Home.tsx: 하이드레이션 전 필터+상품 영역 스켈레톤 표시
- [ ] Header.tsx: 하이드레이션 전 로고만 있는 최소 헤더 표시

## 📎 관련 이슈

Closes #607

## 📋 QA 티켓

https://www.notion.so/32ef2b30796181d2b3eac21a44b783d8

## 💬 리뷰어 참고 사항

- `useMediaQuery`가 SSR에서 `false`를 반환하여 서버 HTML이 모바일 레이아웃으로 렌더링되는 구조적 문제
- 근본 해결(CSS 기반 반응형 전환)은 별도 작업으로, 이번 수정은 스켈레톤으로 FOUC를 가리는 빠른 대응