### PR TITLE
feat: 지도 자동 검색을 "현 지도에서 검색" 버튼 방식으로 변경(#675)

### DIFF
--- a/src/features/map/MapContainer.tsx
+++ b/src/features/map/MapContainer.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useCallback, useRef } from 'react'
 import Script from 'next/script'
 import CategoryTabs from './CategoryTabs'
 import MyLocationButton from './MyLocationButton'
+import SearchInMapButton from './SearchInMapButton'
 import NaverMap from './NaverMap'
 import PlaceListSidebar from './PlaceListSidebar'
 import PlaceDetailSidebar from './PlaceDetailSidebar'
@@ -48,14 +49,26 @@ export default function MapContainer() {
     }
   }, [selectedCategory, activeFilters, mapBounds, setMarkers, setIsLoading])
 
-  // bounds, 카테고리, 필터 변경 시 자동 재조회
+  const initialLoadRef = useRef(true)
+  const setNeedsSearch = useMapStore((s) => s.setNeedsSearch)
+
+  // 초기 로드 시 자동 검색
   useEffect(() => {
     if (!mapReady || !mapBounds) return
+    if (!initialLoadRef.current) return
+    initialLoadRef.current = false
     fetchPlaces()
     return () => {
       abortRef.current?.abort()
     }
   }, [fetchPlaces, mapReady, mapBounds])
+
+  // 카테고리, 필터 변경 시 자동 재검색
+  useEffect(() => {
+    if (!mapReady || !mapBounds || initialLoadRef.current) return
+    fetchPlaces()
+    setNeedsSearch(false)
+  }, [selectedCategory, activeFilters]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (window.naver?.maps) {
@@ -97,6 +110,7 @@ export default function MapContainer() {
               </div>
             )}
 
+            <SearchInMapButton onSearch={() => { fetchPlaces(); setNeedsSearch(false) }} />
             <MyLocationButton />
             <PlaceDetailSlideCard />
           </div>

--- a/src/features/map/MapContainer.tsx
+++ b/src/features/map/MapContainer.tsx
@@ -23,8 +23,11 @@ export default function MapContainer() {
   const isLoading = useMapStore((s) => s.isLoading)
   const setMarkers = useMapStore((s) => s.setMarkers)
   const setIsLoading = useMapStore((s) => s.setIsLoading)
+  const setNeedsSearch = useMapStore((s) => s.setNeedsSearch)
 
   const fetchPlaces = useCallback(async () => {
+    const { mapBounds, selectedCategory, activeFilters } =
+      useMapStore.getState()
     if (!mapBounds) return
 
     abortRef.current?.abort()
@@ -47,10 +50,9 @@ export default function MapContainer() {
     } finally {
       setIsLoading(false)
     }
-  }, [selectedCategory, activeFilters, mapBounds, setMarkers, setIsLoading])
+  }, [setMarkers, setIsLoading])
 
   const initialLoadRef = useRef(true)
