### PR TITLE
fix: 모바일 지도 상세카드 UI 개선 및 BottomNav 스타일 조정(#654)

### DIFF
--- a/src/components/bottom-nav/BottomNav.tsx
+++ b/src/components/bottom-nav/BottomNav.tsx
@@ -67,7 +67,7 @@ export default function BottomNav() {
               )}
             >
               <Icon className="h-5 w-5" strokeWidth={isActive ? 2.5 : 2} />
-              <span className="text-[10px] font-medium">{label}</span>
+              <span className="text-xs font-medium">{label}</span>
             </Link>
           )
         })}

--- a/src/features/map/MyLocationButton.tsx
+++ b/src/features/map/MyLocationButton.tsx
@@ -5,6 +5,7 @@ import { FiCrosshair } from 'react-icons/fi'
 
 export default function MyLocationButton() {
   const setMapCenter = useMapStore((s) => s.setMapCenter)
+  const selectedPlace = useMapStore((s) => s.selectedPlace)
 
   const handleClick = () => {
     if (!navigator.geolocation) return
@@ -32,7 +33,7 @@ export default function MyLocationButton() {
   return (
     <button
       onClick={handleClick}
-      className="absolute bottom-6 right-4 z-10 cursor-pointer rounded-full bg-white p-3 shadow-md transition-colors hover:bg-gray-50"
+      className={`absolute right-4 z-10 cursor-pointer rounded-full bg-white p-3 shadow-md transition-all hover:bg-gray-50 ${selectedPlace ? 'bottom-48' : 'bottom-10'}`}
       title="내 위치"
     >
       <FiCrosshair className="h-5 w-5 text-gray-700" />

--- a/src/features/map/NaverMap.tsx
+++ b/src/features/map/NaverMap.tsx
@@ -112,14 +112,17 @@ export default function NaverMap() {
   useEffect(() => {
     if (!mapRef.current || !window.naver?.maps) return
 
+    const isXl = window.innerWidth >= 1280
+
     const map = new naver.maps.Map(mapRef.current, {
       center: new naver.maps.LatLng(mapCenter.lat, mapCenter.lng),
       zoom: 15,
-      zoomControl: true,
+      zoomControl: isXl,
       zoomControlOptions: {
         position: naver.maps.Position.TOP_RIGHT,
       },
-    })
+      scaleControl: false,
+    } as naver.maps.MapOptions & { scaleControl: boolean })
 
     mapInstanceRef.current = map
 

--- a/src/features/map/PlaceDetailSlideCard.tsx
+++ b/src/features/map/PlaceDetailSlideCard.tsx
@@ -1,19 +1,12 @@
 'use client'
 
 import { useMapStore } from '@/store/mapStore'
-import { FiPhone, FiClock, FiMapPin, FiStar, FiX, FiNavigation } from 'react-icons/fi'
+import { FiPhone, FiClock, FiMapPin, FiStar, FiX } from 'react-icons/fi'
 import { motion, AnimatePresence } from 'framer-motion'
 
 export default function PlaceDetailSlideCard() {
   const selectedPlace = useMapStore((s) => s.selectedPlace)
   const setSelectedPlace = useMapStore((s) => s.setSelectedPlace)
-
-  const naverMapUrl = selectedPlace
-    ? `nmap://place?lat=${selectedPlace.latitude}&lng=${selectedPlace.longitude}&name=${encodeURIComponent(selectedPlace.name)}&appname=cuddle-market`
-    : ''
-  const naverMapWebUrl = selectedPlace
-    ? `https://map.naver.com/v5/search/${encodeURIComponent(selectedPlace.name)}?c=${selectedPlace.longitude},${selectedPlace.latitude},15,0,0,0,dh`
-    : ''
 
   return (
     <AnimatePresence>
@@ -23,7 +16,7 @@ export default function PlaceDetailSlideCard() {
           animate={{ y: 0 }}
           exit={{ y: '100%' }}
           transition={{ type: 'spring', damping: 25, stiffness: 300 }}
-          className="absolute inset-x-0 bottom-0 z-20 rounded-t-2xl bg-white shadow-[0_-4px_20px_rgba(0,0,0,0.15)] md:hidden"
+          className="absolute inset-x-0 bottom-0 z-[100] rounded-t-2xl border-b border-gray-200 bg-white shadow-[0_-4px_20px_rgba(0,0,0,0.15)] md:hidden"
         >
           <div className="mx-auto mt-2 h-1 w-10 rounded-full bg-gray-300" />
 
@@ -96,19 +89,6 @@ export default function PlaceDetailSlideCard() {
               </div>
             )}
 
-            <a
-              href={naverMapUrl}
-              onClick={(e) => {
-                if (!/iPhone|iPad|Android/i.test(navigator.userAgent)) {
-                  e.preventDefault()
-                  window.open(naverMapWebUrl, '_blank')
-                }
-              }}
-              className="mt-4 flex w-full items-center justify-center gap-2 rounded-lg bg-green-500 py-2.5 text-sm font-medium text-white"
-            >
-              <FiNavigation className="h-4 w-4" />
-              네이버 지도에서 보기
-            </a>
           </div>
         </motion.div>
       )}


### PR DESCRIPTION
## 📌 개요

- 모바일 지도 페이지의 상세카드 UI를 개선하고 BottomNav 관련 스타일을 조정합니다.

## 🔧 작업 내용

- [x] 상세카드 z-index `z-[100]`으로 상향 (네이버 맵 컨트롤 위로 표시)
- [x] 모바일 상세카드 "네이버 지도에서 보기" 버튼 제거 및 미사용 코드 정리
- [x] 상세카드-BottomNav 간 경계선(border-b) 추가
- [x] 지도 축적 바(scaleControl) 숨김
- [x] 모바일 줌 컨트롤 숨김 (핀치 투 줌으로 대체)
- [x] 현재위치 버튼 상세카드 열림 시 동적 위치 조정
- [x] BottomNav 글씨 크기 조정 (text-[10px] → text-xs)

## 📎 관련 이슈

Closes #654

## 💬 리뷰어 참고 사항

- 모바일 줌 컨트롤은 실제 모바일 기기에서 터치 이벤트가 동작하지 않아 숨김 처리 (핀치 투 줌으로 충분)
- 현재위치 버튼은 상세카드 열림/닫힘에 따라 `bottom-48`/`bottom-10`으로 전환 (transition-all 적용)