### PR TITLE
fix: Home.tsx useEffect cascading render 에러 수정(#662)

### DIFF
--- a/src/features/home/Home.tsx
+++ b/src/features/home/Home.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useInfiniteQuery } from '@tanstack/react-query'
-import { useState, useCallback, useMemo, useEffect } from 'react'
+import { useState, useCallback, useMemo } from 'react'
 import Tabs from '@/components/Tabs'
 import { DetailFilter } from '@/features/home/components/filter/DetailFilter'
 import { ProductsSection } from '@/features/home/components/product-section/ProductsSection'
@@ -24,8 +24,6 @@ function Home() {
   const { isLogin } = useUserStore()
   const hasHydrated = useUserStore((state) => state._hasHydrated)
   const isLoggedIn = hasHydrated && isLogin()
-  const [isHydrated, setIsHydrated] = useState(false)
-  useEffect(() => { setIsHydrated(true) }, [])
   const isMd = useMediaQuery('(min-width: 768px)')
   const { searchParams, pathname, push } = useFilterNavigation()
   const router = useRouter()
@@ -200,7 +198,7 @@ function Home() {
 
   const totalElements = data?.pages?.[0]?.totalElements || 0
 
-  if (!isHydrated) {
+  if (!hasHydrated) {
     return (
       <div className="pb-4xl pt-6">
         <h1 className="sr-only">커들마켓</h1>


### PR DESCRIPTION
## 📌 개요

- Home.tsx에서 React 19 cascading render 경고 수정

## 🔧 작업 내용

- [x] `isHydrated` state + `useEffect(() => { setIsHydrated(true) }, [])` 삭제
- [x] `if (!isHydrated)` → `if (!hasHydrated)` 변경 (Zustand `_hasHydrated`로 통합)
- [x] 미사용 `useEffect` import 제거
- [x] 빌드 통과 확인

## 📎 관련 이슈

Close #662

## 💬 리뷰어 참고 사항

- `isHydrated`는 Zustand의 `_hasHydrated`와 역할이 완전히 중복되는 불필요한 상태였음
- 다른 컴포넌트(UserControls, MobileNavigation 등)는 모두 `_hasHydrated`만 사용