-  const setNeedsSearch = useMapStore((s) => s.setNeedsSearch)
 
   // 초기 로드 시 자동 검색
   useEffect(() => {
@@ -65,10 +67,10 @@ export default function MapContainer() {
 
   // 카테고리, 필터 변경 시 자동 재검색
   useEffect(() => {
-    if (!mapReady || !mapBounds || initialLoadRef.current) return
+    if (!mapReady || initialLoadRef.current) return
     fetchPlaces()
     setNeedsSearch(false)
-  }, [selectedCategory, activeFilters]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [selectedCategory, activeFilters, fetchPlaces, mapReady, setNeedsSearch])
 
   useEffect(() => {
     if (window.naver?.maps) {

--- a/src/features/map/MyLocationButton.tsx
+++ b/src/features/map/MyLocationButton.tsx
@@ -33,7 +33,7 @@ export default function MyLocationButton() {
   return (
     <button
       onClick={handleClick}
-      className={`absolute right-4 z-10 cursor-pointer rounded-full bg-white p-3 shadow-md transition-all hover:bg-gray-50 ${selectedPlace ? 'bottom-48' : 'bottom-10'}`}
+      className={`absolute right-4 z-10 cursor-pointer rounded-full bg-white p-3 shadow-md transition-all hover:bg-gray-50 ${selectedPlace ? 'bottom-48' : 'bottom-16 xl:bottom-10'}`}
       title="내 위치"
     >
       <FiCrosshair className="h-5 w-5 text-gray-700" />

--- a/src/features/map/NaverMap.tsx
+++ b/src/features/map/NaverMap.tsx
@@ -75,6 +75,7 @@ export default function NaverMap() {
   const setMapCenter = useMapStore((s) => s.setMapCenter)
   const setMapBounds = useMapStore((s) => s.setMapBounds)
   const setSelectedPlace = useMapStore((s) => s.setSelectedPlace)
+  const setNeedsSearch = useMapStore((s) => s.setNeedsSearch)
 
   const createMarkerIcon = useCallback((isRecommended: boolean) => {
     const color = isRecommended ? '#FF6F0F' : '#3B82F6'
@@ -105,8 +106,11 @@ export default function NaverMap() {
   // 지도 이동/줌 변경 시 debounce 후 bounds 업데이트
   const handleMapChanged = useCallback(() => {
     if (debounceRef.current) clearTimeout(debounceRef.current)
-    debounceRef.current = setTimeout(updateBounds, 500)
-  }, [updateBounds])
+    debounceRef.current = setTimeout(() => {
+      updateBounds()
+      setNeedsSearch(true)
+    }, 500)
+  }, [updateBounds, setNeedsSearch])
 
   // 지도 초기화
   useEffect(() => {

--- a/src/features/map/SearchInMapButton.tsx
+++ b/src/features/map/SearchInMapButton.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import { useMapStore } from '@/store/mapStore'
+
+interface SearchInMapButtonProps {
+  onSearch: () => void
+}
+
+export default function SearchInMapButton({ onSearch }: SearchInMapButtonProps) {
+  const needsSearch = useMapStore((s) => s.needsSearch)
+  const selectedPlace = useMapStore((s) => s.selectedPlace)
+
+  if (!needsSearch) return null
+
+  return (
+    <button
+      onClick={onSearch}
+      className={`absolute left-1/2 -translate-x-1/2 z-10 rounded-full bg-white px-4 py-3 text-sm font-medium text-gray-700 shadow-md transition-colors hover:bg-gray-50 active:bg-gray-100 ${selectedPlace ? 'bottom-48' : 'bottom-16 xl:bottom-10'}`}
+    >
+      현 지도에서 검색
+    </button>
+  )
+}

--- a/src/store/mapStore.ts
+++ b/src/store/mapStore.ts
@@ -19,6 +19,7 @@ interface MapStore {
   mapBounds: MapBounds | null
   markers: PlaceListItem[]
   isLoading: boolean
+  needsSearch: boolean
 
   setSelectedCategory: (category: PlaceCategory) => void
   toggleFilter: (filter: HospitalFilter) => void
@@ -27,6 +28,7 @@ interface MapStore {
   setMapBounds: (bounds: MapBounds) => void
   setMarkers: (markers: PlaceListItem[]) => void
   setIsLoading: (loading: boolean) => void
+  setNeedsSearch: (needs: boolean) => void
 }
 
 export const useMapStore = create<MapStore>((set) => ({
@@ -37,6 +39,7 @@ export const useMapStore = create<MapStore>((set) => ({
   mapBounds: null,
   markers: [],
   isLoading: false,
+  needsSearch: false,
 
   setSelectedCategory: (category) =>
     set({ selectedCategory: category, activeFilters: [], selectedPlace: null }),
@@ -53,6 +56,7 @@ export const useMapStore = create<MapStore>((set) => ({
   setMapBounds: (mapBounds) => set({ mapBounds }),
   setMarkers: (markers) => set({ markers }),
   setIsLoading: (isLoading) => set({ isLoading }),
+  setNeedsSearch: (needsSearch) => set({ needsSearch }),
 }))
 
 export function getFilterParams(activeFilters: HospitalFilter[]) {


### PR DESCRIPTION
## 📌 개요

- 지도 이동 시 자동으로 마커를 재검색하던 방식을, "현 지도에서 검색" 버튼 클릭 시에만 재검색하도록 변경

## 🔧 작업 내용

- [x] 지도 이동 시 자동 fetchPlaces 호출 제거 (초기 로드, 카테고리/필터 변경 시에만 자동 검색 유지)
- [x] "현 지도에서 검색" 버튼 컴포넌트 추가 (하단 중앙 배치)
- [x] 지도 이동 감지 시 버튼 표시, 클릭 시 검색 후 버튼 숨김
- [x] MyLocationButton 모바일 BottomNav 겹침 수정

## 📎 관련 이슈

Closes #675

## 💬 리뷰어 참고 사항

- mapStore에 `needsSearch` 상태 추가하여 지도 이동 여부 추적
- 초기 로드와 카테고리/필터 변경은 기존처럼 자동 검색 유지
- MyLocationButton, SearchInMapButton 모두 `selectedPlace` 선택 시 `bottom-48`로 올라감