### PR TITLE
feat: 채팅방 더보기 버튼 및 부가 기능 드롭다운 추가(#621)

### DIFF
--- a/src/components/commons/card/ChatProductCard.tsx
+++ b/src/components/commons/card/ChatProductCard.tsx
@@ -15,6 +15,11 @@ const sizeClasses = {
   md: 'w-16',
 }
 
+const priceClasses = {
+  sm: 'text-sm font-bold',
+  md: 'font-bold',
+}
+
 export default function ChatProductCard({ productImageUrl, productTitle, productPrice, size = 'sm' }: ChatProductCardProps) {
   return (
     <>
@@ -40,8 +45,8 @@ export default function ChatProductCard({ productImageUrl, productTitle, product
         />
       </div>
       <div className="min-w-0 flex-1">
-        <p className="truncate text-xs font-medium">{productTitle}</p>
-        <p className="font-bold">{productPrice != null ? `${formatPrice(productPrice)}원` : ''}</p>
+        <p className={`truncate font-medium ${size === 'sm' ? 'text-xs' : 'text-sm'}`}>{productTitle}</p>
+        <p className={priceClasses[size]}>{productPrice != null ? `${formatPrice(productPrice)}원` : ''}</p>
       </div>
     </>
   )

--- a/src/features/chatting-page/ChattingPage.tsx
+++ b/src/features/chatting-page/ChattingPage.tsx
@@ -86,7 +86,7 @@ export default function ChattingPage() {
       const data = await fetchGraphQL<{ chatRooms: any }>(`
         query ChatRooms($page: Int!, $size: Int!) {
           chatRooms(page: $page, size: $size) {
-            chatRooms { chatRoomId productId productTitle productPrice productMainImageUrl opponentNickname opponentProfileImageUrl lastMessage lastMessageTime unreadCount }
+            chatRooms { chatRoomId productId productTitle productPrice productImageUrl opponentId opponentNickname opponentProfileImageUrl lastMessage lastMessageTime unreadCount }
             currentPage hasNext
           }
         }

--- a/src/features/chatting-page/components/ChatLog.tsx
+++ b/src/features/chatting-page/components/ChatLog.tsx
@@ -192,7 +192,7 @@ export function ChatLog({
       {Object.entries(groupedMessages).map(([dateKey, messages]) => (
         <div key={dateKey} className="flex flex-col gap-2">
           <div className="flex justify-center">
-            <span className="rounded-full bg-[#8d99a3] px-3 py-2 text-sm font-semibold text-[#f0f9ff]">
+            <span className="rounded-full bg-[#8d99a3] px-3 py-1 text-xs font-semibold text-[#f0f9ff]">
               {chatFormatDate(messages[0].createdAt)}
             </span>
           </div>
@@ -213,7 +213,6 @@ export function ChatLog({
                   key={message.messageId}
                   className={cn('flex max-w-64 min-w-60 flex-col gap-1 rounded-lg px-3 py-2', isMine ? 'ml-auto' : 'mr-auto')}
                 >
-                  {!isMine ? <p className="text-sm text-gray-600">{message.senderNickname}</p> : null}
                   {message.messageType === 'IMAGE' ? (
                     <ChatImageMessage imageUrl={message.imageUrl ?? undefined} alt={message.senderNickname} />
                   ) : (

--- a/src/features/chatting-page/components/ChatRoomInfo.tsx
+++ b/src/features/chatting-page/components/ChatRoomInfo.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import Button from '@/components/commons/button/Button'
+import { useRef, useState } from 'react'
 import { ROUTES } from '@/constants/routes'
 import type { fetchChatRoom } from '@/types'
 import Link from 'next/link'
@@ -9,7 +9,9 @@ import ChatProductCard from '@/components/commons/card/ChatProductCard'
 import { fetchGraphQL } from '@/lib/api/graphql'
 import { chatSocketStore } from '@/store/chatSocketStore'
 import { useQueryClient } from '@tanstack/react-query'
-import { ArrowLeft } from 'lucide-react'
+import { ArrowLeft, EllipsisVertical } from 'lucide-react'
+import IconButton from '@/components/commons/button/IconButton'
+import { useOutsideClick } from '@/hooks/useOutsideClick'
 
 interface ChatRoomInfoProps {
   data: fetchChatRoom
@@ -20,17 +22,17 @@ interface ChatRoomInfoProps {
 export function ChatRoomInfo({ data, onLeaveRoom, onBack }: ChatRoomInfoProps) {
   const queryClient = useQueryClient()
   const { unsubscribeFromRoom } = chatSocketStore()
+  const [isMenuOpen, setIsMenuOpen] = useState(false)
+  const menuRef = useRef<HTMLDivElement>(null)
+  useOutsideClick(isMenuOpen, [menuRef], () => setIsMenuOpen(false))
 
   const handleOutChatRoom = async () => {
     try {
-      const LEAVE_CHAT_ROOM = `
+      await fetchGraphQL(`
         mutation LeaveChatRoom($chatRoomId: Int!) {
-          leaveChatRoom(chatRoomId: $chatRoomId) {
-            success
-          }
+          leaveChatRoom(chatRoomId: $chatRoomId) { success }
         }
-      `
-      await fetchGraphQL(LEAVE_CHAT_ROOM, { chatRoomId: data.chatRoomId })
+      `, { chatRoomId: data.chatRoomId })
       unsubscribeFromRoom(data.chatRoomId)
       queryClient.invalidateQueries({ queryKey: ['chatRooms'] })
       onLeaveRoom(data.chatRoomId)
@@ -38,6 +40,62 @@ export function ChatRoomInfo({ data, onLeaveRoom, onBack }: ChatRoomInfoProps) {
       console.error('채팅방 나가기 실패:', error)
     }
   }
+
+  const handleTradeStatusChange = async () => {
+    setIsMenuOpen(false)
+    try {
+      await fetchGraphQL(`
+        mutation UpdateTradeStatus($id: Int!, $tradeStatus: String!) {
+          updateTradeStatus(id: $id, tradeStatus: $tradeStatus) { success }
+        }
+      `, { id: data.productId, tradeStatus: 'SOLD_OUT' })
+      queryClient.invalidateQueries({ queryKey: ['chatRooms'] })
+    } catch (error) {
+      console.error('거래 상태 변경 실패:', error)
+    }
+  }
+
+  const handleReportUser = async () => {
+    setIsMenuOpen(false)
+    try {
+      await fetchGraphQL(`
+        mutation ReportUser($userId: Int!, $reasonCode: String!) {
+          reportUser(userId: $userId, reasonCode: $reasonCode) { success }
+        }
+      `, { userId: data.opponentId, reasonCode: 'CHAT_ABUSE' })
+      alert('신고가 접수되었습니다.')
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('이미 신고한')) {
+        alert('이미 신고한 사용자입니다.')
+      } else {
+        console.error('신고 실패:', error)
+        alert('신고에 실패했습니다. 잠시 후 다시 시도해주세요.')
+      }
+    }
+  }
+
+  const handleBlockUser = async () => {
+    setIsMenuOpen(false)
+    try {
+      await fetchGraphQL(`
+        mutation BlockUser($userId: Int!) {
+          blockUser(userId: $userId) { success }
+        }
+      `, { userId: data.opponentId })
+      alert('차단되었습니다.')
+      queryClient.invalidateQueries({ queryKey: ['chatRooms'] })
+    } catch (error) {
+      console.error('차단 실패:', error)
+      alert('차단에 실패했습니다. 잠시 후 다시 시도해주세요.')
+    }
+  }
+
+  const menuItems = [
+    { label: '판매완료 처리', onClick: handleTradeStatusChange },
+    { label: '신고하기', onClick: handleReportUser, className: 'text-danger-500' },
+    { label: '차단하기', onClick: handleBlockUser, className: 'text-danger-500' },
+    { label: '채팅방 나가기', onClick: handleOutChatRoom, className: 'text-danger-500' },
+  ]
 
   return (
     <div className="flex flex-col gap-2.5 bg-white p-3.5">
@@ -48,18 +106,36 @@ export function ChatRoomInfo({ data, onLeaveRoom, onBack }: ChatRoomInfoProps) {
               <ArrowLeft size={24} />
             </button>
           ) : null}
-          <SellerAvatar profileImageUrl={data?.opponentProfileImageUrl} nickname={data?.opponentNickname} />
-          <p>{data?.opponentNickname}</p>
+          <Link href={ROUTES.USER_ID(data.opponentId)} className="flex items-center gap-2 hover:opacity-80">
+            <SellerAvatar profileImageUrl={data?.opponentProfileImageUrl} nickname={data?.opponentNickname} />
+            <p className="font-semibold">{data?.opponentNickname}</p>
+          </Link>
         </div>
-        <Button size={'md'} className="cursor-pointer bg-gray-50 hover:bg-gray-100" onClick={handleOutChatRoom}>
-          채팅방 나가기
-        </Button>
+        <div className="relative" ref={menuRef}>
+          <IconButton aria-label="더보기" onClick={() => setIsMenuOpen((prev) => !prev)}>
+            <EllipsisVertical size={20} className="text-gray-500" />
+          </IconButton>
+          {isMenuOpen ? (
+            <div className="absolute top-8 right-0 flex flex-col rounded border border-gray-200 bg-white shadow-md">
+              {menuItems.map((item) => (
+                <button
+                  key={item.label}
+                  type="button"
+                  className={`cursor-pointer px-4 py-2 text-left text-sm whitespace-nowrap hover:bg-gray-50 ${item.className ?? ''}`}
+                  onClick={item.onClick}
+                >
+                  {item.label}
+                </button>
+              ))}
+            </div>
+          ) : null}
+        </div>
       </div>
       <Link
         href={ROUTES.DETAIL_ID(Number(data?.productId), data?.productTitle)}
         className="flex items-center gap-2 rounded-lg border border-gray-200 px-2.5 py-3 hover:bg-gray-50"
       >
-        <ChatProductCard productImageUrl={data?.productMainImageUrl} productTitle={data?.productTitle} productPrice={data?.productPrice} size="md" />
+        <ChatProductCard productImageUrl={data?.productImageUrl} productTitle={data?.productTitle} productPrice={data?.productPrice} size="md" />
       </Link>
     </div>
   )

--- a/src/features/chatting-page/components/ChatRooms.tsx
+++ b/src/features/chatting-page/components/ChatRooms.tsx
@@ -40,7 +40,7 @@ export function ChatRooms({ rooms, handleSelectRoom, selectedRoomId, hasNextPage
   }
 
   return (
-    <section className="relative flex flex-col rounded-none border-t border-l border-gray-300 md:max-w-96 md:min-w-96 md:border-b">
+    <section className="relative flex flex-col rounded-none border-t border-l border-gray-300 md:max-w-120 md:min-w-120 md:border-b">
       <h2 className={cn('sticky top-16 border-b border-gray-300 bg-white p-5 md:static', Z_INDEX.HEADER)}>채팅목록</h2>
       <div className="scrollbar-hide flex-1 overflow-y-scroll">
         <ul className="flex flex-col gap-2">
@@ -79,7 +79,7 @@ export function ChatRooms({ rooms, handleSelectRoom, selectedRoomId, hasNextPage
                   </div>
                   <div className="border-primary-100 bg-primary-50 flex w-full items-center gap-2 overflow-hidden rounded-lg border p-1.5">
                     <ChatProductCard
-                      productImageUrl={roomData?.productMainImageUrl}
+                      productImageUrl={roomData?.productImageUrl}
                       productTitle={roomData?.productTitle}
                       productPrice={roomData?.productPrice}
                       size="sm"

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -234,7 +234,8 @@ export const typeDefs = gql`
     productId: Int
     productTitle: String
     productPrice: Int
-    productMainImageUrl: String
+    productImageUrl: String
+    opponentId: Int
     opponentNickname: String
     opponentProfileImageUrl: String
     lastMessage: String

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -51,7 +51,7 @@ export interface fetchChatRoom {
   productId: number
   productTitle: string
   productPrice: number
-  productMainImageUrl: string
+  productImageUrl: string
   opponentId: number
   opponentNickname: string
   opponentProfileImageUrl: string
@@ -79,7 +79,7 @@ export interface ChatRoomUpdateResponse {
   productId: number
   productTitle: string
   productPrice: number
-  productMainImageUrl: string
+  productImageUrl: string
   opponentId: number
   opponentNickname: string
   opponentProfileImageUrl: string


### PR DESCRIPTION
## 📌 개요

- 채팅방 헤더의 "채팅방 나가기" 버튼을 더보기 버튼(⋮)으로 교체
- 드롭다운으로 판매완료 처리, 신고, 차단, 채팅방 나가기 기능 제공
- 프로필 보기는 아바타/닉네임 클릭으로 접근
- 채팅 UI 전반 개선

## 🔧 작업 내용

- [ ] ChatRoomInfo: 더보기 드롭다운 메뉴 (판매완료/신고/차단/나가기)
- [ ] ChatRoomInfo: 아바타+닉네임 클릭 시 프로필 페이지 이동
- [ ] GraphQL 스키마/쿼리: ChatRoom에 opponentId, productPrice 추가, productImageUrl 복원
- [ ] ChatRooms: 채팅방 목록 너비 480px
- [ ] ChatProductCard: size별 제목/가격 크기 분리
- [ ] ChatLog: 1:1 채팅에서 불필요한 상대방 닉네임 제거, 날짜 배지 크기 축소

## 📎 관련 이슈

Closes #621

## 📸 스크린샷 (선택)

(필요시 추가)

## 💬 리뷰어 참고 사항

- CommunityDetail의 더보기 드롭다운 패턴과 동일한 구조 사용
- productImageUrl: 이전 PR(#618)에서 productMainImageUrl로 변경했으나, REST API가 productImageUrl을 반환하므로 원복
- 신고 reasonCode는 'CHAT_ABUSE'로 설정 — 백엔드에서 해당 코드 지원 여부 확인 필요