### PR TITLE
fix: 채팅 목록 상품 카드 가격 미표시 및 이미지 필드명 불일치 수정(#617)

### DIFF
--- a/src/features/chatting-page/ChattingPage.tsx
+++ b/src/features/chatting-page/ChattingPage.tsx
@@ -86,7 +86,7 @@ export default function ChattingPage() {
       const data = await fetchGraphQL<{ chatRooms: any }>(`
         query ChatRooms($page: Int!, $size: Int!) {
           chatRooms(page: $page, size: $size) {
-            chatRooms { chatRoomId productId productTitle productMainImageUrl opponentNickname opponentProfileImageUrl lastMessage lastMessageTime unreadCount }
+            chatRooms { chatRoomId productId productTitle productPrice productMainImageUrl opponentNickname opponentProfileImageUrl lastMessage lastMessageTime unreadCount }
             currentPage hasNext
           }
         }

--- a/src/features/chatting-page/components/ChatRoomInfo.tsx
+++ b/src/features/chatting-page/components/ChatRoomInfo.tsx
@@ -59,7 +59,7 @@ export function ChatRoomInfo({ data, onLeaveRoom, onBack }: ChatRoomInfoProps) {
         href={ROUTES.DETAIL_ID(Number(data?.productId), data?.productTitle)}
         className="flex items-center gap-2 rounded-lg border border-gray-200 px-2.5 py-3 hover:bg-gray-50"
       >
-        <ChatProductCard productImageUrl={data?.productImageUrl} productTitle={data?.productTitle} productPrice={data?.productPrice} size="md" />
+        <ChatProductCard productImageUrl={data?.productMainImageUrl} productTitle={data?.productTitle} productPrice={data?.productPrice} size="md" />
       </Link>
     </div>
   )

--- a/src/features/chatting-page/components/ChatRooms.tsx
+++ b/src/features/chatting-page/components/ChatRooms.tsx
@@ -80,7 +80,7 @@ export function ChatRooms({ rooms, handleSelectRoom, selectedRoomId, hasNextPage
                     </div>
                     <div className="border-primary-100 bg-primary-50 flex items-center gap-2 overflow-hidden rounded-lg border px-2.5 py-3">
                       <ChatProductCard
-                        productImageUrl={roomData?.productImageUrl}
+                        productImageUrl={roomData?.productMainImageUrl}
                         productTitle={roomData?.productTitle}
                         productPrice={roomData?.productPrice}
                         size="sm"

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -233,6 +233,7 @@ export const typeDefs = gql`
     chatRoomId: Int!
     productId: Int
     productTitle: String
+    productPrice: Int
     productMainImageUrl: String
     opponentNickname: String
     opponentProfileImageUrl: String

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -51,7 +51,7 @@ export interface fetchChatRoom {
   productId: number
   productTitle: string
   productPrice: number
-  productImageUrl: string
+  productMainImageUrl: string
   opponentId: number
   opponentNickname: string
   opponentProfileImageUrl: string
@@ -79,7 +79,7 @@ export interface ChatRoomUpdateResponse {
   productId: number
   productTitle: string
   productPrice: number
-  productImageUrl: string
+  productMainImageUrl: string
   opponentId: number
   opponentNickname: string
   opponentProfileImageUrl: string


### PR DESCRIPTION
## 📌 개요

- 채팅 목록 상품 카드에 가격이 표시되지 않는 버그 수정
- 상품 이미지 필드명 불일치(`productImageUrl` → `productMainImageUrl`) 수정

## 🔧 작업 내용

- [ ] GraphQL 스키마 `ChatRoom` 타입에 `productPrice: Int` 필드 추가
- [ ] GraphQL 쿼리에 `productPrice` 필드 추가
- [ ] `ChatRooms.tsx`, `ChatRoomInfo.tsx`에서 `productImageUrl` → `productMainImageUrl` 수정
- [ ] `types/chat.ts` 타입 정의 `productImageUrl` → `productMainImageUrl` 수정

## 📎 관련 이슈

Closes #617

## 📋 QA 티켓

https://www.notion.so/32ff2b3079618125b986c8376a03f154

## 💬 리뷰어 참고 사항

- GraphQL 마이그레이션 시 `productPrice` 필드 누락 및 `productImageUrl`/`productMainImageUrl` 필드명 불일치가 원인
- REST API는 `productMainImageUrl`을 반환하므로 프론트엔드도 동일하게 맞춤