### PR TITLE
chore: 데스크톱 커뮤니티 게시글 본문 이미지 크기 조정(#627)

### DIFF
--- a/src/features/community/components/markdown/MdPreview.tsx
+++ b/src/features/community/components/markdown/MdPreview.tsx
@@ -27,7 +27,7 @@ export default function MdPreview({ value, height, className }: MdPreviewProps) 
           a: (p) => <a {...p} className="text-blue-600 underline" target="_blank" rel="noopener noreferrer" />,
           code: (p) => <code {...p} className="rounded bg-gray-100 px-1 py-0.5" />,
           blockquote: (p) => <blockquote {...p} className="my-2 border-l-4 pl-3 text-gray-700 italic" />,
-          img: (p) => <img {...p} className="my-2 w-full max-w-[50%] rounded-lg" />,
+          img: (p) => <img {...p} className="my-2 h-auto w-full max-w-[50%] rounded-lg" />,
         }}
       >
         {value || '미리보기 내용이 없습니다.'}


### PR DESCRIPTION
## Summary

- 커뮤니티 게시글 본문 마크다운 이미지 크기를 부모 너비의 50%로 제한
- rounded-lg 적용

## Changed Files

- `src/features/community/components/markdown/MdPreview.tsx`: img 컴포넌트 추가

## Test plan

- [ ] 게시글 본문 내 이미지가 50% 너비로 표시되는지 확인
- [ ] 이미지 원본 비율 유지 확인

Closes #627