### PR TITLE
fix: 채팅 목록 최근 메시지 시간 표시 줄바꿈 수정(#668)

### DIFF
--- a/src/features/chatting-page/components/ChatRooms.tsx
+++ b/src/features/chatting-page/components/ChatRooms.tsx
@@ -67,10 +67,10 @@ export function ChatRooms({
                     <div className="shrink-0">
                       <SellerAvatar profileImageUrl={roomData?.opponentProfileImageUrl} nickname={roomData?.opponentNickname} />
                     </div>
-                    <div className="flex w-full flex-col gap-1">
+                    <div className="flex min-w-0 flex-1 flex-col gap-1">
                       <p className="leading-none font-semibold">{roomData?.opponentNickname}</p>
                       <div className="flex items-center gap-1">
-                        <p className={cn('line-clamp-1 text-xs', roomData.lastMessage == null ? 'text-blue-600' : '')}>
+                        <p className={cn('min-w-0 flex-1 truncate text-xs', roomData.lastMessage == null ? 'text-blue-600' : '')}>
                           {roomData.lastMessage == null
                             ? '채팅방에 입장해주세요'
                             : roomData.lastMessage === ''
@@ -78,7 +78,7 @@ export function ChatRooms({
                               : roomData.lastMessage}
                         </p>
                         {roomData.lastMessageTime ? (
-                          <span className="text-xs leading-none font-medium text-gray-500">
+                          <span className="shrink-0 text-xs leading-none font-medium text-gray-500">
                             {getTimeAgo(roomData.lastMessageTime)}
                           </span>
                         ) : null}


### PR DESCRIPTION
## 📌 개요

- 채팅 목록에서 최근 메시지가 길면 시간 표시가 밀려나서 줄바꿈되는 문제 수정

## 🔧 작업 내용

- [x] 메시지 텍스트: `line-clamp-1` → `truncate` + `min-w-0 flex-1`
- [x] 시간 표시: `shrink-0` 추가로 축소 방지
- [x] 부모 div: `w-full` → `min-w-0 flex-1`로 flex 오버플로우 방지

## 📎 관련 이슈

Close #668

## 💬 리뷰어 참고 사항

- 기존에는 `line-clamp-1`만 적용되어 시간 표시 영역이 보장되지 않았음
- `truncate`(text-overflow: ellipsis) + `shrink-0`으로 메시지는 잘리고 시간은 고정