### PR TITLE
refactor: 상품등록 플로팅 버튼을 Link로 변경(#677)

### DIFF
--- a/src/features/home/Home.tsx
+++ b/src/features/home/Home.tsx
@@ -10,10 +10,11 @@ import { useIntersectionObserver } from '@/hooks/useIntersectionObserver'
 import { PRODUCT_TYPE_TABS, PET_TYPE_TABS, type ProductTypeTabId, SORT_TYPE, type PetTypeTabId } from '@/constants/constants'
 import { PetTypeFilter } from './components/filter/PetTypeFilter'
 import { CategoryFilter } from './components/filter/CategoryFilter'
-import { useRouter } from 'next/navigation'
+import Link from 'next/link'
 import { useFilterNavigation } from '@/hooks/useFilterNavigation'
 import { Plus } from 'lucide-react'
-import Button from '@/components/commons/button/Button'
+import { buttonVariants, iconSizeMap } from '@/components/commons/button/buttonClass'
+import { cn } from '@/lib/utils/cn'
 import { useUserStore } from '@/store/userStore'
 import { useMediaQuery } from '@/hooks/useMediaQuery'
 import { Z_INDEX } from '@/constants/ui'
@@ -26,7 +27,6 @@ function Home() {
   const isLoggedIn = hasHydrated && isLogin()
   const isMd = useMediaQuery('(min-width: 768px)')
   const { searchParams, pathname, push } = useFilterNavigation()
-  const router = useRouter()
 
   // URL에서 탭 초기값 결정 (시각적 표시용)
   const urlPetType = searchParams.get('petType')
@@ -191,11 +191,6 @@ function Home() {
     [push, pathname]
   )
 
-  const toGoProductPostPage = (e: React.MouseEvent) => {
-    e.preventDefault()
-    router.push('/product-post')
-  }
-
   const totalElements = data?.pages?.[0]?.totalElements || 0
 
   if (!hasHydrated) {
@@ -322,14 +317,16 @@ function Home() {
       </div>
       {isLoggedIn ? (
         <div className={`fixed right-10 bottom-5 max-md:bottom-18 max-md:right-4 ${Z_INDEX.FLOATING_BUTTON}`}>
-          <Button
-            size={isMd ? 'lg' : 'md'}
-            className="bg-primary-300 cursor-pointer text-white"
-            icon={Plus}
-            onClick={toGoProductPostPage}
+          <Link
+            href="/product-post"
+            className={cn(
+              buttonVariants({ size: isMd ? 'lg' : 'md', iconPosition: 'left' }),
+              'bg-primary-300 cursor-pointer text-white'
+            )}
           >
+            <Plus size={iconSizeMap[isMd ? 'lg' : 'md']} />
             상품등록
-          </Button>
+          </Link>
         </div>
       ) : null}
     </>


### PR DESCRIPTION
## 📌 개요

- 홈의 "상품등록" 플로팅 버튼을 `<Button>` + `router.push`에서 `next/link`의 `<Link>`로 변경했습니다.
- 브라우저가 이 요소를 링크로 인식하지 못해 우클릭 컨텍스트 메뉴, Cmd/Ctrl+클릭 새 탭 열기 등이 동작하지 않던 문제를 해결합니다.

## 🔧 작업 내용

- [x] `src/features/home/Home.tsx`의 `<Button>`을 `<Link href="/product-post">`로 교체
- [x] 기존 `buttonVariants`, `iconSizeMap`, `cn`을 `<Link>`에 그대로 적용하여 시각적 디자인 동일하게 유지
- [x] 불필요해진 `useRouter`, `toGoProductPostPage`, `Button` import 제거
- [x] `Button` 공용 컴포넌트 자체는 변경하지 않음 (51개 사용처에 영향 없음)

## 📎 관련 이슈

- Close #677

## 📸 스크린샷 (선택)

| 변경 전 | 변경 후 |
| ------- | ------- |
| 우클릭 시 컨텍스트 메뉴 없음 | 우클릭 시 "새 탭으로 열기", "링크 주소 복사" 등 표시 |

## 💬 리뷰어 참고 사항

- `Button`이 `<button>` 태그에 하드코딩되어 있고 `asChild`/`as` prop이 없어 공용 컴포넌트 수정 대신 **이 한 곳만 `<Link>`로 교체**하는 방식을 선택했습니다.
- `buttonVariants`가 cva로 만들어진 순수 className 생성 함수라 `<Link>`에도 그대로 적용 가능합니다.
- 네비게이션 외 사이드 이펙트가 없어 시맨틱상 링크가 맞다고 판단했습니다.
- 확인 포인트: 로그인 상태에서 홈 우하단 버튼 우클릭/Cmd·Ctrl+클릭/가운데 클릭 동작, 디자인이 기존과 동일한지.