### PR TITLE
feat: 데스크탑 Header에 플레이스 메뉴 추가(#650)

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -68,6 +68,7 @@ export default function Header() {
 
   const isMarketActive = pathname === '/' || pathname.startsWith('/market')
   const isCommunityActive = pathname.startsWith('/community')
+  const isMapActive = pathname.startsWith('/map')
 
   // 헤더 높이를 CSS 변수로 설정 (검색바 열림/닫힘 및 헤더 가시성에 따라)
   useEffect(() => {
@@ -122,6 +123,12 @@ export default function Header() {
                     className={cn('text-md font-medium', isCommunityActive ? 'border-white text-white' : 'text-gray-700')}
                   >
                     커뮤니티
+                  </Link>
+                  <Link
+                    href={ROUTES.MAP}
+                    className={cn('text-md font-medium', isMapActive ? 'border-white text-white' : 'text-gray-700')}
+                  >
+                    플레이스
                   </Link>
                 </>
               ) : null}

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -7,6 +7,9 @@ export const ROUTES = {
   DETAIL_ID: (id: string | number, name?: string) =>
     name ? `/products/${id}/${toUrlName(name)}` : `/products/${id}`,
 
+  // Map
+  MAP: '/map',
+
   // Community
   COMMUNITY: '/community',
   COMMUNITY_POST: '/community-post',


### PR DESCRIPTION
## 📌 개요

- 데스크탑(xl: 1280px+) Header 네비게이션에 "플레이스"(`/map`) 메뉴를 추가합니다.

## 🔧 작업 내용

- [x] `ROUTES` 상수에 `MAP: '/map'` 경로 추가
- [x] Header 데스크탑 네비게이션에 "플레이스" 링크 추가
- [x] 현재 경로(`/map`) 활성화 스타일 적용

## 📎 관련 이슈

Closes #650

## 💬 리뷰어 참고 사항

- 기존 메뉴(마켓, 커뮤니티)와 동일한 스타일 패턴 적용
- 메뉴명 "플레이스"는 네이버/카카오의 장소 탐색 용어와 동일한 친숙한 네이밍