### PR TITLE
feat: 로그 fetch를 CloudWatch Logs로 전환(#681)

### DIFF
--- a/.github/scripts/health-check.mjs
+++ b/.github/scripts/health-check.mjs
@@ -1,5 +1,9 @@
 import tls from 'node:tls';
 import fs from 'node:fs';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
 
 // ============================================================
 // Configuration
@@ -13,9 +17,9 @@ const DISCORD_WEBHOOK_URL = process.env.DISCORD_WEBHOOK_URL;
 const ALERT_STATE_PATH = process.env.ALERT_STATE_PATH || '.github/scripts/alert-state.json';
 const SUPPRESS_HOURS = 3;
 const CONSECUTIVE_FAILURES_THRESHOLD = 2;
-const LOGFILE_URL = 'https://cmarket-api.duckdns.org/actuator/logfile';
-const LOGFILE_BASIC_AUTH = process.env.LOGFILE_BASIC_AUTH; // "user:pass" 평문
-const LOG_TAIL_BYTES = 3500;
+const AWS_REGION = process.env.AWS_REGION;
+const LOG_GROUP_NAME = process.env.LOG_GROUP_NAME;
+const LOG_FETCH_MINUTES = 15;
 const BACKEND_ROLE_ID = process.env.BACKEND_ROLE_ID;
 
 // ============================================================
@@ -188,31 +192,24 @@ function checkSSL() {
 }
 
 // ============================================================
-// 3. Log Tail
+// 3. CloudWatch Log Tail
 // ============================================================
 async function fetchLogTail() {
-  if (!LOGFILE_URL) return null;
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  if (!AWS_REGION || !LOG_GROUP_NAME) return null;
   try {
-    const headers = { Range: `bytes=-${LOG_TAIL_BYTES}` };
-    if (LOGFILE_BASIC_AUTH) {
-      headers.Authorization = `Basic ${Buffer.from(LOGFILE_BASIC_AUTH).toString('base64')}`;
-    }
-    const res = await fetch(LOGFILE_URL, { signal: controller.signal, headers });
-    clearTimeout(timer);
-    if (!res.ok) {
-      console.log(`[WARN] 로그 조회 실패 (HTTP ${res.status})`);
-      return null;
-    }
-    const text = await res.text();
-    // 206 Partial Content는 바이트 경계에서 잘려 첫 줄이 불완전하므로 drop. 200은 파일 전체라 유지.
-    if (res.status !== 206) return text;
-    const lines = text.split('\n');
-    return lines.length > 1 ? lines.slice(1).join('\n') : text;
+    const { stdout } = await execFileAsync(
+      'aws',
+      [
+        'logs', 'tail', LOG_GROUP_NAME,
+        '--since', `${LOG_FETCH_MINUTES}m`,
+        '--format', 'short',
+        '--region', AWS_REGION,
+      ],
+      { timeout: TIMEOUT_MS, maxBuffer: 10 * 1024 * 1024 },
+    );
+    return stdout.trim() || null;
   } catch (err) {
-    clearTimeout(timer);
-    console.log(`[WARN] 로그 조회 실패: ${err.message}`);
+    console.log(`[WARN] CloudWatch 로그 조회 실패: ${err.message}`);
     return null;
   }
 }
@@ -227,7 +224,7 @@ function buildLogEmbed(logText) {
     title: '📋 서버 로그 (최근)',
     description: '```\n' + safe + '\n```',
     color: 0x808080,
-    footer: { text: '/actuator/logfile tail' },
+    footer: { text: `CloudWatch Logs · ${LOG_GROUP_NAME} · 최근 ${LOG_FETCH_MINUTES}분` },
   };
 }
 

--- a/.github/scripts/health-check.mjs
+++ b/.github/scripts/health-check.mjs
@@ -203,6 +203,7 @@ async function fetchLogTail() {
         'logs', 'tail', LOG_GROUP_NAME,
         '--since', `${LOG_FETCH_MINUTES}m`,
         '--format', 'short',
+        '--color', 'off',
         '--region', AWS_REGION,
       ],
       { timeout: TIMEOUT_MS, maxBuffer: 10 * 1024 * 1024 },

--- a/.github/workflows/server-monitor.yml
+++ b/.github/workflows/server-monitor.yml
@@ -28,8 +28,11 @@ jobs:
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           ALERT_STATE_PATH: .github/scripts/alert-state.json
-          LOGFILE_BASIC_AUTH: ${{ secrets.LOGFILE_BASIC_AUTH }}
           BACKEND_ROLE_ID: ${{ secrets.BACKEND_ROLE_ID }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          LOG_GROUP_NAME: ${{ secrets.LOG_GROUP_NAME }}
         run: node .github/scripts/health-check.mjs
 
       - name: Save alert state


### PR DESCRIPTION
## Summary
- \`fetchLogTail()\`을 \`/actuator/logfile\` HTTP fetch에서 \`aws logs tail\` CLI 호출로 교체
- \`LOGFILE_URL\` / \`LOGFILE_BASIC_AUTH\` 제거, \`AWS_REGION\` / \`LOG_GROUP_NAME\` 도입
- 워크플로우 env에 AWS 자격 증명 추가

Closes #681

## 배경

백엔드 보안 검토로 \`/actuator/logfile\` 외부 노출이 폐쇄됨. 추가로 네트워크 레벨 장애 시 HTTP fetch가 health check와 동시에 타임아웃나서 로그 조회 불가였는데, CloudWatch는 AWS 독립 서비스라 이 문제도 해결됨.

## Test plan (머지 전)
- [x] Node syntax check
- [x] 4개 secret 모두 등록 완료 (\`AWS_ACCESS_KEY_ID\`, \`AWS_SECRET_ACCESS_KEY\`, \`AWS_REGION\`, \`LOG_GROUP_NAME\`)

## Follow-up
- [ ] 실전 장애 시 CloudWatch 로그 embed 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)