### PR TITLE
fix: 채팅 메시지 시간 UTC→KST 변환 누락 수정(#623)

### DIFF
--- a/src/features/chatting-page/components/ChatLog.tsx
+++ b/src/features/chatting-page/components/ChatLog.tsx
@@ -65,7 +65,7 @@ const getIsMine = (message: Message, userId?: number): boolean => {
 }
 
 const chatFormatTime = (dateString: string): string => {
-  const date = new Date(dateString)
+  const date = new Date(dateString.endsWith('Z') ? dateString : `${dateString}Z`)
   const hours = date.getHours()
   const minutes = String(date.getMinutes()).padStart(2, '0')
   const period = hours < 12 ? '오전' : '오후'
@@ -74,7 +74,7 @@ const chatFormatTime = (dateString: string): string => {
 }
 
 const chatFormatDate = (dateString: string): string => {
-  const date = new Date(dateString)
+  const date = new Date(dateString.endsWith('Z') ? dateString : `${dateString}Z`)
   const days = ['일요일', '월요일', '화요일', '수요일', '목요일', '금요일', '토요일']
   const year = date.getFullYear()
   const month = date.getMonth() + 1
@@ -86,7 +86,7 @@ const chatFormatDate = (dateString: string): string => {
 const groupMessagesByDate = (messages: Message[]) => {
   const groups: Record<string, Message[]> = {}
   messages.forEach((message) => {
-    const dateKey = new Date(message.createdAt).toDateString()
+    const dateKey = new Date(message.createdAt.endsWith('Z') ? message.createdAt : `${message.createdAt}Z`).toDateString()
     if (!groups[dateKey]) {
       groups[dateKey] = []
     }


### PR DESCRIPTION
## 📌 개요

- 채팅 메시지 시간이 UTC로 표시되는 버그 수정
- REST API가 Z 접미사 없이 UTC 시간을 반환하여 new Date()가 로컬 시간으로 해석하는 문제

## 🔧 작업 내용

- [x] chatFormatTime: Z 접미사 추가하여 UTC 파싱
- [x] chatFormatDate: 동일 수정
- [x] dateKey 계산: 동일 수정

## 📎 관련 이슈

Closes #623

## 📋 QA 티켓

https://www.notion.so/32ff2b30796181638ecfe594855c6a47

## 💬 리뷰어 참고 사항

- REST API가 "2026-03-26T05:14:15.423042" 형식으로 Z 없이 UTC 시간을 반환
- Z가 없으면 브라우저가 로컬 시간으로 해석하여 KST에서 9시간 차이 발생