### PR TITLE
feat: 모바일 하단 탭바(BottomNav) 추가 및 관련 UI 조정(#652)

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,4 +1,5 @@
 import Header from '@/components/header/Header'
+import BottomNav from '@/components/bottom-nav/BottomNav'
 import type { ReactNode } from 'react'
 
 export default function MainLayout({ children }: { children: ReactNode }) {
@@ -6,11 +7,12 @@ export default function MainLayout({ children }: { children: ReactNode }) {
     <div className="flex min-h-screen flex-col">
       <Header />
       <main
-        className="w-full flex-1 bg-white transition-[padding-top] duration-300"
+        className="w-full flex-1 bg-white pb-14 transition-[padding-top] duration-300 xl:pb-0"
         style={{ paddingTop: 'var(--header-height, 72px)' }}
       >
         {children}
       </main>
+      <BottomNav />
     </div>
   )
 }

--- a/src/components/bottom-nav/BottomNav.tsx
+++ b/src/components/bottom-nav/BottomNav.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { Home, Users, MapPin, MessageCircleMore, UserRound } from 'lucide-react'
+import { cn } from '@/lib/utils/cn'
+import { ROUTES } from '@/constants/routes'
+import { Z_INDEX } from '@/constants/ui'
+import { useMediaQuery } from '@/hooks/useMediaQuery'
+
+const NAV_ITEMS = [
+  { href: ROUTES.HOME, label: '홈', icon: Home, match: (p: string) => p === '/' || p.startsWith('/market') },
+  { href: ROUTES.COMMUNITY, label: '커뮤니티', icon: Users, match: (p: string) => p.startsWith('/community') },
+  { href: ROUTES.MAP, label: '플레이스', icon: MapPin, match: (p: string) => p.startsWith('/map') },
+  { href: ROUTES.CHAT, label: '채팅', icon: MessageCircleMore, match: (p: string) => p.startsWith('/chat') },
+  { href: ROUTES.MYPAGE, label: '마이', icon: UserRound, match: (p: string) => p.startsWith('/mypage') },
+] as const
+
+// BottomNav 숨김 경로
+const HIDE_BOTTOMNAV_PATHS: string[] = [
+  ROUTES.LOGIN,
+  ROUTES.SIGNUP,
+  ROUTES.FIND_PASSWORD,
+  ROUTES.PRODUCT_POST,
+  ROUTES.COMMUNITY_POST,
+  ROUTES.PROFILE_UPDATE,
+  ROUTES.NOTIFICATIONS,
+]
+
+const HIDE_BOTTOMNAV_PATTERNS = [
+  /^\/chat\/\d+$/, // 채팅방
+  /^\/community\/\d+$/, // 커뮤니티 상세
+  /^\/community\/\d+\/edit$/, // 커뮤니티 수정
+  /^\/products\/\d+\/edit$/, // 상품 수정
+]
+
+export default function BottomNav() {
+  const pathname = usePathname()
+  const isXl = useMediaQuery('(min-width: 1280px)')
+
+  if (isXl) return null
+
+  const shouldHide =
+    HIDE_BOTTOMNAV_PATHS.includes(pathname) ||
+    HIDE_BOTTOMNAV_PATTERNS.some((pattern) => pattern.test(pathname))
+
+  if (shouldHide) return null
+
+  return (
+    <nav
+      className={cn(
+        'fixed bottom-0 left-0 right-0 border-t border-gray-200 bg-white pb-[env(safe-area-inset-bottom)]',
+        Z_INDEX.HEADER
+      )}
+      aria-label="하단 메뉴"
+    >
+      <div className="flex h-14 items-center justify-around">
+        {NAV_ITEMS.map(({ href, label, icon: Icon, match }) => {
+          const isActive = match(pathname)
+          return (
+            <Link
+              key={href}
+              href={href}
+              className={cn(
+                'flex flex-1 flex-col items-center justify-center gap-0.5',
+                isActive ? 'text-primary-200' : 'text-gray-400'
+              )}
+            >
+              <Icon className="h-5 w-5" strokeWidth={isActive ? 2.5 : 2} />
+              <span className="text-[10px] font-medium">{label}</span>
+            </Link>
+          )
+        })}
+      </div>
+    </nav>
+  )
+}

--- a/src/components/header/components/MobileNavigation.tsx
+++ b/src/components/header/components/MobileNavigation.tsx
@@ -12,16 +12,13 @@ import IconButton from '@/components/commons/button/IconButton'
 import { useUserStore } from '@/store/userStore'
 import { useLogout } from '@/hooks/useLogout'
 
+
 interface MobileNavigationProps {
   isOpen: boolean
   onClose: () => void
 }
 
 export default function MobileNavigation({ isOpen, onClose }: MobileNavigationProps) {
-  const [isCommunityOpen, setIsCommunityOpen] = useState(false)
-  const [communityHeight, setCommunityHeight] = useState(0)
-  const communityRef = useRef<HTMLDivElement>(null)
-
   const [isCustomerOpen, setIsCustomerOpen] = useState(false)
   const [customerHeight, setCustomerHeight] = useState(0)
   const customerRef = useRef<HTMLDivElement>(null)
@@ -34,9 +31,6 @@ export default function MobileNavigation({ isOpen, onClose }: MobileNavigationPr
   const { openLogoutConfirm } = useLogout(onClose)
 
   useEffect(() => {
-    if (communityRef.current) {
-      setCommunityHeight(communityRef.current.scrollHeight)
-    }
     if (customerRef.current) {
       setCustomerHeight(customerRef.current.scrollHeight)
     }
@@ -103,33 +97,6 @@ export default function MobileNavigation({ isOpen, onClose }: MobileNavigationPr
           </div>
         </div>
         <div className="pt-5">
-          <Link href={ROUTES.HOME} onClick={onClose} className="flex w-full items-center justify-between py-2">
-            <span className="font-normal">마켓</span>
-          </Link>
-          <div>
-            <button
-              type="button"
-              onClick={() => setIsCommunityOpen((prev) => !prev)}
-              className="flex w-full cursor-pointer items-center justify-between py-2"
-            >
-              <span className="font-normal">커뮤니티</span>
-              <ChevronDown className={cn('h-5 w-5 transition-transform', isCommunityOpen && 'rotate-180')} />
-            </button>
-            <div
-              ref={communityRef}
-              className="overflow-hidden transition-[height] duration-300"
-              style={{ height: isCommunityOpen ? `${communityHeight}px` : '0' }}
-            >
-              <div className="flex flex-col gap-2 pl-4">
-                <Link href={`${ROUTES.COMMUNITY}?tab=tab-question`} onClick={onClose}>
-                  질문 있어요
-                </Link>
-                <Link href={`${ROUTES.COMMUNITY}?tab=tab-info`} onClick={onClose}>
-                  정보 공유
-                </Link>
-              </div>
-            </div>
-          </div>
           <div>
             <button type="button" onClick={() => setIsCustomerOpen((prev) => !prev)} className="flex w-full items-center justify-between py-2">
               <span className="font-normal">고객센터</span>

--- a/src/components/header/components/UserControls.tsx
+++ b/src/components/header/components/UserControls.tsx
@@ -54,7 +54,7 @@ export default function UserControls({ isSideOpen, setIsSideOpen, hideMenuButton
     <div className="flex items-center gap-2 xl:gap-4">
       {hasHydrated && isLogin() ? (
         <div className="flex items-center gap-1">
-          <Link href={ROUTES.CHAT} className="ml-1" aria-label="채팅">
+          <Link href={ROUTES.CHAT} className="ml-1 hidden xl:block" aria-label="채팅">
             <MessageCircleMore className="text-white" strokeWidth={1.5} />
           </Link>
           <div className="relative mr-2.5" onClick={handleBellToggle}>

--- a/src/features/community/CommunityPage.tsx
+++ b/src/features/community/CommunityPage.tsx
@@ -380,7 +380,7 @@ export default function CommunityPage({ initialQuestionData, initialInfoData }: 
       {hasHydrated && isLogin() ? (
         <Link
           href={`${ROUTES.COMMUNITY_POST}?tab=${activeCommunityTypeTab}`}
-          className={`bg-primary-200 fixed right-4 bottom-4 rounded-full px-3 py-3 text-white md:hidden ${Z_INDEX.FLOATING_BUTTON}`}
+          className={`bg-primary-200 fixed right-4 bottom-18 rounded-full px-3 py-3 text-white md:hidden ${Z_INDEX.FLOATING_BUTTON}`}
         >
           <Plus />
         </Link>

--- a/src/features/home/Home.tsx
+++ b/src/features/home/Home.tsx
@@ -323,7 +323,7 @@ function Home() {
         </div>
       </div>
       {isLoggedIn ? (
-        <div className={`fixed right-10 bottom-5 ${Z_INDEX.FLOATING_BUTTON}`}>
+        <div className={`fixed right-10 bottom-5 max-md:bottom-18 max-md:right-4 ${Z_INDEX.FLOATING_BUTTON}`}>
           <Button
             size={isMd ? 'lg' : 'md'}
             className="bg-primary-300 cursor-pointer text-white"

--- a/src/features/map/CategoryTabs.tsx
+++ b/src/features/map/CategoryTabs.tsx
@@ -8,7 +8,7 @@ export default function CategoryTabs() {
   const setSelectedCategory = useMapStore((s) => s.setSelectedCategory)
 
   return (
-    <div className="flex gap-2 overflow-x-auto px-4 py-3">
+    <div className="sticky top-0 z-10 flex gap-2 overflow-x-auto bg-white px-4 py-3">
       {CATEGORIES.map(({ key, label }) => (
         <button
           key={key}

--- a/src/features/map/MapContainer.tsx
+++ b/src/features/map/MapContainer.tsx
@@ -71,7 +71,7 @@ export default function MapContainer() {
         onLoad={() => setMapReady(true)}
       />
 
-      <div className="flex h-[calc(100vh-var(--header-height,72px))] flex-col">
+      <div className="flex h-[calc(100vh-var(--header-height,72px)-56px)] flex-col xl:h-[calc(100vh-var(--header-height,72px))]">
         <CategoryTabs />
 
         <div className="flex flex-1 overflow-hidden">


### PR DESCRIPTION
## 📌 개요

- 모바일(< xl) 환경에서 하단 탭바(BottomNav)를 추가하여 주요 메뉴 접근성을 개선합니다.

## 🔧 작업 내용

- [x] BottomNav 컴포넌트 생성 (홈, 커뮤니티, 플레이스, 채팅, 마이)
- [x] (main) layout.tsx에 BottomNav 배치 + 모바일 하단 여백 추가
- [x] 현재 경로 활성화 스타일 적용
- [x] 특정 페이지에서 BottomNav 숨김 처리 (글 작성, 채팅방, 상세 페이지 등)
- [x] 모바일 Header 채팅 아이콘 숨김 (BottomNav와 중복 제거)
- [x] 사이드바에서 마켓/커뮤니티 메뉴 제거 (BottomNav와 중복 제거)
- [x] 플로팅 버튼 위치 조정 (커뮤니티 게시글 등록, 홈 상품등록)
- [x] 지도 컨테이너 높이 BottomNav 반영
- [x] 지도 CategoryTabs sticky 처리

## 📎 관련 이슈

Closes #652

## 💬 리뷰어 참고 사항

- BottomNav 탭 구성: 홈, 커뮤니티, 플레이스, 채팅, 마이 (당근마켓 등 C2C 앱 패턴 참고)
- 사이드바는 고객센터 + 로그인/로그아웃만 유지
- 지도 페이지는 MapContainer에서 BottomNav 높이를 제외하여 내부 컴포넌트(상세카드, 내위치 버튼)는 원래 위치값 유지