### PR TITLE
chore: 커뮤니티 게시글 작성/수정 페이지 데스크톱 UI 개선(#612)

### DIFF
--- a/src/components/commons/TitleField.tsx
+++ b/src/components/commons/TitleField.tsx
@@ -17,6 +17,7 @@ interface TitleFieldProps<T extends FieldValues> {
   placeholder?: string
   size?: string
   counterClassName?: string
+  labelClassName?: string
 }
 
 export default function TitleField<T extends FieldValues>({
@@ -31,10 +32,11 @@ export default function TitleField<T extends FieldValues>({
   placeholder = '제목을 입력해주세요',
   size = 'text-sm',
   counterClassName,
+  labelClassName = 'heading-h5',
 }: TitleFieldProps<T>) {
   return (
     <div className="flex flex-col gap-1">
-      <RequiredLabel htmlFor={id} labelClass="heading-h5">
+      <RequiredLabel htmlFor={id} labelClass={labelClassName}>
         {label}
       </RequiredLabel>
       <InputField

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -46,8 +46,6 @@ const HIDE_SEARCHBAR_MOBILE_PATTERNS = [/^\/user-profile\/\d+$/]
 const HIDE_SEARCHBAR_ALWAYS_PATTERNS = [COMMUNITY_DETAIL, COMMUNITY_EDIT, /^\/products\/\d+\/edit$/, /^\/chat\/\d+$/]
 
 export default function Header() {
-  const [isHydrated, setIsHydrated] = useState(false)
-  useEffect(() => { setIsHydrated(true) }, [])
   const isXl = useMediaQuery('(min-width: 1280px)')
   const [isSideOpen, setIsSideOpen] = useState(false)
   const [isSearchOpen, setIsSearchOpen] = useState(false)
@@ -95,32 +93,6 @@ export default function Header() {
   }, [showHeader, isSearchOpen, isXl])
 
   if (!showHeader) return null
-
-  if (!isHydrated) {
-    return (
-      <header className={cn('bg-primary-200 fixed top-0 flex w-full items-center justify-center pt-3 pb-3', Z_INDEX.HEADER)}>
-        <div className="flex w-full flex-col px-4 xl:block xl:max-w-7xl xl:px-3.5">
-          <div className="flex h-12 items-center justify-between gap-4">
-            <nav className="flex items-center gap-8">
-              <Logo />
-              <div className="hidden xl:flex items-center gap-8">
-                <div className="h-5 w-10 animate-pulse rounded bg-white/30" />
-                <div className="h-5 w-16 animate-pulse rounded bg-white/30" />
-              </div>
-            </nav>
-            <div className="flex items-center gap-1 xl:gap-8">
-              <div className="hidden xl:block h-9 w-80 animate-pulse rounded-full bg-white/20" />
-              <div className="flex items-center gap-2">
-                <div className="h-6 w-6 animate-pulse rounded-full bg-white/30" />
-                <div className="h-6 w-6 animate-pulse rounded-full bg-white/30" />
-                <div className="h-8 w-8 animate-pulse rounded-full bg-white/30" />
-              </div>
-            </div>
-          </div>
-        </div>
-      </header>
-    )
-  }
 
   return (
     <>

--- a/src/components/header/SimpleHeader.tsx
+++ b/src/components/header/SimpleHeader.tsx
@@ -6,19 +6,21 @@ interface SimpleHeaderProps {
   description?: string
   href?: string
   layoutClassname?: string
+  titleClassName?: string
+  descriptionClassName?: string
 }
 
-export default function SimpleHeader({ title, description, href, layoutClassname }: SimpleHeaderProps) {
+export default function SimpleHeader({ title, description, href, layoutClassname, titleClassName, descriptionClassName }: SimpleHeaderProps) {
   return (
     <div className={cn('mx-auto flex max-w-7xl flex-col gap-2 bg-white px-3.5 py-2.5', layoutClassname)}>
       {href ? (
-        <Link href={href} className="heading-h2 hover:text-primary-200 w-fit cursor-pointer transition-all">
+        <Link href={href} className={cn(titleClassName || 'heading-h2', 'hover:text-primary-200 w-fit cursor-pointer transition-all')}>
           {title}
         </Link>
       ) : (
-        <span className="heading-h2">{title}</span>
+        <span className={titleClassName || 'heading-h2'}>{title}</span>
       )}
-      {description ? <p>{description}</p> : null}
+      {description ? <p className={descriptionClassName}>{description}</p> : null}
     </div>
   )
 }

--- a/src/features/community/components/CommunityPostForm.tsx
+++ b/src/features/community/components/CommunityPostForm.tsx
@@ -15,7 +15,6 @@ import { ArrowLeft } from 'lucide-react'
 import { fetchGraphQL } from '@/lib/api/graphql'
 import { useEffect, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { useMediaQuery } from '@/hooks/useMediaQuery'
 import SimpleHeader from '@/components/header/SimpleHeader'
 import { Z_INDEX } from '@/constants/ui'
 import { AnimatePresence } from 'framer-motion'
@@ -53,7 +52,6 @@ const getSavedDraft = (boardType: string): CommunityPostFormValues => {
 
 export default function CommunityPostForm() {
   const router = useRouter()
-  const isMd = useMediaQuery('(min-width: 768px)')
   const params = useParams()
   const id = params.id as string | undefined
   const isEditMode = !!id
@@ -192,24 +190,27 @@ export default function CommunityPostForm() {
   return (
     <>
       <h1 className="sr-only">{isEditMode ? '게시글 수정' : '커뮤니티 글쓰기'}</h1>
-      {!isMd ? (
-        <div
-          className={cn('bg-primary-200 sticky top-0 mx-auto flex w-full max-w-7xl justify-between px-3.5 py-4', Z_INDEX.HEADER)}
-        >
-          <button type="button" onClick={() => router.back()} className="flex cursor-pointer items-center gap-1 text-gray-600">
-            <ArrowLeft size={23} className="text-white" />
-          </button>
-          <span className="heading-h4 absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-lg font-extrabold! text-white">
-            커뮤니티
-          </span>
-        </div>
-      ) : (
+      {/* 모바일 서브헤더 */}
+      <div
+        className={cn('bg-primary-200 sticky top-0 mx-auto flex w-full max-w-7xl justify-between px-3.5 py-4 md:hidden', Z_INDEX.HEADER)}
+      >
+        <button type="button" onClick={() => router.back()} className="flex cursor-pointer items-center gap-1 text-gray-600">
+          <ArrowLeft size={23} className="text-white" />
+        </button>
+        <span className="heading-h4 absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-lg font-extrabold! text-white">
+          커뮤니티
+        </span>
+      </div>
+      {/* 데스크톱 서브헤더 */}
+      <div className="hidden md:block">
         <SimpleHeader
           title="커뮤니티 글쓰기"
           description="일상 이야기를 마음껏 나눠보세요!"
-          layoutClassname="py-5 flex-col justify-between border-b border-gray-200"
+          layoutClassname="py-5 gap-0 flex-col justify-between border-b border-gray-200"
+          titleClassName="text-[22px] leading-[1.5] font-bold"
+          descriptionClassName="text-sm"
         />
-      )}
+      </div>
       <div className="bg-[#F3F4F6]">
         <div className="px-lg mx-auto max-w-7xl pt-5">
           <AnimatePresence>
@@ -226,14 +227,14 @@ export default function CommunityPostForm() {
           <form className="w-full" onSubmit={handleSubmit(onSubmit)}>
             <fieldset className="flex flex-col gap-5">
               <legend className="sr-only">커뮤니티 등록폼</legend>
-              <div className="flex flex-col gap-6 rounded-lg border border-gray-400 bg-white px-3.5 py-5 shadow-xl md:px-6">
+              <div className="flex flex-col gap-3.5 rounded-lg border border-gray-400 bg-white px-5 py-3.5 shadow-xl">
                 <Controller
                   name="boardType"
                   control={control}
                   rules={{ required: '카테고리를 선택해주세요' }}
                   render={({ field, fieldState }) => (
                     <div className="flex flex-col gap-1">
-                      <RequiredLabel labelClass="heading-h5">카테고리</RequiredLabel>
+                      <RequiredLabel labelClass="text-base font-semibold">카테고리</RequiredLabel>
                       <SelectDropdown
                         value={field.value || ''}
                         onChange={field.onChange}
@@ -260,23 +261,24 @@ export default function CommunityPostForm() {
                   id="community-title"
                   placeholder="제목을 입력해주세요"
                   size="text-base"
-                  counterClassName="text-sm text-gray-500"
+                  counterClassName="text-xs text-gray-500"
+                  labelClassName="text-base font-semibold"
                 />
               </div>
-              <div className="rounded-lg border border-gray-400 bg-white px-3.5 py-5 shadow-xl md:px-6">
+              <div className="rounded-lg border border-gray-400 bg-white px-5 py-3.5 shadow-xl">
                 <Controller
                   name="content"
                   control={control}
                   rules={communityContentValidationRules}
                   render={({ field, fieldState }) => (
                     <div className="flex flex-col gap-1">
-                      <RequiredLabel labelClass="heading-h5">내용</RequiredLabel>
+                      <RequiredLabel labelClass="text-base font-semibold">내용</RequiredLabel>
                       <Markdown value={field.value} onChange={field.onChange} placeholder="내용을 입력하세요" height={320} />
                       <div className="flex flex-col gap-1">
                         {fieldState.error ? (
                           <p className="pt-1.5 text-xs font-semibold text-red-500">{fieldState.error.message}</p>
                         ) : null}
-                        <p className="text-sm text-gray-500">{field.value?.length ?? 0}/1000자</p>
+                        <p className="text-xs text-gray-500">{field.value?.length ?? 0}/1000자</p>
                       </div>
                     </div>
                   )}

--- a/src/features/community/components/markdown/MdToolbar.tsx
+++ b/src/features/community/components/markdown/MdToolbar.tsx
@@ -22,14 +22,14 @@ export default function MdToolbar({ tab, setTab, onBold, onItalic, onCode, onLin
         <button
           type="button"
           onClick={() => setTab('edit')}
-          className={`rounded-lg px-3 py-1 text-sm hover:cursor-pointer ${tab === 'edit' ? 'bg-gray-100 text-gray-900 shadow-sm' : 'text-gray-600 hover:bg-gray-50'}`}
+          className={`rounded-lg px-2.5 py-1 text-xs hover:cursor-pointer ${tab === 'edit' ? 'bg-gray-100 text-gray-900 shadow-sm' : 'text-gray-600 hover:bg-gray-50'}`}
         >
           작성
         </button>
         <button
           type="button"
           onClick={() => setTab('preview')}
-          className={`rounded-lg px-3 py-1 text-sm ${tab === 'preview' ? 'bg-gray-100 text-gray-900 shadow-sm' : 'text-gray-600 hover:cursor-pointer hover:bg-gray-50'}`}
+          className={`rounded-lg px-2.5 py-1 text-xs ${tab === 'preview' ? 'bg-gray-100 text-gray-900 shadow-sm' : 'text-gray-600 hover:cursor-pointer hover:bg-gray-50'}`}
         >
           미리보기
         </button>


### PR DESCRIPTION
## 📌 개요

- 커뮤니티 게시글 작성/수정 페이지 데스크톱 UI 스타일 개선
- 서브헤더 CSS 기반 반응형 전환으로 FOUC 방지

## 🔧 작업 내용

- [ ] 서브헤더 스타일 조정 (제목 22px, 설명 14px, gap 제거)
- [ ] 카드 padding/gap 축소 (py-3.5, px-5, gap-3.5)
- [ ] 라벨 font-size 조정 (heading-h5 18px → text-base 16px)
- [ ] 글자수 카운터 크기 축소 (text-sm → text-xs)
- [ ] 마크다운 탭 버튼 크기 축소 (text-xs, px-2.5)
- [ ] 서브헤더 CSS 기반 반응형 전환 (md:hidden / hidden md:block)
- [ ] SimpleHeader에 titleClassName, descriptionClassName props 추가
- [ ] TitleField에 labelClassName prop 추가
- [ ] Header.tsx isHydrated 스켈레톤 제거 (다른 페이지 부작용으로 원래 방식 복원)

## 📎 관련 이슈

Closes #612

## 📸 스크린샷 (선택)

(필요시 추가)

## 💬 리뷰어 참고 사항

- SimpleHeader, TitleField의 새 props는 기본값이 있어 기존 사용처에 영향 없음
- Header.tsx의 isHydrated 스켈레톤은 커뮤니티 수정 페이지 등에서 부작용이 있어 제거함