### PR TITLE
fix: HomeSkeleton/StaticHomeFallback grid를 ProductList와 일치시킴(#607)

### DIFF
--- a/src/features/home/components/StaticHomeFallback.tsx
+++ b/src/features/home/components/StaticHomeFallback.tsx
@@ -53,7 +53,7 @@ export default function StaticHomeFallback({ products, totalElements }: StaticHo
                   <div className="bg-primary-50 rounded px-3 py-2 text-gray-900 text-sm">최신순</div>
                 </div>
               </div>
-              <ul className="grid grid-cols-1 gap-4 md:grid-cols-3 lg:grid-cols-4">
+              <ul className="grid grid-cols-1 gap-4 md:grid-cols-4 lg:grid-cols-5">
                 {products.map((product, index) => (
                   <li key={product.id}>
                     <StaticProductCard product={product} index={index} />

--- a/src/features/home/components/product-section/HomeSkeleton.tsx
+++ b/src/features/home/components/product-section/HomeSkeleton.tsx
@@ -10,7 +10,7 @@ export default function HomeSkeleton() {
         <div className="h-10 w-36 animate-pulse rounded bg-gray-200" />
       </div>
       {/* 상품 그리드 스켈레톤 */}
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-3 lg:grid-cols-4">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-4 lg:grid-cols-5">
         {[...Array(8)].map((_, i) => (
           <div key={i} className="animate-pulse">
             <div className="aspect-square rounded-xl bg-gray-200" />


### PR DESCRIPTION
## Summary

- HomeSkeleton과 StaticHomeFallback의 grid 설정을 실제 ProductList와 일치시킴
- `md:grid-cols-3 lg:grid-cols-4` → `md:grid-cols-4 lg:grid-cols-5`

## Changed Files

- `src/features/home/components/product-section/HomeSkeleton.tsx`
- `src/features/home/components/StaticHomeFallback.tsx`

## Test plan

- [ ] 메인페이지 새로고침 시 스켈레톤 → 실제 상품 목록 전환 시 grid 레이아웃 일관성 확인

Closes #607