### PR TITLE
fix: 헤더 스켈레톤에 검색바/메뉴 플레이스홀더 추가(#607)

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -100,8 +100,22 @@ export default function Header() {
     return (
       <header className={cn('bg-primary-200 fixed top-0 flex w-full items-center justify-center pt-3 pb-3', Z_INDEX.HEADER)}>
         <div className="flex w-full flex-col px-4 xl:block xl:max-w-7xl xl:px-3.5">
-          <div className="flex h-12 items-center">
-            <Logo />
+          <div className="flex h-12 items-center justify-between gap-4">
+            <nav className="flex items-center gap-8">
+              <Logo />
+              <div className="hidden xl:flex items-center gap-8">
+                <div className="h-5 w-10 animate-pulse rounded bg-white/30" />
+                <div className="h-5 w-16 animate-pulse rounded bg-white/30" />
+              </div>
+            </nav>
+            <div className="flex items-center gap-1 xl:gap-8">
+              <div className="hidden xl:block h-9 w-80 animate-pulse rounded-full bg-white/20" />
+              <div className="flex items-center gap-2">
+                <div className="h-6 w-6 animate-pulse rounded-full bg-white/30" />
+                <div className="h-6 w-6 animate-pulse rounded-full bg-white/30" />
+                <div className="h-8 w-8 animate-pulse rounded-full bg-white/30" />
+              </div>
+            </div>
           </div>
         </div>
       </header>


### PR DESCRIPTION
## Summary

- 헤더 하이드레이션 스켈레톤에 검색바, 마켓/커뮤니티 링크, 아이콘 플레이스홀더 추가
- 로고만 달랑 있던 스켈레톤을 실제 헤더와 유사한 구조로 개선

## Changed Files

- `src/components/header/Header.tsx`: 스켈레톤 헤더에 플레이스홀더 요소 추가

## Test plan

- [ ] 데스크톱 메인페이지 강력 새로고침 시 헤더 스켈레톤이 자연스럽게 보이는지 확인

Closes #607