### PR TITLE
chore: 데스크톱 상품 작성/수정 페이지 UI 개선(#634)

### DIFF
--- a/src/components/product/ProductStateFilter.tsx
+++ b/src/components/product/ProductStateFilter.tsx
@@ -56,7 +56,7 @@ export function ProductStateFilter({
           상품 상태
         </h4>
       ) : (
-        <span id="condition-filter-heading" className="heading-h5 text-gray-900">
+        <span id="condition-filter-heading" className={cn(labelClassname ?? 'heading-h5', 'text-gray-900')}>
           상품 상태 <span className="text-red-500">*</span>
         </span>
       )}

--- a/src/features/community/components/CommunityPostForm.tsx
+++ b/src/features/community/components/CommunityPostForm.tsx
@@ -207,7 +207,7 @@ export default function CommunityPostForm() {
         <SimpleHeader
           title="커뮤니티 글쓰기"
           description="일상 이야기를 마음껏 나눠보세요!"
-          layoutClassname="py-5 gap-0 flex-col justify-between border-b border-gray-200"
+          layoutClassname="py-3.5 gap-0 flex-col justify-between border-b border-gray-200"
           titleClassName="text-[22px] leading-[1.5] font-bold"
           descriptionClassName="text-sm"
         />

--- a/src/features/product-post/ProductPost.tsx
+++ b/src/features/product-post/ProductPost.tsx
@@ -84,7 +84,13 @@ function ProductPost() {
   return (
     <>
       <h1 className="sr-only">{headerTitle}</h1>
-      <SimpleHeader title={headerTitle} description={headerDescription} />
+      <SimpleHeader
+        title={headerTitle}
+        description={headerDescription}
+        layoutClassname="py-3.5 gap-0 flex-col justify-between border-b border-gray-200"
+        titleClassName="text-[22px] leading-[1.5] font-bold"
+        descriptionClassName="text-sm"
+      />
       <div className="bg-[#F3F4F6] pt-5">
         <div className="px-lg pb-4xl mx-auto max-w-7xl">
           <div className="gap-2xl flex w-full flex-col">

--- a/src/features/product-post/components/FormSectionHeader.tsx
+++ b/src/features/product-post/components/FormSectionHeader.tsx
@@ -6,9 +6,9 @@ interface FormSectionHeaderProps {
 
 export default function FormSectionHeader({ heading, description, headingClassName }: FormSectionHeaderProps) {
   return (
-    <div className="flex flex-col gap-1">
-      <h2 className={headingClassName ?? 'heading-h3'}>{heading}</h2>
-      {description ? <p>{description}</p> : null}
+    <div className="flex flex-col gap-0">
+      <h2 className={headingClassName ?? 'text-[20px] font-bold'}>{heading}</h2>
+      {description ? <p className="text-sm">{description}</p> : null}
     </div>
   )
 }

--- a/src/features/product-post/components/basicInfoSection/BasicInfoSection.tsx
+++ b/src/features/product-post/components/basicInfoSection/BasicInfoSection.tsx
@@ -30,8 +30,9 @@ export default function BasicInfoSection({
   titleLength,
 }: BasicInfoSectionProps) {
   return (
-    <section className="flex flex-col gap-5 rounded-xl border border-gray-100 bg-white px-6 py-5">
-      <FormSectionHeader heading="기본 정보" description="상품의 기본 정보를 입력해주세요. *는 필수 항목입니다." />
+    <section className="flex flex-col gap-2 rounded-xl border border-gray-100 bg-white px-5 pt-3.5 pb-5">
+      <FormSectionHeader heading="기본 정보" />
+      <div className="flex flex-col gap-3.5">
       <PetTypeField<ProductPostFormValues> control={control} setValue={setValue} primaryName="petType" secondaryName="petDetailType" />
       <Controller
         name="category"
@@ -39,7 +40,7 @@ export default function BasicInfoSection({
         rules={{ required: '카테고리를 선택해주세요' }}
         render={({ field, fieldState }) => (
           <div className="flex flex-col gap-1">
-            <RequiredLabel htmlFor="category" labelClass="heading-h5">
+            <RequiredLabel htmlFor="category" labelClass="text-base font-semibold">
               상품 카테고리
             </RequiredLabel>
             <SelectDropdown
@@ -59,6 +60,7 @@ export default function BasicInfoSection({
       />
       <ProductNameField register={register} errors={errors} label={productNameLabel} titleLength={titleLength} />
       <ProductDescriptionFiled register={register} errors={errors} label={productDescriptionLabel} placeholder={productDescriptionPlaceHolder} />
+      </div>
     </section>
   )
 }

--- a/src/features/product-post/components/basicInfoSection/components/PetTypeField.tsx
+++ b/src/features/product-post/components/basicInfoSection/components/PetTypeField.tsx
@@ -48,7 +48,7 @@ export function PetTypeField<T extends FieldValues>({
       secondaryId="pet-detail"
       secondaryRule="소분류를 선택해주세요"
       label={label}
-      labelClass="heading-h5"
+      labelClass="text-base font-semibold"
       layoutClass="gap-1"
       buttonClassName="px-3 py-3"
       optionClassName=""

--- a/src/features/product-post/components/basicInfoSection/components/ProductDescriptionFiled.tsx
+++ b/src/features/product-post/components/basicInfoSection/components/ProductDescriptionFiled.tsx
@@ -19,7 +19,7 @@ export function ProductDescriptionFiled({
 }: ProductDescriptionFiledProps) {
   return (
     <div className="flex flex-col gap-1">
-      <RequiredLabel htmlFor="product-description" labelClass="heading-h5">
+      <RequiredLabel htmlFor="product-description" labelClass="text-base font-semibold">
         {label}
       </RequiredLabel>
       <textarea

--- a/src/features/product-post/components/basicInfoSection/components/ProductNameFiled.tsx
+++ b/src/features/product-post/components/basicInfoSection/components/ProductNameFiled.tsx
@@ -22,6 +22,8 @@ export function ProductNameField({ register, errors, label = '상품명', titleL
       maxLength={50}
       id="product-title"
       placeholder="예: 강아지 사료 10kg 상품"
+      labelClassName="text-base font-semibold"
+      counterClassName="text-xs text-gray-500"
     />
   )
 }

--- a/src/features/product-post/components/imageUploadField/ImageUploadField.tsx
+++ b/src/features/product-post/components/imageUploadField/ImageUploadField.tsx
@@ -56,5 +56,5 @@ export default function ImageUploadField<T extends FieldValues>({
     return content
   }
 
-  return <section className="flex flex-col gap-6 rounded-xl border border-gray-100 bg-white px-6 py-5">{content}</section>
+  return <section className="flex flex-col gap-6 rounded-xl border border-gray-100 bg-white px-5 pt-3.5 pb-5">{content}</section>
 }

--- a/src/features/product-post/components/priceAndStatusSection/PriceAndStatusSection.tsx
+++ b/src/features/product-post/components/priceAndStatusSection/PriceAndStatusSection.tsx
@@ -22,8 +22,9 @@ export default function PriceAndStatusSection({
   priceLabel,
 }: PriceAndStatusSectionProps) {
   return (
-    <section className="flex flex-col gap-5 rounded-xl border border-gray-100 bg-white px-6 py-5">
+    <section className="flex flex-col gap-2 rounded-xl border border-gray-100 bg-white px-5 pt-3.5 pb-5">
       <FormSectionHeader heading={heading} />
+      <div className="flex flex-col gap-3.5">
       <PriceField register={register} errors={errors} label={priceLabel} suffix="원" />
       {showProductStateFilter ? (
         <Controller
@@ -34,7 +35,7 @@ export default function PriceAndStatusSection({
             <>
               <ProductStateFilter
                 inputClassname="flex-1"
-                labelClassname="py-4 font-semibold"
+                labelClassname="text-base font-semibold"
                 subTitle
                 selectedProductStatus={field.value || null}
                 onProductStatusChange={(status) => field.onChange(status ?? '')}
@@ -44,6 +45,7 @@ export default function PriceAndStatusSection({
           )}
         />
       ) : null}
+      </div>
     </section>
   )
 }

--- a/src/features/product-post/components/priceAndStatusSection/components/PriceField.tsx
+++ b/src/features/product-post/components/priceAndStatusSection/components/PriceField.tsx
@@ -14,7 +14,7 @@ interface PriceFieldProps {
 export function PriceField({ register, errors, suffix, label = '판매 가격' }: PriceFieldProps) {
   return (
     <div className="flex flex-col gap-1">
-      <RequiredLabel htmlFor="price" labelClass="heading-h5">
+      <RequiredLabel htmlFor="price" labelClass="text-base font-semibold">
         {label}
       </RequiredLabel>
       <div className="relative">

--- a/src/features/product-post/components/tradeInfoSection/TradeInfoSection.tsx
+++ b/src/features/product-post/components/tradeInfoSection/TradeInfoSection.tsx
@@ -10,7 +10,7 @@ interface TradeInfoSectionProps {
 
 export default function TradeInfoSection({ control, setValue }: TradeInfoSectionProps) {
   return (
-    <div className="flex flex-col gap-5 rounded-xl border border-gray-100 bg-white px-6 py-5">
+    <div className="flex flex-col gap-2 rounded-xl border border-gray-100 bg-white px-5 pt-3.5 pb-5">
       <FormSectionHeader heading="거래 정보" />
       <AddressField<ProductPostFormValues>
         control={control}
@@ -18,7 +18,7 @@ export default function TradeInfoSection({ control, setValue }: TradeInfoSection
         primaryName="addressSido"
         secondaryName="addressGugun"
         label="거래 희망 지역"
-        labelClass="heading-h5"
+        labelClass="text-base font-semibold"
         layoutClass="gap-1"
       />
     </div>


### PR DESCRIPTION
## 📌 개요

- 데스크톱 환경에서 상품 작성/수정 페이지 UI 스타일 개선
- 커뮤니티 수정 페이지와 일관된 디자인 적용

## 🔧 작업 내용

- [ ] 서브헤더 스타일 조정 (제목 22px, 설명 14px, py-3.5)
- [ ] "기본 정보" 설명 텍스트 제거
- [ ] 섹션 라벨 font-size 조정 (heading-h5 18px → text-base 16px)
- [ ] 섹션 헤더 font-size 조정 (heading-h3 24px → 20px)
- [ ] 섹션 padding 조정 (px-5 pt-3.5 pb-5)
- [ ] 섹션 헤더와 필드 영역 사이 gap-2
- [ ] 상품명 글자수 카운터 text-xs
- [ ] 상품 상태 라벨 불필요한 padding 제거
- [ ] FormSectionHeader description text-sm, gap-0
- [ ] 커뮤니티 서브헤더 py도 동일하게 py-3.5로 통일

## 📎 관련 이슈

Closes #634

## 💬 리뷰어 참고 사항

- ProductStateFilter는 공유 컴포넌트이므로 labelClassname prop을 활용하여 상품 수정 폼에서만 스타일 변경
- FormSectionHeader 기본값 변경은 이 컴포넌트를 사용하는 모든 곳에 영향