### PR TITLE
feat: 네이버 서치어드바이저 소유 확인 메타 태그 추가(#683)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,6 +20,9 @@ export const metadata: Metadata = {
   },
   verification: {
     google: 'QwSeEYXUKCcLgTD8CtBEEpERKpp34sHBD_6r8dvKM2Q',
+    other: {
+      'naver-site-verification': '765503856b8ad106fd6d4890a149f0a5bc5de581',
+    },
   },
 }
 


### PR DESCRIPTION
## Summary
- \`src/app/layout.tsx\`의 \`metadata.verification.other\`에 \`naver-site-verification\` 토큰 추가

Closes #683

## 배경
구글에선 \"커들마켓\" 검색 시 노출되지만 네이버에선 미노출. \`layout.tsx\`에 \`google-site-verification\`만 있고 네이버 토큰이 없어 서치어드바이저 소유 확인 불가였음.

## Test plan (머지 전)
- [x] TypeScript metadata 타입 호환 (\`verification.other\`는 Next.js Metadata API 표준)

## Follow-up (머지 후)
- [ ] Vercel 배포 완료 후 서치어드바이저에서 소유 확인 클릭
- [ ] 서치어드바이저에서 \`/sitemap.xml\` 제출
- [ ] 주요 URL 수동 수집 요청 (선택)

🤖 Generated with [Claude Code](https://claude.com/claude-code)