### PR TITLE
fix: 메인페이지 스켈레톤에 세부 필터/탭 스켈레톤 추가(#607)

### DIFF
--- a/src/features/home/Home.tsx
+++ b/src/features/home/Home.tsx
@@ -224,8 +224,26 @@ function Home() {
                   ))}
                 </div>
               </div>
+              {/* 세부 필터 스켈레톤 */}
+              <div className="flex items-center justify-between rounded-lg border border-gray-200 px-4 py-3">
+                <div className="flex items-center gap-2">
+                  <div className="h-5 w-5 animate-pulse rounded bg-gray-200" />
+                  <div className="h-5 w-24 animate-pulse rounded bg-gray-200" />
+                  <div className="h-5 w-32 animate-pulse rounded bg-gray-200" />
+                </div>
+                <div className="flex items-center gap-2">
+                  <div className="h-5 w-16 animate-pulse rounded bg-gray-200" />
+                  <div className="h-5 w-5 animate-pulse rounded bg-gray-200" />
+                </div>
+              </div>
             </section>
             <section className="flex flex-col gap-2.5">
+              {/* 탭 스켈레톤 */}
+              <div className="flex gap-4 border-b-[1.5px] border-b-primary-200 pb-1">
+                {['전체', '판매', '판매요청'].map((label) => (
+                  <div key={label} className="h-8 w-16 animate-pulse rounded bg-gray-200" />
+                ))}
+              </div>
               <HomeSkeleton />
             </section>
           </div>


### PR DESCRIPTION
## Summary

- 메인페이지 하이드레이션 스켈레톤에 누락된 세부 필터, 탭 스켈레톤 추가
- 실제 레이아웃과 스켈레톤의 구조 일치

## Changed Files

- `src/features/home/Home.tsx`: 세부 필터 스켈레톤 + 전체/판매/판매요청 탭 스켈레톤 추가

## Test plan

- [ ] 데스크톱 메인페이지 강력 새로고침 시 스켈레톤이 실제 레이아웃과 일치하는지 확인

Closes #607