### PR TITLE
fix: 채팅 페이지 레이아웃 버그 수정(#666)

### DIFF
--- a/src/features/chatting-page/ChattingPage.tsx
+++ b/src/features/chatting-page/ChattingPage.tsx
@@ -247,8 +247,8 @@ export default function ChattingPage() {
       ) : null}
       <div
         className={cn(
-          'flex h-full flex-col md:mx-auto md:h-[80vh] md:max-w-7xl md:flex-row',
-          isChatOpen ? 'flex-1 overflow-hidden' : ''
+          'flex h-full flex-col md:mx-auto md:h-[80vh] md:w-full md:max-w-7xl md:flex-row',
+          isChatOpen ? 'flex-1 md:flex-none overflow-hidden' : ''
         )}
       >
         <div className={cn('md:flex', isChatOpen ? 'hidden' : 'block')}>


### PR DESCRIPTION
## 📌 개요

- 채팅 페이지에서 채팅방별 너비 불일치 및 메시지 영역 브라우저 스크롤 문제 수정

## 🔧 작업 내용

- [x] 채팅 컨테이너에 `md:w-full` 추가 — 콘텐츠 길이에 따라 너비가 달라지던 문제 해결
- [x] `md:flex-none` 추가 — `flex-1`이 `md:h-[80vh]`를 무시하여 메시지 영역이 브라우저 스크롤을 유발하던 문제 해결

## 📎 관련 이슈

Close #666

## 💬 리뷰어 참고 사항

- `md:max-w-7xl`만으로는 실제 너비를 보장하지 않아 `md:w-full` 추가 필요
- `flex-1`의 `flex-basis: 0%`가 `height: 80vh`보다 우선 적용되어 높이 제한이 풀리는 문제를 `md:flex-none`으로 해결
- 모바일은 `fixed inset-0`으로 전체화면이라 `flex-1`이 정상 동작하므로 영향 없음