### PR TITLE
refactor: Vercel React Best Practice 규칙 기반 main 그룹 코드 리팩토링(#629)

### DIFF
--- a/src/features/UserPage.tsx
+++ b/src/features/UserPage.tsx
@@ -12,8 +12,9 @@ import { useMediaQuery } from '@/hooks/useMediaQuery'
 import LoadMoreButton from '@/components/commons/button/LoadMoreButton'
 import EmptyState from '@/components/EmptyState'
 import { Package } from 'lucide-react'
-import UserReportModal from '@/components/modal/UserReportModal'
-import BlockModal from '@/components/modal/BlockModal'
+import dynamic from 'next/dynamic'
+const UserReportModal = dynamic(() => import('@/components/modal/UserReportModal'))
+const BlockModal = dynamic(() => import('@/components/modal/BlockModal'))
 import { useUserStore } from '@/store/userStore'
 import { AnimatePresence } from 'framer-motion'
 import InlineNotification from '@/components/commons/InlineNotification'

--- a/src/features/community/CommunityDetail.tsx
+++ b/src/features/community/CommunityDetail.tsx
@@ -21,8 +21,8 @@ import { useForm } from 'react-hook-form'
 import type { CommentPostRequestData, CommunityDetailItem, Comment } from '@/types'
 import { useEffect, useRef, useState } from 'react'
 import { MessageSquareText } from 'lucide-react'
-import PostReportModal from '@/components/modal/PostReportModal'
-import DeletePostConfirmModal from '@/components/modal/DeletePostConfirmModal'
+const PostReportModal = dynamic(() => import('@/components/modal/PostReportModal'))
+const DeletePostConfirmModal = dynamic(() => import('@/components/modal/DeletePostConfirmModal'))
 import { useUserStore } from '@/store/userStore'
 import { useLoginModalStore } from '@/store/modalStore'
 import { EllipsisVertical } from 'lucide-react'

--- a/src/features/community/components/CommentItem.tsx
+++ b/src/features/community/components/CommentItem.tsx
@@ -10,7 +10,8 @@ import ProfileAvatar from '@/components/commons/ProfileAvatar'
 import { useRef, useState } from 'react'
 import { useUserStore } from '@/store/userStore'
 import { useOutsideClick } from '@/hooks/useOutsideClick'
-import DeleteReplyModal from '@/components/modal/DeleteReplyModal'
+import dynamic from 'next/dynamic'
+const DeleteReplyModal = dynamic(() => import('@/components/modal/DeleteReplyModal'))
 
 interface CommentItemProps {
   comment: Comment

--- a/src/features/community/components/CommunityPostForm.tsx
+++ b/src/features/community/components/CommunityPostForm.tsx
@@ -20,7 +20,8 @@ import { Z_INDEX } from '@/constants/ui'
 import { AnimatePresence } from 'framer-motion'
 import InlineNotification from '@/components/commons/InlineNotification'
 import { useUserStore } from '@/store/userStore'
-import DraftModal from '@/components/modal/DraftModal'
+import dynamic from 'next/dynamic'
+const DraftModal = dynamic(() => import('@/components/modal/DraftModal'))
 
 export interface CommunityPostFormValues {
   boardType: string

--- a/src/features/my-page/MyPage.tsx
+++ b/src/features/my-page/MyPage.tsx
@@ -8,8 +8,10 @@ import { api } from '@/lib/api/api'
 import Tabs from '@/components/Tabs'
 import { MY_PAGE_TABS, type MyPageTabId } from '@/constants/constants'
 import MyPagePanel from './components/MyPagePanel'
-import DeleteConfirmModal from '@/components/modal/DeleteConfirmModal'
-import WithdrawModal, { type WithDrawFormValues } from '@/components/modal/WithdrawModal'
+import dynamic from 'next/dynamic'
+import type { WithDrawFormValues } from '@/components/modal/WithdrawModal'
+const DeleteConfirmModal = dynamic(() => import('@/components/modal/DeleteConfirmModal'))
+const WithdrawModal = dynamic(() => import('@/components/modal/WithdrawModal'))
 import ProfileData from '@/components/profile/ProfileData'
 import { AnimatePresence } from 'framer-motion'
 import InlineNotification from '@/components/commons/InlineNotification'

--- a/src/features/product-detail/components/ProductDetailMobileMeta.tsx
+++ b/src/features/product-detail/components/ProductDetailMobileMeta.tsx
@@ -3,7 +3,8 @@
 import { useState } from 'react'
 import { Eye, Heart, Flag } from 'lucide-react'
 import { ProductMetaItem } from '@/components/product/ProductMetaItem'
-import ProductReportModal from '@/components/modal/ProductReportModal'
+import dynamic from 'next/dynamic'
+const ProductReportModal = dynamic(() => import('@/components/modal/ProductReportModal'))
 
 interface ProductDetailMobileMetaProps {
   productId: number

--- a/src/features/product-detail/components/ProductSummary.tsx
+++ b/src/features/product-detail/components/ProductSummary.tsx
@@ -4,7 +4,8 @@ import { useState } from 'react'
 import { Flag } from 'lucide-react'
 import ProductMetadataList from './ProductMetadataList'
 import ProductTitle from './ProductTitle'
-import ProductReportModal from '@/components/modal/ProductReportModal'
+import dynamic from 'next/dynamic'
+const ProductReportModal = dynamic(() => import('@/components/modal/ProductReportModal'))
 
 interface ProductHeaderProps {
   data: {

--- a/src/features/product-detail/components/SellerProfileCard.tsx
+++ b/src/features/product-detail/components/SellerProfileCard.tsx
@@ -31,8 +31,7 @@ export default function SellerProfileCard({ sellerInfo }: SellerProfileCardProps
     router.push(`/user-profile/${sellerId}`)
   }
 
-  return (
-    sellerInfo?.sellerId !== user?.id && (
+  return sellerInfo?.sellerId !== user?.id ? (
       <div className="flex items-center justify-between rounded-lg border border-gray-200 bg-white p-3">
         <div className="flex items-center gap-2">
           <div className="bg-primary-50 relative flex h-10 w-10 items-center justify-center overflow-hidden rounded-full">
@@ -61,6 +60,5 @@ export default function SellerProfileCard({ sellerInfo }: SellerProfileCardProps
           판매자 프로필 보기
         </Button>
       </div>
-    )
-  )
+  ) : null
 }

--- a/src/features/product-detail/components/SubImages.tsx
+++ b/src/features/product-detail/components/SubImages.tsx
@@ -45,14 +45,11 @@ function SubImageItem({ image, title, idx }: { image: string; title: string; idx
 }
 
 export default function SubImages({ mainImageUrl, subImageUrls, title }: SubImagesProps) {
-  return (
-    mainImageUrl &&
-    subImageUrls.length > 0 && (
-      <div className="grid grid-cols-4 gap-2">
-        {subImageUrls.map((image, idx) => (
-          <SubImageItem key={idx} image={image} title={title} idx={idx} />
-        ))}
-      </div>
-    )
-  )
+  return mainImageUrl && subImageUrls.length > 0 ? (
+    <div className="grid grid-cols-4 gap-2">
+      {subImageUrls.map((image, idx) => (
+        <SubImageItem key={idx} image={image} title={title} idx={idx} />
+      ))}
+    </div>
+  ) : null
 }


### PR DESCRIPTION
## 📌 개요

- Vercel React Best Practice Skill(58개 규칙)로 main 그룹 코드를 스캔하여 발견된 위반 사항 리팩토링

## 🔧 작업 내용

### CRITICAL: 모달 dynamic import 전환 (번들 크기 감소)
- [ ] MyPage.tsx: DeleteConfirmModal, WithdrawModal
- [ ] CommunityDetail.tsx: PostReportModal, DeletePostConfirmModal
- [ ] UserPage.tsx: UserReportModal, BlockModal
- [ ] CommentItem.tsx: DeleteReplyModal
- [ ] CommunityPostForm.tsx: DraftModal
- [ ] ProductSummary.tsx, ProductDetailMobileMeta.tsx: ProductReportModal

### MEDIUM: && 조건부 렌더링 → 삼항 연산자
- [ ] SellerProfileCard.tsx: && → 삼항 연산자 + null
- [ ] SubImages.tsx: && → 삼항 연산자 + null

## 📎 관련 이슈

Closes #629

## 💬 리뷰어 참고 사항

- 모달 컴포넌트는 사용자 액션 시에만 렌더링되므로 dynamic import로 초기 번들에서 제외
- && 조건부 렌더링은 falsy 값(0, '')이 DOM에 렌더링될 수 있어 삼항 연산자로 통일