### PR TITLE
chore: 서버 모니터링 false positive 알림 감소

### DIFF
--- a/.github/scripts/health-check.mjs
+++ b/.github/scripts/health-check.mjs
@@ -10,7 +10,8 @@ const execFileAsync = promisify(execFile);
 // ============================================================
 const HEALTH_URL = 'https://cmarket-api.duckdns.org/actuator/health';
 const HOST = 'cmarket-api.duckdns.org';
-const TIMEOUT_MS = 10_000;
+const TIMEOUT_MS = 15_000;
+const RETRY_DELAY_MS = 2_000;
 const SSL_WARN_DAYS = 7;
 const SSL_DANGER_DAYS = 3;
 const DISCORD_WEBHOOK_URL = process.env.DISCORD_WEBHOOK_URL;
@@ -34,6 +35,14 @@ function formatDuration(ms) {
   const minutes = Math.floor((ms % (1000 * 60 * 60)) / (1000 * 60));
   if (hours > 0) return `${hours}시간 ${minutes}분`;
   return `${minutes}분`;
+}
+
+async function withRetry(checkFn, name) {
+  const first = await checkFn();
+  if (!first) return null;
+  console.log(`[RETRY] ${name} 1차 실패 — ${RETRY_DELAY_MS / 1000}초 후 재시도`);
+  await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
+  return await checkFn();
 }
 
 // ============================================================
@@ -237,7 +246,10 @@ async function main() {
 
   const state = readState();
   const now = Date.now();
-  const [apiResult, sslResult] = await Promise.all([checkAPI(), checkSSL()]);
+  const [apiResult, sslResult] = await Promise.all([
+    withRetry(checkAPI, 'API'),
+    withRetry(checkSSL, 'SSL'),
+  ]);
   const problems = [apiResult, sslResult].filter(Boolean);
 
   // ── 정상: 문제 없음 ──
@@ -270,7 +282,7 @@ async function main() {
   if (state.status === 'ok' && consecutiveFailures < CONSECUTIVE_FAILURES_THRESHOLD) {
     console.log(`\n[대기] ${problems.length}건의 문제 감지 — 연속 ${consecutiveFailures}/${CONSECUTIVE_FAILURES_THRESHOLD}회 (알림 보류)\n`);
     writeState({ ...state, consecutiveFailures });
-    process.exit(1);
+    process.exit(0);
   }
 
   // ── 장애: 첫 알림 (연속 실패 임계값 도달) ──
@@ -328,12 +340,12 @@ async function main() {
       consecutiveFailures,
     });
     console.log('[알림] 리마인더 전송 완료');
-  } else {
-    console.log(`\n[SKIP] 알림 억제 중 (마지막 알림: ${hoursSinceLastAlert.toFixed(1)}시간 전, ${SUPPRESS_HOURS}시간 간격)\n`);
-    writeState({ ...state, consecutiveFailures });
+    process.exit(1);
   }
 
-  process.exit(1);
+  console.log(`\n[SKIP] 알림 억제 중 (마지막 알림: ${hoursSinceLastAlert.toFixed(1)}시간 전, ${SUPPRESS_HOURS}시간 간격)\n`);
+  writeState({ ...state, consecutiveFailures });
+  process.exit(0);
 }
 
 main();


### PR DESCRIPTION
## Summary
- API/SSL 체크 타임아웃 10초 → 15초로 완화 (GC pause / swap 페이지 인 마진 확보)
- 단일 cron 실행 내 1회 자동 재시도 추가 (`withRetry` 헬퍼, 2초 대기 후 재시도)
- exit code 정렬: Discord 알림이 발송될 때만 `process.exit(1)` → GitHub 워크플로우 실패 메일이 Discord 알림과 1:1 일치

## Background
2026-05-04 15:45경 디스코드 + 메일 장애 알림이 발생. 원인 분석 결과 EC2 t3.micro(916MB)에서 JVM 힙 일부가 swap-out된 상태에서 일시적 swap thrashing/STW로 health check 응답이 지연된 것으로 추정. 서버 측 조치(`vm.swappiness=10`, swap 회수)와 별개로, 모니터링 스크립트의 false positive 노이즈를 줄이기 위한 개선.

## Changed Files
- `.github/scripts/health-check.mjs`

## Test plan
- [ ] `workflow_dispatch`로 수동 실행 → 정상 응답 시 exit 0 확인
- [ ] 일시적 글리치 시 재시도로 회복 → 알림 안 가는지 확인
- [ ] 2회 연속 실패 시 Discord + GitHub 메일이 함께 발송되는지 확인
- [ ] 임계값 미달(1차 실패) 또는 알림 억제 창 동안에는 메일이 안 오는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)