### PR TITLE
chore: 커뮤니티 작성/수정 페이지 모바일 카드 padding 조정(#615)

### DIFF
--- a/src/features/community/components/CommunityPostForm.tsx
+++ b/src/features/community/components/CommunityPostForm.tsx
@@ -227,7 +227,7 @@ export default function CommunityPostForm() {
           <form className="w-full" onSubmit={handleSubmit(onSubmit)}>
             <fieldset className="flex flex-col gap-5">
               <legend className="sr-only">커뮤니티 등록폼</legend>
-              <div className="flex flex-col gap-3.5 rounded-lg border border-gray-400 bg-white px-5 py-3.5 shadow-xl">
+              <div className="flex flex-col gap-3.5 rounded-lg border border-gray-400 bg-white px-3.5 py-3.5 md:px-5 shadow-xl">
                 <Controller
                   name="boardType"
                   control={control}
@@ -265,7 +265,7 @@ export default function CommunityPostForm() {
                   labelClassName="text-base font-semibold"
                 />
               </div>
-              <div className="rounded-lg border border-gray-400 bg-white px-5 py-3.5 shadow-xl">
+              <div className="rounded-lg border border-gray-400 bg-white px-3.5 py-3.5 md:px-5 shadow-xl">
                 <Controller
                   name="content"
                   control={control}


### PR DESCRIPTION
## Summary

- 커뮤니티 작성/수정 페이지 카드 영역 모바일 padding-x를 14px로 축소
- 데스크톱은 20px 유지

## Changed Files

- `src/features/community/components/CommunityPostForm.tsx`: `px-5` → `px-3.5 md:px-5`

## Test plan

- [ ] 모바일 커뮤니티 작성/수정 페이지에서 카드 양쪽 여백 확인
- [ ] 데스크톱에서 기존과 동일한지 확인

Closes #615