### PR TITLE
chore: 모바일 채팅 페이지 전체 화면 레이아웃 적용(#644)

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -20,7 +20,8 @@ const COMMUNITY_EDIT = /^\/community\/\d+\/edit$/
 const PRODUCT_EDIT = /^\/products\/\d+\/edit$/
 
 // Header 숨김 패턴 (모바일에서만 숨김)
-const HIDE_HEADER_MOBILE_PATTERNS = [COMMUNITY_DETAIL, COMMUNITY_EDIT, PRODUCT_EDIT, new RegExp(`^${ROUTES.COMMUNITY_POST}$`), new RegExp(`^${ROUTES.PRODUCT_POST}$`), new RegExp(`^${ROUTES.NOTIFICATIONS}$`)]
+const CHAT_ROOM = /^\/chat(\/\d+)?$/
+const HIDE_HEADER_MOBILE_PATTERNS = [COMMUNITY_DETAIL, COMMUNITY_EDIT, PRODUCT_EDIT, CHAT_ROOM, new RegExp(`^${ROUTES.COMMUNITY_POST}$`), new RegExp(`^${ROUTES.PRODUCT_POST}$`), new RegExp(`^${ROUTES.NOTIFICATIONS}$`)]
 
 // SearchBar 숨김 경로 - 모바일만 (정적 경로)
 const HIDE_SEARCHBAR_MOBILE_PATHS: string[] = [ROUTES.MYPAGE]

--- a/src/features/chatting-page/ChattingPage.tsx
+++ b/src/features/chatting-page/ChattingPage.tsx
@@ -5,7 +5,7 @@ import { useUserStore } from '@/store/userStore'
 import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query'
 import { useRouter, useParams } from 'next/navigation'
 import type { fetchChatRoom } from '@/types'
-import { Send, Paperclip } from 'lucide-react'
+import { Send, Paperclip, ArrowLeft } from 'lucide-react'
 import IconButton from '@/components/commons/button/IconButton'
 import { ChatRooms } from '@/features/chatting-page/components/ChatRooms'
 import { ChatRoomInfo } from '@/features/chatting-page/components/ChatRoomInfo'
@@ -55,14 +55,17 @@ export default function ChattingPage() {
   } = useInfiniteQuery({
     queryKey: ['messages', chatRoomId],
     queryFn: async ({ pageParam }) => {
-      const data = await fetchGraphQL<{ chatMessages: any }>(`
+      const data = await fetchGraphQL<{ chatMessages: any }>(
+        `
         query ChatMessages($chatRoomId: Int!, $page: Int!, $size: Int!) {
           chatMessages(chatRoomId: $chatRoomId, page: $page, size: $size) {
             messages { messageId senderId senderNickname content messageType imageUrl createdAt }
             currentPage hasNext
           }
         }
-      `, { chatRoomId: Number(chatRoomId), page: pageParam, size: 50 })
+      `,
+        { chatRoomId: Number(chatRoomId), page: pageParam, size: 50 }
+      )
       return data.chatMessages
     },
     getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.currentPage + 1 : undefined),
@@ -83,14 +86,17 @@ export default function ChattingPage() {
   } = useInfiniteQuery({
     queryKey: ['chatRooms'],
     queryFn: async ({ pageParam }) => {
-      const data = await fetchGraphQL<{ chatRooms: any }>(`
+      const data = await fetchGraphQL<{ chatRooms: any }>(
+        `
         query ChatRooms($page: Int!, $size: Int!) {
           chatRooms(page: $page, size: $size) {
             chatRooms { chatRoomId productId productTitle productPrice productImageUrl opponentId opponentNickname opponentProfileImageUrl lastMessage lastMessageTime unreadCount }
             currentPage hasNext
           }
         }
-      `, { page: pageParam, size: 10 })
+      `,
+        { page: pageParam, size: 10 }
+      )
       return data.chatRooms
     },
     getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.currentPage + 1 : undefined),
@@ -224,9 +230,27 @@ export default function ChattingPage() {
   }
 
   return (
-    <div className="md:pb-4xl md:h-auto md:pt-8">
+    <div
+      className={cn(
+        'md:pb-4xl fixed inset-0 z-50 flex flex-col bg-white md:static md:z-auto md:h-auto md:bg-transparent md:pt-8'
+      )}
+    >
       <h1 className="sr-only">채팅 페이지</h1>
-      <div className="mx-auto flex h-full max-w-7xl flex-col md:h-[80vh] md:flex-row">
+      {/* 모바일 상단 헤더 (채팅 목록에서만 표시) */}
+      {!isChatOpen ? (
+        <div className="flex items-center gap-3 border-b border-gray-200 px-4 py-3 md:hidden">
+          <button type="button" onClick={() => router.back()} className="cursor-pointer">
+            <ArrowLeft size={20} />
+          </button>
+          <span className="text-base font-bold">채팅</span>
+        </div>
+      ) : null}
+      <div
+        className={cn(
+          'flex h-full flex-col md:mx-auto md:h-[80vh] md:max-w-7xl md:flex-row',
+          isChatOpen ? 'flex-1 overflow-hidden' : ''
+        )}
+      >
         <div className={cn('md:flex', isChatOpen ? 'hidden' : 'block')}>
           <ChatRooms
             rooms={allRooms ?? []}
@@ -237,13 +261,13 @@ export default function ChattingPage() {
             fetchNextPage={fetchNextRooms}
           />
         </div>
-        <section className={cn('relative flex flex-1 flex-col border border-gray-300 md:flex', isChatOpen ? 'flex' : 'hidden')}>
+        <section className={cn('relative flex flex-1 flex-col overflow-hidden border border-gray-300 md:flex', isChatOpen ? 'flex' : 'hidden')}>
           {selectedRoom ? (
             <>
-              <div className="sticky top-16 shrink-0 md:static">
+              <div className="sticky top-0 shrink-0 md:static md:top-16">
                 <ChatRoomInfo data={selectedRoom} onLeaveRoom={handleLeaveRoom} onBack={handleBack} />
               </div>
-              <div className="bg-primary-50 min-h-0 flex-1 p-3.5 pb-20 md:pb-3.5">
+              <div className="bg-primary-50 min-h-0 flex-1 overflow-y-auto px-3.5 pt-0 pb-20 md:pt-3.5 md:pb-3.5">
                 <ChatLog
                   key={chatRoomId}
                   isLoadingMessages={isLoadingMessages}

--- a/src/features/chatting-page/components/ChatLog.tsx
+++ b/src/features/chatting-page/components/ChatLog.tsx
@@ -42,7 +42,7 @@ function ChatImageMessage({ imageUrl, alt }: { imageUrl?: string; alt: string })
   }
 
   return (
-    <div className="relative aspect-square w-72 shrink-0 overflow-hidden rounded-lg">
+    <div className="relative aspect-square w-48 shrink-0 overflow-hidden rounded-lg md:w-72">
       <Image
         src={getImageSrc()}
         loader={imgError || usePlaceholder || !imageUrl ? undefined : imageLoader}
@@ -191,7 +191,7 @@ export function ChatLog({
       </AnimatePresence>
       {Object.entries(groupedMessages).map(([dateKey, messages]) => (
         <div key={dateKey} className="flex flex-col gap-2">
-          <div className="flex justify-center">
+          <div className="mt-3.5 flex justify-center">
             <span className="rounded-full bg-[#8d99a3] px-3 py-1 text-xs font-semibold text-[#f0f9ff]">
               {chatFormatDate(messages[0].createdAt)}
             </span>

--- a/src/features/chatting-page/components/ChatRoomInfo.tsx
+++ b/src/features/chatting-page/components/ChatRoomInfo.tsx
@@ -116,7 +116,7 @@ export function ChatRoomInfo({ data, onLeaveRoom, onBack }: ChatRoomInfoProps) {
             <EllipsisVertical size={20} className="text-gray-500" />
           </IconButton>
           {isMenuOpen ? (
-            <div className="absolute top-8 right-0 flex flex-col rounded border border-gray-200 bg-white shadow-md">
+            <div className="absolute top-8 right-0 z-50 flex flex-col rounded border border-gray-200 bg-white shadow-md">
               {menuItems.map((item) => (
                 <button
                   key={item.label}

--- a/src/features/chatting-page/components/ChatRooms.tsx
+++ b/src/features/chatting-page/components/ChatRooms.tsx
@@ -47,8 +47,8 @@ export function ChatRooms({
   }
 
   return (
-    <section className="relative flex flex-col rounded-none border-t border-l border-gray-300 md:max-w-112 md:min-w-112 md:border-b">
-      <h2 className={cn('sticky top-16 border-b border-gray-300 bg-white p-5 md:static', Z_INDEX.HEADER)}>채팅목록</h2>
+    <section className="relative flex flex-col rounded-none border-gray-300 md:max-w-112 md:min-w-112 md:border-t md:border-b md:border-l">
+      <h2 className={cn('hidden border-b border-gray-300 bg-white p-5 md:static md:block', Z_INDEX.HEADER)}>채팅목록</h2>
       <div className="scrollbar-hide flex-1 overflow-y-scroll">
         <ul className="flex flex-col gap-2">
           {rooms &&
@@ -58,7 +58,7 @@ export function ChatRooms({
                 <li
                   key={roomData.chatRoomId}
                   className={cn(
-                    'flex cursor-pointer flex-col gap-2 p-3',
+                    'flex cursor-pointer flex-col gap-2 p-4 md:p-3',
                     roomData.chatRoomId === selectedRoomId && 'md:bg-[#E5E7EB]/50'
                   )}
                   onClick={() => handleSelectRoom(room)}
@@ -71,7 +71,11 @@ export function ChatRooms({
                       <p className="leading-none font-semibold">{roomData?.opponentNickname}</p>
                       <div className="flex items-center gap-1">
                         <p className={cn('line-clamp-1 text-xs', roomData.lastMessage == null ? 'text-blue-600' : '')}>
-                          {roomData.lastMessage == null ? '채팅방에 입장해주세요' : roomData.lastMessage === '' ? '사진' : roomData.lastMessage}
+                          {roomData.lastMessage == null
+                            ? '채팅방에 입장해주세요'
+                            : roomData.lastMessage === ''
+                              ? '사진'
+                              : roomData.lastMessage}
                         </p>
                         {roomData.lastMessageTime ? (
                           <span className="text-xs leading-none font-medium text-gray-500">


### PR DESCRIPTION
## 📌 개요

- 모바일 환경에서 채팅 페이지를 전체 화면 레이아웃으로 변경
- ReplyOverlay 패턴과 동일한 UX 적용

## 🔧 작업 내용

- [ ] 모바일 채팅 목록: 전체 화면 + 서브헤더(뒤로가기 + "채팅")
- [ ] 모바일 채팅방: 전체 화면 + ChatRoomInfo 헤더
- [ ] 모바일 메인 헤더 숨김 (/chat, /chat/:id)
- [ ] ChatRooms "채팅목록" 텍스트 모바일 숨김
- [ ] 더보기 드롭다운 z-50 추가 (이미지 뒤 가림 방지)
- [ ] 채팅 이미지 모바일 w-48, 데스크톱 w-72
- [ ] 날짜 구분 영역 mt-3.5
- [ ] 채팅 영역 모바일 pt-0

## 📎 관련 이슈

Closes #644

## 💬 리뷰어 참고 사항

- 모바일에서 fixed inset-0으로 전체 화면, 데스크톱에서 md:static으로 기존 레이아웃 유지
- 채팅 목록에서만 서브헤더 표시, 채팅방에서는 ChatRoomInfo가 헤더 역할