### PR TITLE
feat: 메인 페이지 디자인 리뉴얼(#686)

### DIFF
--- a/.github/workflows/kimi-review.yml
+++ b/.github/workflows/kimi-review.yml
@@ -55,7 +55,7 @@ jobs:
             --arg pr_body "$PR_BODY" \
             --arg diff "$DIFF_CONTENT" \
             '{
-              model: "moonshotai/kimi-k2.5",
+              model: "moonshotai/kimi-k2-0905",
               messages: [
                 {
                   role: "system",
@@ -81,6 +81,7 @@ jobs:
 
           # 응답에서 리뷰 내용 추출
           REVIEW_CONTENT=$(echo "$REVIEW_RESPONSE" | jq -r '.choices[0].message.content // "리뷰 생성에 실패했습니다."')
+          echo "$REVIEW_RESPONSE" | jq -r '.error // empty'
 
           # GitHub PR에 코멘트 작성
           printf "## 🤖 Kimi Code Review (via OpenRouter)\n\n%s\n\n---\n*Powered by Moonshot AI (kimi-k2.5) via OpenRouter*" "$REVIEW_CONTENT" | gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file -

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -11,15 +11,43 @@ interface Tab {
   code: string
 }
 
+type TabsVariant = 'default' | 'card-pill'
+
 interface TabsProps {
   tabs: readonly Tab[]
   activeTab: string
   onTabChange: (tabId: string) => void
   ariaLabel: string
   excludeTabId?: string
+  variant?: TabsVariant
 }
 
-export default function Tabs({ tabs, activeTab, onTabChange, ariaLabel, excludeTabId }: TabsProps) {
+const VARIANT_STYLES: Record<
+  TabsVariant,
+  { container: string; tab: string; tabActive: string; tabInactive: string }
+> = {
+  default: {
+    container: 'flex w-fit gap-1 md:gap-2.5',
+    tab: 'bg-primary-100 flex-1 cursor-pointer rounded-full px-4 py-2 text-sm whitespace-nowrap md:text-base xl:rounded-2xl xl:bg-white',
+    tabActive: 'bg-primary-500 xl:bg-primary-300 font-bold text-white',
+    tabInactive: 'hover:bg-primary-500 hover:text-white text-gray-900',
+  },
+  'card-pill': {
+    container: 'flex flex-wrap items-center gap-2',
+    tab: 'cursor-pointer rounded-full px-6 py-2.5 font-bold whitespace-nowrap transition-all md:px-8 md:text-base',
+    tabActive: 'bg-[#825500] text-white shadow-sm',
+    tabInactive: 'border border-[#d4c4b2] bg-white text-gray-600 hover:border-[#825500] hover:text-[#825500]',
+  },
+}
+
+export default function Tabs({
+  tabs,
+  activeTab,
+  onTabChange,
+  ariaLabel,
+  excludeTabId,
+  variant = 'default',
+}: TabsProps) {
   const filteredTabs = excludeTabId ? tabs.filter((tab) => tab.id !== excludeTabId) : tabs
   const isMd = useMediaQuery('(min-width: 768px)')
 
@@ -52,29 +80,29 @@ export default function Tabs({ tabs, activeTab, onTabChange, ariaLabel, excludeT
     document.getElementById(nextTab.id)?.focus()
   }
 
+  const styles = VARIANT_STYLES[variant]
+
   return (
-    <div role="tablist" aria-label={ariaLabel} onKeyDown={handleKeyDown} className={cn('flex w-fit gap-1 md:gap-2.5')}>
-      {filteredTabs.map((tab) => (
-        <Button
-          key={tab.id}
-          id={tab.id}
-          size={isMd ? 'md' : 'sm'}
-          role="tab"
-          type="button"
-          onClick={() => onTabChange(tab.id)}
-          className={cn(
-            'bg-primary-100 flex-1 cursor-pointer rounded-full px-4 py-2 text-sm whitespace-nowrap md:text-base xl:rounded-2xl xl:bg-white',
-            activeTab === tab.id
-              ? 'bg-primary-500 xl:bg-primary-300 font-bold text-white'
-              : 'hover:bg-primary-500 hover:text-white text-gray-900'
-          )}
-          aria-selected={activeTab === tab.id}
-          aria-controls={`panel-${tab.code}`}
-          tabIndex={activeTab === tab.id ? 0 : -1}
-        >
-          {tab.label}
-        </Button>
-      ))}
+    <div role="tablist" aria-label={ariaLabel} onKeyDown={handleKeyDown} className={styles.container}>
+      {filteredTabs.map((tab) => {
+        const isActive = activeTab === tab.id
+        return (
+          <Button
+            key={tab.id}
+            id={tab.id}
+            size={isMd ? 'md' : 'sm'}
+            role="tab"
+            type="button"
+            onClick={() => onTabChange(tab.id)}
+            className={cn(styles.tab, isActive ? styles.tabActive : styles.tabInactive)}
+            aria-selected={isActive}
+            aria-controls={`panel-${tab.code}`}
+            tabIndex={isActive ? 0 : -1}
+          >
+            {tab.label}
+          </Button>
+        )
+      })}
     </div>
   )
 }

--- a/src/components/product/ProductCard.tsx
+++ b/src/components/product/ProductCard.tsx
@@ -10,7 +10,6 @@ import { getTradeStatus } from '@/lib/utils/getTradeStatus'
 import { getPetTypeName } from '@/lib/utils/getPetTypeName'
 import { getProductStatus } from '@/lib/utils/getProductStatus'
 import { getProductType } from '@/lib/utils/getProductType'
-import { getTradeStatusColor } from '@/lib/utils/getTradeStatusColor'
 import { useFavorite } from '@/hooks/useFavorite'
 import { cn } from '@/lib/utils/cn'
 
@@ -29,12 +28,26 @@ function ProductCard({ data, 'data-index': dataIndex, vertical = false }: Produc
 
   if (!data) return null
 
-  const { id, title, price, mainImageUrl, petDetailType, productStatus, tradeStatus, createdAt, favoriteCount, viewCount, productType } = data
+  const {
+    id,
+    title,
+    price,
+    mainImageUrl,
+    petDetailType,
+    productStatus,
+    tradeStatus,
+    createdAt,
+    favoriteCount,
+    productType,
+    addressSido,
+    addressGugun,
+  } = data
+  const location = addressGugun || addressSido || ''
   const petTypeName = getPetTypeName(petDetailType)
   const productStatusName = getProductStatus(productStatus)
   const productTradeName = getTradeStatus(tradeStatus)
   const productTypeName = getProductType(productType)
-  const productTradeColor = getTradeStatusColor(tradeStatus)
+
   const handleContentClick = () => {
     if (window.getSelection()?.toString()) return
     window.scrollTo({ top: 0, behavior: 'smooth' })
@@ -43,7 +56,7 @@ function ProductCard({ data, 'data-index': dataIndex, vertical = false }: Produc
 
   return (
     <article
-      className="border-border text-text-primary relative overflow-hidden rounded-xl border bg-white shadow-md transition-shadow duration-200 hover:shadow-xl"
+      className="group relative overflow-hidden rounded-3xl border border-black/5 bg-white shadow-sm transition-all duration-500 hover:-translate-y-1 hover:shadow-xl"
       data-index={dataIndex}
     >
       <Link
@@ -51,18 +64,33 @@ function ProductCard({ data, 'data-index': dataIndex, vertical = false }: Produc
         className="absolute inset-0 z-0"
         aria-label={`${title}, ${price}원, ${productStatusName}, ${petTypeName}, ${productTradeName}`}
       />
-      <div className={cn("relative z-1 flex cursor-pointer", vertical ? "flex-col-reverse" : "flex-row-reverse md:flex-col-reverse")} onClick={handleContentClick}>
-        <ProductInfo title={title} price={price} createdAt={createdAt} favoriteCount={favoriteCount} viewCount={viewCount} productTypeName={productTypeName} isFavorite={isFavorite} onLikeClick={handleToggleFavorite} hideProductType={vertical} />
+      <div
+        className={cn(
+          'relative z-1 flex cursor-pointer',
+          vertical ? 'flex-col-reverse' : 'flex-row-reverse md:flex-col-reverse'
+        )}
+        onClick={handleContentClick}
+      >
+        <ProductInfo
+          title={title}
+          price={price}
+          createdAt={createdAt}
+          favoriteCount={favoriteCount}
+          productTypeName={productTypeName}
+          productStatusName={productStatusName}
+          isFavorite={isFavorite}
+          hideProductType={vertical}
+          location={location}
+        />
         <ProductThumbnail
           imageUrl={mainImageUrl}
           title={title}
-          petTypeName={petTypeName}
           productTypeName={productTypeName}
-          productStatusName={productStatusName}
           tradeStatus={productTradeName}
-          productTradeColor={productTradeColor}
           priority={dataIndex !== undefined && dataIndex < 4}
           vertical={vertical}
+          isFavorite={isFavorite}
+          onLikeClick={handleToggleFavorite}
         />
       </div>
     </article>

--- a/src/components/product/ProductListItem.tsx
+++ b/src/components/product/ProductListItem.tsx
@@ -16,7 +16,7 @@ import { useMediaQuery } from '@/hooks/useMediaQuery'
 import { getPetTypeName } from '@/lib/utils/getPetTypeName'
 import { getProductStatus } from '@/lib/utils/getProductStatus'
 import { getProductType } from '@/lib/utils/getProductType'
-import { ProductBadge } from './components/ProductBadge'
+import { ProductBadge, type ProductBadgeItem } from './components/ProductBadge'
 
 interface ProductListItemProps {
   product: Product
@@ -43,6 +43,13 @@ export function ProductListItem({ product, children }: ProductListItemProps) {
   const tradeStatusText = getTradeStatus(tradeStatus)
   const tradeStatusColor = getTradeStatusColor(tradeStatus)
   const isMd = useMediaQuery('(min-width: 768px)')
+
+  const badgeItems: ProductBadgeItem[] = [
+    { label: petTypeName, tone: 'primary' },
+    ...(productTypeName !== '판매요청'
+      ? [{ label: productStatusName, tone: 'light' as const }]
+      : []),
+  ]
   return (
     <li id={id.toString()} className="w-full">
       <Link
@@ -80,9 +87,7 @@ export function ProductListItem({ product, children }: ProductListItemProps) {
         </div>
         <div className="flex flex-1 items-start">
           <div className="flex h-fit flex-1 flex-col items-start gap-2">
-            {isMd && (
-              <ProductBadge petTypeName={petTypeName} productStatusName={productStatusName} productTypeName={productTypeName} />
-            )}
+            {isMd && <ProductBadge items={badgeItems} />}
             <div className="flex w-full items-start justify-between">
               <div className="flex flex-col gap-1">
                 <h3 className="line-clamp-2 w-full text-[17px] leading-6.5 font-bold md:line-clamp-none md:w-96 md:truncate">

--- a/src/components/product/ProductMetaItem.tsx
+++ b/src/components/product/ProductMetaItem.tsx
@@ -2,18 +2,27 @@ import type { LucideIcon } from 'lucide-react'
 import { cn } from '@/lib/utils/cn'
 
 interface ProductMetaItemProps {
-  icon: LucideIcon
+  icon?: LucideIcon // 선택값 — 없으면 텍스트만 렌더링
   iconSize?: number
   label: string | number
-  className?: string // 색상 커스터마이징
+  className?: string // 래퍼 색상 커스터마이징 (currentColor 상속 기준점)
   textClassName?: string
+  iconClassName?: string // 아이콘 자체 추가 클래스 (fill, stroke 등)
   strokeWidth?: number
 }
 
-export function ProductMetaItem({ icon: Icon, label, iconSize = 16, className = 'text-gray-500', textClassName, strokeWidth }: ProductMetaItemProps) {
+export function ProductMetaItem({
+  icon: Icon,
+  label,
+  iconSize = 16,
+  className = 'text-gray-500',
+  textClassName,
+  iconClassName,
+  strokeWidth,
+}: ProductMetaItemProps) {
   return (
     <div className={`flex items-center gap-1 ${className}`}>
-      <Icon size={iconSize} strokeWidth={strokeWidth} aria-hidden="true" />
+      {Icon ? <Icon size={iconSize} strokeWidth={strokeWidth} className={iconClassName} aria-hidden="true" /> : null}
       <span className={cn('text-xs font-semibold whitespace-nowrap', textClassName)}>{label}</span>
     </div>
   )

--- a/src/components/product/ProductStateFilter.tsx
+++ b/src/components/product/ProductStateFilter.tsx
@@ -4,7 +4,9 @@ import { useState } from 'react'
 import { CONDITION_ITEMS } from '@/constants/constants'
 import { cn } from '@/lib/utils/cn'
 import { useFilterNavigation } from '@/hooks/useFilterNavigation'
+import { CARD_CHIP_STYLES } from './filterChipStyles'
 
+type ProductStateFilterVariant = 'default' | 'card-chip'
 
 interface ProductStateFilterProps {
   headingClassName?: string
@@ -14,6 +16,26 @@ interface ProductStateFilterProps {
   selectedProductStatus?: string | null
   onProductStatusChange?: (status: string | null) => void
   useUrlSync?: boolean // true: URL 동기화 (DetailFilter용), false: 로컬 state (ProductPostForm용)
+  variant?: ProductStateFilterVariant
+}
+
+const VARIANT_STYLES: Record<
+  ProductStateFilterVariant,
+  { container: string; label: string; activeLabel: string; inactiveLabel: string }
+> = {
+  default: {
+    container: 'grid grid-cols-2 flex-wrap gap-2.5 md:flex',
+    label:
+      'flex cursor-pointer flex-col gap-1 rounded-lg bg-primary-50 px-4 py-2 text-center text-xs font-medium md:text-sm',
+    activeLabel: 'bg-primary-300 text-white',
+    inactiveLabel: 'text-gray-900 hover:bg-primary-300 hover:text-white',
+  },
+  'card-chip': {
+    container: CARD_CHIP_STYLES.container,
+    label: CARD_CHIP_STYLES.chip,
+    activeLabel: CARD_CHIP_STYLES.chipActive,
+    inactiveLabel: CARD_CHIP_STYLES.chipInactive,
+  },
 }
 
 export function ProductStateFilter({
@@ -24,30 +46,38 @@ export function ProductStateFilter({
   selectedProductStatus: externalSelectedStatus,
   onProductStatusChange,
   useUrlSync = false,
+  variant = 'default',
 }: ProductStateFilterProps) {
   const { searchParams, pathname, push } = useFilterNavigation()
   const [internalSelectedStatus, setInternalSelectedStatus] = useState<string | null>(null)
 
   // 외부에서 전달된 값이 있으면 사용, 없으면 내부 state 사용
-  const selectedProductStatus = externalSelectedStatus !== undefined ? externalSelectedStatus : internalSelectedStatus
+  const selectedProductStatus =
+    externalSelectedStatus !== undefined ? externalSelectedStatus : internalSelectedStatus
 
   const handleStatusChange = (value: string) => {
-    if (selectedProductStatus === value) return
+    // card-chip variant은 토글 동작 (다시 클릭 시 해제), default는 단방향 선택
+    const nextValue = variant === 'card-chip' && selectedProductStatus === value ? null : value
 
     // URL 동기화 모드일 때만 URL 업데이트
     if (useUrlSync) {
       const params = new URLSearchParams(searchParams.toString())
-      params.set('productStatuses', value)
+      if (nextValue === null) {
+        params.delete('productStatuses')
+      } else {
+        params.set('productStatuses', nextValue)
+      }
       push(`${pathname}?${params.toString()}`)
     }
 
-    // 외부 콜백이 있으면 호출, 없으면 내부 state 업데이트
     if (onProductStatusChange) {
-      onProductStatusChange(value)
+      onProductStatusChange(nextValue)
     } else {
-      setInternalSelectedStatus(value)
+      setInternalSelectedStatus(nextValue)
     }
   }
+
+  const styles = VARIANT_STYLES[variant]
 
   return (
     <div className="flex flex-col gap-2">
@@ -60,37 +90,32 @@ export function ProductStateFilter({
           상품 상태 <span className="text-red-500">*</span>
         </span>
       )}
-      <div
-        className={cn('grid grid-cols-2 flex-wrap gap-2.5 md:flex')}
-        role="radiogroup"
-        aria-labelledby="condition-filter-heading"
-      >
-        {CONDITION_ITEMS.map((item) => (
-          <div key={item.value} className={inputClassname}>
-            <input
-              type="radio"
-              id={`productStatus-${item.value}`}
-              name="productStatus"
-              value={item.value}
-              checked={selectedProductStatus === item.value}
-              onChange={() => handleStatusChange(item.value)}
-              className={cn('peer sr-only')}
-            />
-            <label
-              htmlFor={`productStatus-${item.value}`}
-              className={cn(
-                'flex cursor-pointer flex-col gap-1 rounded-lg px-4 py-2 text-center',
-                'bg-primary-50 text-xs md:text-sm font-medium',
-                selectedProductStatus === item.value
-                  ? 'bg-primary-300 text-white'
-                  : 'hover:bg-primary-300 text-gray-900 hover:text-white'
-              )}
-            >
-              <span>{item.title}</span>
-              {subTitle ? <span className="text-xs font-medium">{item.subtitle}</span> : null}
-            </label>
-          </div>
-        ))}
+      <div className={styles.container} role="radiogroup" aria-labelledby="condition-filter-heading">
+        {CONDITION_ITEMS.map((item) => {
+          const isActive = selectedProductStatus === item.value
+          return (
+            <div key={item.value} className={inputClassname}>
+              <input
+                type="radio"
+                id={`productStatus-${item.value}`}
+                name="productStatus"
+                value={item.value}
+                checked={isActive}
+                onChange={() => handleStatusChange(item.value)}
+                className="peer sr-only"
+              />
+              <label
+                htmlFor={`productStatus-${item.value}`}
+                className={cn(styles.label, isActive ? styles.activeLabel : styles.inactiveLabel)}
+              >
+                <span>{item.title}</span>
+                {subTitle && variant === 'default' ? (
+                  <span className="text-xs font-medium">{item.subtitle}</span>
+                ) : null}
+              </label>
+            </div>
+          )
+        })}
       </div>
     </div>
   )

--- a/src/components/product/components/ProductBadge.tsx
+++ b/src/components/product/components/ProductBadge.tsx
@@ -1,16 +1,40 @@
 import Badge from '@/components/commons/badge/Badge'
+import { cn } from '@/lib/utils/cn'
 
-interface ProductBadgeProps {
-  petTypeName: string
-  productStatusName: string
-  productTypeName?: string
+export type ProductBadgeTone = 'primary' | 'light' | 'info' | 'warning' | 'outline'
+
+const TONE_CLASSES: Record<ProductBadgeTone, string> = {
+  // 기존 ProductListItem 디자인 (진한 브라운 채움)
+  primary: 'rounded-md bg-primary-700 px-1.5 py-1 text-[11px] font-semibold text-white',
+  // 기존 ProductListItem 디자인 (연한 채움)
+  light: 'rounded-md bg-primary-200 px-1.5 py-1 text-[11px] font-semibold text-gray-900',
+  // 새 디자인 판매 (블루 톤)
+  info: 'rounded bg-[#cbe2fa] px-2 py-0.5 text-[10px] font-bold text-[#33495c]',
+  // 새 디자인 판매요청 (앰버 톤)
+  warning: 'rounded border border-[#f0d9a8] bg-[#fff5e0] px-2 py-0.5 text-[10px] font-bold text-[#825500]',
+  // 새 디자인 상품상태 (아웃라인)
+  outline: 'rounded border border-[#d4c4b2] bg-transparent px-2 py-0.5 text-[10px] font-bold text-gray-600',
 }
 
-export function ProductBadge({ petTypeName, productStatusName, productTypeName }: ProductBadgeProps) {
+export interface ProductBadgeItem {
+  label: string
+  tone: ProductBadgeTone
+}
+
+interface ProductBadgeProps {
+  items: ProductBadgeItem[]
+  className?: string
+}
+
+export function ProductBadge({ items, className }: ProductBadgeProps) {
+  if (items.length === 0) return null
   return (
-    <div className="gap-xs z-1 flex flex-wrap">
-      <Badge className="bg-primary-700 px-1.5 py-1 text-[11px] font-semibold text-white">{petTypeName}</Badge>
-      {productTypeName !== '판매요청' ? <Badge className="bg-primary-200 px-1.5 py-1 text-[11px] font-semibold text-gray-900">{productStatusName}</Badge> : null}
+    <div className={cn('z-1 flex flex-wrap items-center gap-xs', className)}>
+      {items.map((item, idx) => (
+        <Badge key={`${item.label}-${idx}`} className={cn('whitespace-nowrap', TONE_CLASSES[item.tone])}>
+          {item.label}
+        </Badge>
+      ))}
     </div>
   )
 }

--- a/src/components/product/components/ProductHeading.tsx
+++ b/src/components/product/components/ProductHeading.tsx
@@ -3,20 +3,15 @@ import { formatPrice } from '@/lib/utils/formatPrice'
 interface ProductHeadingProps {
   title: string
   price: number
-  productTypeName: string
-  hideProductType?: boolean
 }
 
-export function ProductHeading({ title, price, productTypeName, hideProductType = false }: ProductHeadingProps) {
+export function ProductHeading({ title, price }: ProductHeadingProps) {
   return (
-    <div className="flex flex-col gap-1">
-      <span className="line-clamp line-1 text-sm font-normal md:text-base md:font-medium text-gray-900">{title}</span>
-      <p className="flex w-full flex-col">
-        <span className="text-primary-300 max-w-[90%] overflow-hidden font-bold">
-          <span>{formatPrice(price)}</span>원
-        </span>
-        {productTypeName && !hideProductType ? <span className="text-[13px] md:text-sm font-normal md:font-semibold text-gray-500">{productTypeName}</span> : null}
-      </p>
+    <div className="flex flex-col">
+      <h3 className="line-clamp line-1 text-[13px] text-gray-900">{title}</h3>
+      <span className="text-md max-w-[90%] overflow-hidden font-bold text-gray-900">
+        <span>{formatPrice(price)}</span>원
+      </span>
     </div>
   )
 }

--- a/src/components/product/components/ProductInfo.tsx
+++ b/src/components/product/components/ProductInfo.tsx
@@ -1,6 +1,6 @@
 import { getTimeAgo } from '@/lib/utils/getTimeAgo'
 import { ProductHeading } from './ProductHeading'
-import { Clock, Heart, Eye } from 'lucide-react'
+import { ProductBadge, type ProductBadgeItem } from './ProductBadge'
 import { ProductMetaItem } from '../ProductMetaItem'
 
 interface ProductInfoProps {
@@ -8,31 +8,46 @@ interface ProductInfoProps {
   price: number
   createdAt: string
   favoriteCount: number
-  viewCount?: number
   productTypeName: string
+  productStatusName: string
   isFavorite: boolean
-  onLikeClick: (e: React.MouseEvent) => void
   hideProductType?: boolean
+  location?: string
 }
 
-export function ProductInfo({ title, price, createdAt, favoriteCount, viewCount, productTypeName, isFavorite, onLikeClick, hideProductType = false }: ProductInfoProps) {
+export function ProductInfo({
+  title,
+  price,
+  createdAt,
+  favoriteCount,
+  productTypeName,
+  productStatusName,
+  hideProductType = false,
+  location,
+}: ProductInfoProps) {
+  const badgeItems: ProductBadgeItem[] = hideProductType
+    ? []
+    : [
+        { label: productTypeName, tone: productTypeName === '판매요청' ? 'warning' : 'info' },
+        { label: productStatusName, tone: 'outline' },
+      ]
+
+  const metaTextClass = 'text-xs font-medium'
+
   return (
-    <div className="flex flex-[3] flex-col justify-between gap-5 bg-white p-3 md:flex-none">
-      <ProductHeading title={title} price={price} productTypeName={productTypeName} hideProductType={hideProductType} />
-      <div className="flex w-full items-center justify-between">
-        <ProductMetaItem icon={Clock} label={getTimeAgo(createdAt)} iconSize={13} className="text-gray-400" textClassName="text-[13px] md:text-sm font-normal" />
-        <div className="flex items-center gap-2">
-          {viewCount !== undefined ? (
-            <span className="flex items-center gap-1 text-gray-400">
-              <Eye size={13} aria-hidden="true" />
-              <span className="text-[13px] md:text-sm font-normal">{viewCount}</span>
-            </span>
-          ) : null}
-          <button type="button" className="pointer-events-auto flex cursor-pointer items-center gap-1 text-gray-400" onClick={onLikeClick} aria-label="찜하기">
-            <Heart size={13} color={isFavorite ? '#fc8181' : 'currentColor'} fill={isFavorite ? '#fc8181' : 'none'} aria-hidden="true" />
-            <span className="text-[13px] md:text-sm font-normal">{favoriteCount}</span>
-          </button>
-        </div>
+    <div className="flex flex-3 flex-col gap-2 bg-white p-3 md:flex-none md:p-4">
+      <ProductBadge items={badgeItems} />
+      <ProductHeading title={title} price={price} />
+      {/* 메타 (레퍼런스 패턴): 은평구 · 좋아요 15  ........  3분 전 */}
+      <div className="mt-auto flex w-full items-center gap-1 text-gray-500">
+        {location ? (
+          <>
+            <ProductMetaItem label={location} textClassName={metaTextClass} />
+            <span className={metaTextClass} aria-hidden="true">·</span>
+          </>
+        ) : null}
+        <ProductMetaItem label={`좋아요 ${favoriteCount}`} textClassName={metaTextClass} />
+        <ProductMetaItem label={getTimeAgo(createdAt)} className="ml-auto text-gray-500" textClassName={metaTextClass} />
       </div>
     </div>
   )

--- a/src/components/product/components/ProductThumbnail.tsx
+++ b/src/components/product/components/ProductThumbnail.tsx
@@ -1,44 +1,54 @@
 'use client'
 
 import { useCallback, useState } from 'react'
-import { ProductBadge } from './ProductBadge'
-import Badge from '@/components/commons/badge/Badge'
+import { Heart } from 'lucide-react'
 import { cn } from '@/lib/utils/cn'
 import { getImageSrcSet, IMAGE_SIZES, toResizedWebpUrl, PLACEHOLDER_IMAGES } from '@/lib/utils/imageUrl'
+import Button from '@/components/commons/button/Button'
 
 interface ProductThumbnailProps {
   imageUrl: string
   title: string
-  petTypeName: string
-  productStatusName: string
   productTypeName: string
   tradeStatus: string | null
-  productTradeColor: string
   priority?: boolean
   vertical?: boolean
+  isFavorite: boolean
+  onLikeClick: (e: React.MouseEvent) => void
 }
 
 export function ProductThumbnail({
   imageUrl,
   title,
-  petTypeName,
-  productStatusName,
-  tradeStatus,
   productTypeName,
-  productTradeColor,
+  tradeStatus,
   priority = false,
   vertical = false,
+  isFavorite,
+  onLikeClick,
 }: ProductThumbnailProps) {
-  const [imgErrorStep, setImgErrorStep] = useState(0) // 0: CDN, 1: 원본, 2: placeholder
+  const [imgErrorStep, setImgErrorStep] = useState(0)
+
+  const handleImageRef = useCallback(
+    (img: HTMLImageElement | null) => {
+      if (img && img.complete && img.naturalWidth === 0 && imgErrorStep < 2) {
+        setImgErrorStep((prev) => prev + 1)
+      }
+    },
+    [imgErrorStep]
+  )
 
   const getDisplayTradeStatus = () => {
     if (productTypeName === '판매요청') {
       if (tradeStatus === '판매완료') return '요청완료'
-      if (tradeStatus === null || tradeStatus === '') return '요청중'
+      if (!tradeStatus) return '요청중'
     }
     return tradeStatus || ''
   }
   const displayTradeStatus = getDisplayTradeStatus()
+  const isOverlayShown =
+    tradeStatus === '예약중' || tradeStatus === '판매완료' || displayTradeStatus === '요청완료'
+  const overlayBg = tradeStatus === '예약중' ? 'bg-black/40' : 'bg-black/60'
 
   const getSrc = () => {
     if (!imageUrl || imgErrorStep >= 2) return PLACEHOLDER_IMAGES[800]
@@ -51,22 +61,22 @@ export function ProductThumbnail({
     return getImageSrcSet(imageUrl)
   }
 
+  const handleHeartClick = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    e.preventDefault()
+    onLikeClick(e)
+  }
+
   return (
-    <div className={cn('relative overflow-hidden', vertical ? 'flex-none pb-[75%]' : 'flex-2 pb-[35%] md:flex-none md:pb-[75%]')}>
-      <div className="top-sm px-sm absolute z-1">
-        <ProductBadge petTypeName={petTypeName} productStatusName={productStatusName} productTypeName={productTypeName} />
-      </div>
-      <Badge className={cn('bottom-sm right-sm absolute z-1 text-xs text-white', productTradeColor)}>{displayTradeStatus}</Badge>
+    <div
+      className={cn(
+        'relative overflow-hidden bg-[#f6efe2]',
+        vertical ? 'flex-none pb-[75%]' : 'flex-2 pb-[35%] md:flex-none md:pb-[75%]'
+      )}
+    >
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
-        ref={useCallback(
-          (img: HTMLImageElement | null) => {
-            if (img && img.complete && img.naturalWidth === 0 && imgErrorStep < 2) {
-              setImgErrorStep((prev) => prev + 1)
-            }
-          },
-          [imgErrorStep]
-        )}
+        ref={handleImageRef}
         alt={title}
         src={getSrc()}
         srcSet={getSrcSet()}
@@ -74,11 +84,34 @@ export function ProductThumbnail({
         fetchPriority={priority ? 'high' : 'auto'}
         loading={priority ? 'eager' : 'lazy'}
         onError={() => {
-          if (imgErrorStep < 2) {
-            setImgErrorStep((prev) => prev + 1)
-          }
+          if (imgErrorStep < 2) setImgErrorStep((prev) => prev + 1)
         }}
-        className="t-0 l-0 absolute h-full w-full object-cover transition-all duration-300 ease-in-out group-hover:scale-105"
+        className="absolute top-0 left-0 h-full w-full object-cover transition-transform duration-700 group-hover:scale-110"
+      />
+
+      {/* 거래상태 중앙 큰 오버레이 (모바일/데스크탑 동일) */}
+      {isOverlayShown ? (
+        <div className={cn('absolute inset-0 z-10 flex items-center justify-center', overlayBg)}>
+          <span className="rounded-full bg-white/95 px-4 py-1.5 text-xs font-bold text-gray-900 shadow-md">
+            {displayTradeStatus}
+          </span>
+        </div>
+      ) : null}
+
+      {/* 찜 토글 버튼 (이미지 우상단 오버레이) */}
+      <Button
+        type="button"
+        size="sm"
+        icon={Heart}
+        iconProps={{
+          size: 18,
+          strokeWidth: 2,
+          className: cn(isFavorite ? 'fill-[#fc8181] stroke-[#fc8181]' : 'fill-none stroke-gray-600'),
+          'aria-hidden': true,
+        }}
+        onClick={handleHeartClick}
+        aria-label={isFavorite ? '찜 해제' : '찜하기'}
+        className="pointer-events-auto absolute top-2 right-2 z-20 h-8 w-8 cursor-pointer rounded-full bg-white/90 p-0 shadow-sm backdrop-blur-md transition-all hover:bg-white md:top-3 md:right-3 md:h-9 md:w-9"
       />
     </div>
   )

--- a/src/components/product/filterChipStyles.ts
+++ b/src/components/product/filterChipStyles.ts
@@ -1,0 +1,16 @@
+/**
+ * 새 홈 디자인의 카드형 필터 칩 스타일 (베이지/브라운 톤).
+ *
+ * `ProductStateFilter`, `PriceFilter` 등 chip 형태로 단일 선택 가능한
+ * 필터들이 `variant="card-chip"` 모드일 때 공통으로 사용한다.
+ *
+ * 색상 raw hex(`#825500` 등)는 차후 디자인 토큰화 작업(옵션 B)에서
+ * `bg-brand-700` 등 Tailwind 유틸로 일괄 교체될 예정.
+ */
+export const CARD_CHIP_STYLES = {
+  container: 'flex flex-wrap gap-2',
+  chip: 'cursor-pointer rounded-lg border px-3 py-2 text-[13px] font-medium whitespace-nowrap transition-all',
+  chipActive: 'border-[#825500] bg-[#825500] text-white',
+  chipInactive:
+    'border-[#d4c4b2] bg-[#f6f3f2] text-gray-700 hover:border-[#825500] hover:text-[#825500]',
+} as const

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -211,9 +211,9 @@ export interface LocationFilter {
 // ========== 상품상태 관련 상수 ==========
 export const SORT_TYPE = [
   { id: 'createdAt', label: '최신순' },
-  { id: 'orderedLowPriced', label: '가격 낮은순' },
-  { id: 'orderedHighPriced', label: '가격 높은순' },
-  { id: 'favoriteCount', label: '찜 많은순' },
+  { id: 'orderedLowPriced', label: '저가순' },
+  { id: 'orderedHighPriced', label: '고가순' },
+  { id: 'favoriteCount', label: '찜 많은 순' },
 ]
 export type SORT_LABELS = (typeof SORT_TYPE)[number]['label']
 

--- a/src/features/home/Home.tsx
+++ b/src/features/home/Home.tsx
@@ -2,7 +2,6 @@
 
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { useState, useCallback, useMemo } from 'react'
-import Tabs from '@/components/Tabs'
 import { DetailFilter } from '@/features/home/components/filter/DetailFilter'
 import { ProductsSection } from '@/features/home/components/product-section/ProductsSection'
 import { fetchGraphQL } from '@/lib/api/graphql'
@@ -10,13 +9,13 @@ import { useIntersectionObserver } from '@/hooks/useIntersectionObserver'
 import { PRODUCT_TYPE_TABS, PET_TYPE_TABS, type ProductTypeTabId, SORT_TYPE, type PetTypeTabId } from '@/constants/constants'
 import { PetTypeFilter } from './components/filter/PetTypeFilter'
 import { CategoryFilter } from './components/filter/CategoryFilter'
+import HomeHero from './components/HomeHero'
+import HomeLoadingState from './components/HomeLoadingState'
 import Link from 'next/link'
 import { useFilterNavigation } from '@/hooks/useFilterNavigation'
 import { Plus } from 'lucide-react'
-import { buttonVariants, iconSizeMap } from '@/components/commons/button/buttonClass'
-import { cn } from '@/lib/utils/cn'
+import Button from '@/components/commons/button/Button'
 import { useUserStore } from '@/store/userStore'
-import { useMediaQuery } from '@/hooks/useMediaQuery'
 import { Z_INDEX } from '@/constants/ui'
 import HomeSkeleton from './components/product-section/HomeSkeleton'
 import { productListQueryKey, extractProductSearchParams } from '@/lib/queries/productQueryKeys'
@@ -25,7 +24,6 @@ function Home() {
   const { isLogin } = useUserStore()
   const hasHydrated = useUserStore((state) => state._hasHydrated)
   const isLoggedIn = hasHydrated && isLogin()
-  const isMd = useMediaQuery('(min-width: 768px)')
   const { searchParams, pathname, push } = useFilterNavigation()
 
   // URL에서 탭 초기값 결정 (시각적 표시용)
@@ -91,7 +89,7 @@ function Home() {
   }, [sortBy, sortOrder])
 
   const hasDetailFilter = searchParams.has('productStatuses') || searchParams.has('minPrice') || searchParams.has('addressSido')
-  const [isDetailFilterOpen, setIsDetailFilterOpen] = useState(hasDetailFilter)
+  const [isDetailFilterOpen, setIsDetailFilterOpen] = useState(true)
   const [prevSearchParams, setPrevSearchParams] = useState(searchParams)
 
   if (searchParams !== prevSearchParams) {
@@ -128,7 +126,7 @@ function Home() {
         `
         query Products($page: Int!, $size: Int!, $productType: String, $productStatuses: String, $minPrice: Int, $maxPrice: Int, $addressSido: String, $addressGugun: String, $categories: String, $petType: String, $petDetailType: String, $keyword: String, $sortBy: String, $sortOrder: String) {
           products(page: $page, size: $size, productType: $productType, productStatuses: $productStatuses, minPrice: $minPrice, maxPrice: $maxPrice, addressSido: $addressSido, addressGugun: $addressGugun, categories: $categories, petType: $petType, petDetailType: $petDetailType, keyword: $keyword, sortBy: $sortBy, sortOrder: $sortOrder) {
-            content { id title price mainImageUrl petDetailType productStatus productType tradeStatus createdAt viewCount favoriteCount isFavorite }
+            content { id title price mainImageUrl petDetailType productStatus productType tradeStatus createdAt viewCount favoriteCount isFavorite addressSido addressGugun }
             page totalPages totalElements hasNext
           }
         }
@@ -194,102 +192,62 @@ function Home() {
   const totalElements = data?.pages?.[0]?.totalElements || 0
 
   if (!hasHydrated) {
-    return (
-      <div className="pb-4xl pt-6">
-        <h1 className="sr-only">커들마켓</h1>
-        <div className="px-lg mx-auto max-w-7xl">
-          <div className="flex flex-col gap-12">
-            <section className="flex flex-col gap-7">
-              {/* 필터 스켈레톤 */}
-              <div className="flex flex-col gap-3">
-                <div className="h-5 w-20 animate-pulse rounded bg-gray-200" />
-                <div className="flex gap-2">
-                  {[...Array(6)].map((_, i) => (
-                    <div key={i} className="h-10 w-16 animate-pulse rounded-full bg-gray-200" />
-                  ))}
-                </div>
-              </div>
-              <div className="flex flex-col gap-3">
-                <div className="h-5 w-20 animate-pulse rounded bg-gray-200" />
-                <div className="flex gap-2">
-                  {[...Array(5)].map((_, i) => (
-                    <div key={i} className="h-10 w-20 animate-pulse rounded-full bg-gray-200" />
-                  ))}
-                </div>
-              </div>
-              {/* 세부 필터 스켈레톤 */}
-              <div className="flex items-center justify-between rounded-lg border border-gray-200 px-4 py-3">
-                <div className="flex items-center gap-2">
-                  <div className="h-5 w-5 animate-pulse rounded bg-gray-200" />
-                  <div className="h-5 w-24 animate-pulse rounded bg-gray-200" />
-                  <div className="h-5 w-32 animate-pulse rounded bg-gray-200" />
-                </div>
-                <div className="flex items-center gap-2">
-                  <div className="h-5 w-16 animate-pulse rounded bg-gray-200" />
-                  <div className="h-5 w-5 animate-pulse rounded bg-gray-200" />
-                </div>
-              </div>
-            </section>
-            <section className="flex flex-col gap-2.5">
-              {/* 탭 스켈레톤 */}
-              <div className="flex gap-4 border-b-[1.5px] border-b-primary-200 pb-1">
-                {['전체', '판매', '판매요청'].map((label) => (
-                  <div key={label} className="h-8 w-16 animate-pulse rounded bg-gray-200" />
-                ))}
-              </div>
-              <HomeSkeleton />
-            </section>
-          </div>
-        </div>
-      </div>
-    )
+    return <HomeLoadingState />
   }
 
   if (error && !isLoading) {
     return (
-      <div className="flex min-h-screen items-center justify-center">
-        <div className="flex flex-col items-center gap-4">
-          <p>상품을 불러올 수 없습니다</p>
-          <button onClick={() => refetch()} className="text-blue-600 hover:text-blue-800">
-            다시 시도
-          </button>
+      <>
+        <HomeHero />
+        <div className="flex min-h-100 items-center justify-center bg-white">
+          <div className="flex flex-col items-center gap-4">
+            <p>상품을 불러올 수 없습니다</p>
+            <Button variant="link" onClick={() => refetch()} className="font-bold text-[#825500] hover:text-[#633f00]">
+              다시 시도
+            </Button>
+          </div>
         </div>
-      </div>
+      </>
     )
   }
 
   return (
     <>
-      <div className="pb-4xl pt-6">
-        <h1 className="sr-only">커들마켓</h1>
-        <div className="px-lg mx-auto max-w-7xl">
-          <div className="flex flex-col gap-12">
-            <section aria-label="상품 필터" className="flex flex-col gap-7" data-nosnippet>
+      <HomeHero />
+      <div className="bg-white">
+        <div className="mx-auto max-w-[1280px] px-6 pt-12 pb-24 md:px-8 md:pt-16">
+          <h1 className="sr-only">커들마켓</h1>
+          <div className="flex flex-col gap-10">
+            {/* Pet category & filters section */}
+            <section aria-label="상품 필터" className="flex flex-col gap-6" data-nosnippet>
+              <div className="flex flex-col gap-1">
+                <h2 className="text-md flex flex-wrap items-center gap-2 font-medium text-gray-900">
+                  우리 아이 맞춤 검색
+                  <span className="text-sm font-normal text-[#825500]/70">어떤 아이와 함께하시나요?</span>
+                </h2>
+              </div>
               <PetTypeFilter
                 activeTab={activePetTypeTab}
                 onTabChange={handlePetTypeTabChange}
                 selectedDetailPet={selectedDetailPet}
-                headingClassName="text-base font-semibold"
               />
-              <CategoryFilter selectedCategory={selectedCategory} headingClassName="text-base font-semibold" />
+              <CategoryFilter selectedCategory={selectedCategory} />
+            </section>
+
+            {/* Detail filter section */}
+            <section aria-label="세부 필터" data-nosnippet>
               <DetailFilter
                 isOpen={isDetailFilterOpen}
                 onToggle={handleDetailFilterToggle}
                 selectedProductStatus={selectedProductStatus}
                 selectedPriceRange={selectedProductPrice}
                 filterReset={filterReset}
-                headingClassName="text-sm font-medium"
               />
             </section>
-            <section aria-label="상품 목록" className="flex flex-col gap-2.5">
-              <div className="border-b-[1.5px] border-b-primary-200 pb-1" data-nosnippet>
-                <Tabs
-                  tabs={PRODUCT_TYPE_TABS}
-                  activeTab={activeProductTypeTab}
-                  onTabChange={handleProductTypeTabChange}
-                  ariaLabel="상품 타입 분류"
-                />
-              </div>
+
+            {/* Product list section */}
+            <section aria-label="상품 목록" className="flex flex-col gap-6">
+              <h2 className="heading-h3 text-gray-900">상품 목록</h2>
               {isLoading && allProducts.length === 0 ? (
                 <HomeSkeleton />
               ) : (
@@ -298,6 +256,7 @@ function Home() {
                   totalElements={totalElements}
                   activeTab={activeProductTypeTab}
                   selectedSort={selectedSort}
+                  onTabChange={handleProductTypeTabChange}
                 />
               )}
             </section>
@@ -308,26 +267,23 @@ function Home() {
           {isFetchingNextPage ? (
             <div className="flex items-center justify-center py-8">
               <div role="status" aria-live="polite">
-                <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-blue-600" aria-hidden="true"></div>
+                <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-[#825500]" aria-hidden="true"></div>
                 <span className="sr-only">상품 로딩 중</span>
               </div>
             </div>
           ) : null}
         </div>
       </div>
+
       {isLoggedIn ? (
-        <div className={`fixed right-10 bottom-5 max-md:bottom-18 max-md:right-4 ${Z_INDEX.FLOATING_BUTTON}`}>
-          <Link
-            href="/product-post"
-            className={cn(
-              buttonVariants({ size: isMd ? 'lg' : 'md', iconPosition: 'left' }),
-              'bg-primary-300 cursor-pointer text-white'
-            )}
-          >
-            <Plus size={iconSizeMap[isMd ? 'lg' : 'md']} />
-            상품등록
-          </Link>
-        </div>
+        <Link
+          href="/product-post"
+          className={`fixed right-8 bottom-8 flex items-center gap-2 rounded-full bg-[#825500] px-5 py-3.5 text-white shadow-lg transition-all hover:brightness-110 active:scale-95 max-md:right-4 max-md:bottom-20 md:px-6 md:py-4 ${Z_INDEX.FLOATING_BUTTON}`}
+          aria-label="상품 등록"
+        >
+          <Plus size={20} strokeWidth={2.5} />
+          <span className="text-sm font-bold md:text-base">상품 등록</span>
+        </Link>
       ) : null}
     </>
   )

--- a/src/features/home/components/HomeHero.tsx
+++ b/src/features/home/components/HomeHero.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+export default function HomeHero() {
+  return (
+    <section
+      aria-label="히어로"
+      className="relative h-130 w-full overflow-hidden md:h-162.5"
+      style={{ backgroundColor: '#e2cbb2' }}
+    >
+      <div className="pointer-events-none absolute inset-0 flex items-end justify-center">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          alt="반려동물과 함께하는 따뜻한 마켓"
+          src="https://lh3.googleusercontent.com/aida-public/AB6AXuDxuIgWc6PX7n6vl_OVSBIn92DU2D7zwOVChB9mNdgVh-eKQln4K4hdS2e0bKV7TE-QvJ55mbChSzWsvS6S56fri1iH9jGIPNYog400flI7tXFX3_SOM4F6o3avX-LVPv0FgXnNISCGnA3-pJ0_BNIRWfh6FJvqPTHldSAXHYRmTLO8F-Dr_REELfi_jH2X2PjvHtPNWI8zN2m8_0wuwciJ8P2WQN4N972ETvicm7qrvxLkuZwZM0U0wtm20SC-7Z3bsd8Emu8q1E5H"
+          className="h-full w-full object-cover object-bottom"
+        />
+      </div>
+    </section>
+  )
+}

--- a/src/features/home/components/HomeLoadingState.tsx
+++ b/src/features/home/components/HomeLoadingState.tsx
@@ -1,0 +1,93 @@
+import HomeSkeleton from './product-section/HomeSkeleton'
+import HomeHero from './HomeHero'
+
+/**
+ * Home 컴포넌트가 클라이언트 하이드레이션 대기 중일 때 보여주는 스켈레톤.
+ * 실제 레이아웃의 섹션 구조와 1:1 매칭되도록 구성:
+ *   1. PetTypeFilter (탭바 + 칩)
+ *   2. CategoryFilter (아이콘 그리드)
+ *   3. DetailFilter (흰 카드 + 3섹션)
+ *   4. ProductsSection (탭 + 정렬 + 상품 그리드)
+ */
+export default function HomeLoadingState() {
+  return (
+    <>
+      <HomeHero />
+      <div className="bg-white">
+        <div className="mx-auto max-w-[1280px] px-6 pt-12 pb-24 md:px-8 md:pt-16">
+          <h1 className="sr-only">커들마켓</h1>
+          <div className="flex flex-col gap-10">
+            {/* "우리 아이 맞춤 검색" 영역 (헤딩 + PetTypeFilter + CategoryFilter) */}
+            <section className="flex flex-col gap-6">
+              <h2 className="text-md flex flex-wrap items-center gap-2 text-gray-900">
+                우리 아이 맞춤 검색
+                <span className="text-sm font-normal text-[#825500]/70 md:text-base">어떤 아이와 함께하시나요?</span>
+              </h2>
+
+              {/* PetTypeFilter: 탭바 + 칩 */}
+              <div className="flex flex-col gap-5">
+                <div className="flex gap-6 overflow-hidden border-b border-[#d4c4b2] pb-2">
+                  {[...Array(6)].map((_, i) => (
+                    <div key={i} className="h-7 w-16 shrink-0 animate-pulse rounded bg-gray-200" />
+                  ))}
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {[...Array(8)].map((_, i) => (
+                    <div key={i} className="h-10 w-20 animate-pulse rounded-full bg-gray-200" />
+                  ))}
+                </div>
+              </div>
+
+              {/* CategoryFilter: 아이콘 그리드 */}
+              <div className="flex items-start gap-4 overflow-hidden md:gap-6">
+                {[...Array(9)].map((_, i) => (
+                  <div key={i} className="flex min-w-18 shrink-0 flex-col items-center gap-2">
+                    <div className="h-16 w-16 animate-pulse rounded-2xl bg-gray-200 md:h-18 md:w-18" />
+                    <div className="h-3 w-12 animate-pulse rounded bg-gray-200" />
+                  </div>
+                ))}
+              </div>
+            </section>
+
+            {/* DetailFilter: 흰 카드 + 3섹션 (상품 상태 / 가격대 / 지역) */}
+            <section
+              aria-hidden="true"
+              className="rounded-3xl border border-[#d4c4b2] bg-white px-6 py-6 shadow-sm md:px-10 md:py-8"
+            >
+              <div className="flex flex-col gap-8 md:flex-row md:gap-10">
+                {[...Array(3)].map((_, sectionIdx) => (
+                  <div key={sectionIdx} className="flex flex-1 flex-col gap-3">
+                    <div className="h-4 w-16 animate-pulse rounded bg-gray-200" />
+                    <div className="flex flex-wrap gap-2">
+                      {[...Array(4)].map((_, i) => (
+                        <div key={i} className="h-9 w-20 animate-pulse rounded-lg bg-gray-200" />
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </section>
+
+            {/* ProductsSection: 헤딩 + 탭/정렬 + 상품 그리드 */}
+            <section className="flex flex-col gap-6">
+              <h2 className="heading-h3 text-gray-900">상품 목록</h2>
+              <div className="flex flex-col justify-between gap-4 border-b border-[#d4c4b2] pb-5 md:flex-row md:items-center">
+                <div className="flex items-center gap-2">
+                  {[...Array(3)].map((_, i) => (
+                    <div key={i} className="h-10 w-24 animate-pulse rounded-full bg-gray-200" />
+                  ))}
+                </div>
+                <div className="flex items-center gap-3">
+                  {[...Array(4)].map((_, i) => (
+                    <div key={i} className="h-4 w-12 animate-pulse rounded bg-gray-200" />
+                  ))}
+                </div>
+              </div>
+              <HomeSkeleton />
+            </section>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/features/home/components/filter/CategoryFilter.tsx
+++ b/src/features/home/components/filter/CategoryFilter.tsx
@@ -1,55 +1,108 @@
 'use client'
 
-import Button from '@/components/commons/button/Button'
 import { PRODUCT_CATEGORIES } from '@/constants/constants'
 import { cn } from '@/lib/utils/cn'
 import { useFilterNavigation } from '@/hooks/useFilterNavigation'
+import {
+  Cookie,
+  Gamepad2,
+  Home,
+  HeartPulse,
+  Shirt,
+  Backpack,
+  Scissors,
+  MoreHorizontal,
+  Sparkles,
+  type LucideIcon,
+} from 'lucide-react'
+import Button from '@/components/commons/button/Button'
 
 interface CategoryFilterProps {
   headingClassName?: string
   selectedCategory?: string | null
 }
 
-export function CategoryFilter({ headingClassName, selectedCategory }: CategoryFilterProps) {
+const CATEGORY_ICONS: Record<string, LucideIcon> = {
+  FOOD: Cookie,
+  TOY: Gamepad2,
+  HOUSE: Home,
+  HEALTH: HeartPulse,
+  CLOTHING: Shirt,
+  WALKING: Backpack,
+  GROOMING: Scissors,
+  ETC: MoreHorizontal,
+}
+
+// "전체" 항목을 맨 앞에 두기 위한 sentinel — code: null
+const ALL_ITEM = { code: null, name: '전체', icon: Sparkles } as const
+
+interface CategoryItem {
+  code: string | null
+  name: string
+  icon: LucideIcon
+}
+
+export function CategoryFilter({ selectedCategory }: CategoryFilterProps) {
   const { searchParams, pathname, push } = useFilterNavigation()
 
-  const handleProductCategory = (e: React.MouseEvent, category: string) => {
-    e.stopPropagation() // 이벤트 버블링 방지
-
-    // 같은 카테고리 클릭 시 선택 해제, 다른 카테고리 클릭 시 선택
-    const isDeselecting = selectedCategory === category
-
+  const handleSelect = (e: React.MouseEvent, code: string | null) => {
+    e.stopPropagation()
     const params = new URLSearchParams(searchParams.toString())
-    if (isDeselecting) {
-      params.delete('categories') // 선택 해제 시 URL에서 제거
+    if (code === null || selectedCategory === code) {
+      params.delete('categories')
     } else {
-      params.set('categories', category) // 선택 시 URL에 추가
+      params.set('categories', code)
     }
     push(`${pathname}?${params.toString()}`)
   }
+
+  const items: CategoryItem[] = [
+    ALL_ITEM,
+    ...PRODUCT_CATEGORIES.map((category) => ({
+      code: category.code,
+      name: category.name,
+      icon: CATEGORY_ICONS[category.code] ?? MoreHorizontal,
+    })),
+  ]
+
   return (
-    <div className="flex flex-col gap-2.5">
-      <h2 id="category-filter-heading" className={headingClassName ?? 'heading-h4'}>
-        상품 카테고리
-      </h2>
-      <div className="flex flex-wrap gap-1.5" role="group" aria-labelledby="category-filter-heading">
-        {PRODUCT_CATEGORIES?.map((category) => (
-          <Button
-            key={category.code}
-            type="button"
-            size="sm"
-            className={cn(
-              'border-primary-200 cursor-pointer border px-2.5 py-0.75 text-[13px] font-normal md:font-medium',
-              selectedCategory === category.code
-                ? 'bg-primary-300 font-bold text-white'
-                : 'hover:bg-primary-300 text-gray-900 hover:text-white'
-            )}
-            onClick={(e) => handleProductCategory(e, category.code)}
-            aria-pressed={selectedCategory === category.code}
-          >
-            {category.name}
-          </Button>
-        ))}
+    <div className="flex flex-col gap-4">
+      <div
+        className="scrollbar-hide -mx-2 flex items-start gap-4 overflow-x-auto px-2 pb-2 md:gap-6"
+        role="group"
+        aria-label="상품 카테고리"
+      >
+        {items.map((item) => {
+          const Icon = item.icon
+          const isActive = item.code === null ? !selectedCategory : selectedCategory === item.code
+          return (
+            <Button
+              key={item.code ?? 'all'}
+              type="button"
+              size="sm"
+              onClick={(e) => handleSelect(e, item.code)}
+              aria-pressed={isActive}
+              className="group flex min-w-18 shrink-0 flex-col items-center gap-2 rounded-none bg-transparent p-0 transition-all hover:bg-transparent"
+            >
+              <span
+                className={cn(
+                  'flex h-16 w-16 items-center justify-center rounded-2xl transition-all group-hover:-translate-y-1 md:h-18 md:w-18',
+                  isActive ? 'bg-[#825500] text-white shadow-md' : 'bg-[#f6efe2] text-[#825500] group-hover:bg-[#ecdcc3]'
+                )}
+              >
+                <Icon size={28} strokeWidth={2} />
+              </span>
+              <span
+                className={cn(
+                  'whitespace-nowrap transition-colors md:text-sm',
+                  isActive ? 'font-bold text-[#825500]' : 'font-medium text-gray-600 group-hover:text-[#825500]'
+                )}
+              >
+                {item.name}
+              </span>
+            </Button>
+          )
+        })}
       </div>
     </div>
   )

--- a/src/features/home/components/filter/DetailFilter.tsx
+++ b/src/features/home/components/filter/DetailFilter.tsx
@@ -1,9 +1,13 @@
+'use client'
+
 import { memo } from 'react'
-import { DetailFilterButton } from './DetailFilterButton'
+import { type PriceRange } from '@/constants/constants'
+import { RotateCcw } from 'lucide-react'
+import Button from '@/components/commons/button/Button'
 import { ProductStateFilter } from '@/components/product/ProductStateFilter'
 import { PriceFilter } from './PriceFilter'
 import { LocationFilter } from './LocationFilter'
-import type { PriceRange } from '@/constants/constants'
+import { DetailFilterButton } from './DetailFilterButton'
 
 interface DetailFilterProps {
   isOpen: boolean
@@ -14,33 +18,58 @@ interface DetailFilterProps {
   headingClassName?: string
 }
 
+const SECTION_HEADING_CLASS = 'mb-1 text-[13px] font-bold text-gray-900'
+const FILTER_CONTENT_ID = 'detail-filter-content'
+
 export const DetailFilter = memo(function DetailFilterSection({
   isOpen,
   onToggle,
   selectedProductStatus,
   selectedPriceRange,
   filterReset,
-  headingClassName,
 }: DetailFilterProps) {
   return (
-    <div className="flex flex-col gap-2.5">
-      <h3 className="sr-only">세부필터</h3>
+    <div className="flex flex-col gap-3">
       <DetailFilterButton
         isOpen={isOpen}
-        onClick={() => onToggle(!isOpen)}
-        ariaControls="detail-filter-content"
+        onToggle={() => onToggle(!isOpen)}
         filterReset={filterReset}
+        ariaControls={FILTER_CONTENT_ID}
       />
+
       {isOpen ? (
         <div
-          className="bg-primary-100 flex flex-col gap-3.5 rounded-lg px-3 py-2.5 md:flex-row md:gap-10"
+          id={FILTER_CONTENT_ID}
           role="group"
-          id="detail-filter-content"
           aria-label="세부 필터 옵션"
+          className="relative rounded-3xl border border-[#d4c4b2] bg-white px-6 py-6 shadow-sm md:px-10 md:py-8"
         >
-          <ProductStateFilter selectedProductStatus={selectedProductStatus} useUrlSync headingClassName={headingClassName} />
-          <PriceFilter selectedPriceRange={selectedPriceRange} headingClassName={headingClassName} />
-          <LocationFilter headingClassName={headingClassName} />
+          {/* 데스크탑 필터 초기화 (카드 우상단 액션) */}
+          <Button
+            type="button"
+            variant="link"
+            size="sm"
+            onClick={filterReset}
+            className="absolute top-6 right-6 hidden cursor-pointer items-center gap-1 p-0 text-xs font-medium text-gray-500 hover:text-[#825500] hover:no-underline md:flex md:top-8 md:right-10"
+          >
+            <RotateCcw size={12} aria-hidden="true" />
+            필터 초기화
+          </Button>
+
+          <div className="flex flex-col gap-8 md:flex-row md:items-start md:justify-between md:gap-10">
+            <ProductStateFilter
+              variant="card-chip"
+              useUrlSync
+              selectedProductStatus={selectedProductStatus}
+              headingClassName={SECTION_HEADING_CLASS}
+            />
+            <PriceFilter
+              variant="card-chip"
+              selectedPriceRange={selectedPriceRange}
+              headingClassName={SECTION_HEADING_CLASS}
+            />
+            <LocationFilter variant="card-chip" headingClassName={SECTION_HEADING_CLASS} />
+          </div>
         </div>
       ) : null}
     </div>

--- a/src/features/home/components/filter/DetailFilterButton.tsx
+++ b/src/features/home/components/filter/DetailFilterButton.tsx
@@ -1,58 +1,50 @@
 'use client'
 
-import { Funnel as FilterIcon, ChevronDown as DownArrow } from 'lucide-react'
+import { ChevronDown, RotateCcw } from 'lucide-react'
 import { cn } from '@/lib/utils/cn'
 import Button from '@/components/commons/button/Button'
-import { useMediaQuery } from '@/hooks/useMediaQuery'
 
-interface DetailFilterToggleProps {
+interface DetailFilterButtonProps {
   isOpen: boolean
-  onClick: () => void
-  ariaControls?: string
+  onToggle: () => void
   filterReset: (e: React.MouseEvent) => void
+  ariaControls?: string
 }
 
-export function DetailFilterButton({ isOpen, onClick, ariaControls, filterReset }: DetailFilterToggleProps) {
-  const isMd = useMediaQuery('(min-width: 768px)')
+/**
+ * 모바일 전용 세부 필터 토글 헤더.
+ * "세부 필터" 토글 버튼 + 필터 초기화 버튼 한 줄.
+ * 데스크탑에서는 hidden.
+ */
+export function DetailFilterButton({ isOpen, onToggle, filterReset, ariaControls }: DetailFilterButtonProps) {
   return (
-    <div
-      role="button"
-      onClick={onClick}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault()
-          onClick()
-        }
-      }}
-      tabIndex={0}
-      aria-expanded={isOpen}
-      aria-controls={ariaControls}
-      aria-label={isOpen ? '세부 필터 닫기' : '세부 필터 열기'}
-      className={cn('bg-primary-100 flex cursor-pointer items-center justify-between rounded-lg px-3 py-2.5 transition-all')}
-    >
-      <div className={cn('flex items-center gap-2')}>
-        <FilterIcon className={cn('h-4 w-4')} aria-hidden="true" />
-        <span className={cn('text-sm font-semibold')}>세부 필터</span>
-        {isMd ? (
-          <p
-            className={cn('bg-primary-50 items-center justify-center overflow-hidden rounded-md px-3 py-1 text-xs')}
-            aria-hidden="true"
-          >
-            상품상태 · 가격대 · 지역
-          </p>
-        ) : null}
-      </div>
-
-      <div className="flex items-center gap-1 md:gap-4">
-        <Button size="xs" type="button" className="bg-primary-50 cursor-pointer py-0.75" onClick={filterReset}>
-          필터 초기화
-        </Button>
-        <DownArrow
-          className={cn('h-6 w-6 text-gray-900 transition-transform', isOpen && 'rotate-180')}
-          strokeWidth={2}
+    <div className="flex items-center justify-between md:hidden">
+      <Button
+        type="button"
+        variant="link"
+        size="sm"
+        onClick={onToggle}
+        className="cursor-pointer gap-2 p-0 font-bold text-gray-900 hover:no-underline"
+        aria-expanded={isOpen}
+        aria-controls={ariaControls}
+      >
+        세부 필터
+        <ChevronDown
+          size={18}
+          className={cn('transition-transform', isOpen && 'rotate-180')}
           aria-hidden="true"
         />
-      </div>
+      </Button>
+      <Button
+        type="button"
+        variant="link"
+        size="sm"
+        onClick={filterReset}
+        className="cursor-pointer gap-1 p-0 text-xs font-medium text-gray-500 hover:text-[#825500] hover:no-underline"
+      >
+        <RotateCcw size={12} aria-hidden="true" />
+        필터 초기화
+      </Button>
     </div>
   )
 }

--- a/src/features/home/components/filter/LocationFilter.tsx
+++ b/src/features/home/components/filter/LocationFilter.tsx
@@ -4,11 +4,28 @@ import SelectDropdown from '@/components/commons/select/SelectDropdown'
 import { CITIES, PROVINCES, type Province } from '@/constants/cities'
 import { useFilterNavigation } from '@/hooks/useFilterNavigation'
 
+type LocationFilterVariant = 'default' | 'card-chip'
+
 interface LocationFilterProps {
   headingClassName?: string
+  variant?: LocationFilterVariant
 }
 
-export function LocationFilter({ headingClassName }: LocationFilterProps) {
+const VARIANT_STYLES: Record<LocationFilterVariant, { sidoButton: string; gugunButton: string }> = {
+  default: {
+    sidoButton: 'border-0 bg-primary-50 text-gray-900 px-3 py-2',
+    gugunButton:
+      'border-0 disabled:bg-primary-50 bg-primary-50 text-gray-900 px-3 py-2 disabled:text-gray-500',
+  },
+  'card-chip': {
+    sidoButton:
+      'border border-[#d4c4b2] bg-white text-gray-900 px-4 py-2 text-[13px] focus:border-[#825500] focus:ring-2 focus:ring-[#825500]/20',
+    gugunButton:
+      'border border-[#d4c4b2] bg-white text-gray-900 px-4 py-2 text-[13px] disabled:bg-[#f6f3f2] disabled:text-gray-400 focus:border-[#825500] focus:ring-2 focus:ring-[#825500]/20',
+  },
+}
+
+export function LocationFilter({ headingClassName, variant = 'default' }: LocationFilterProps) {
   const { searchParams, pathname, push } = useFilterNavigation()
 
   const isValidProvince = (value: string): value is Province => {
@@ -52,12 +69,18 @@ export function LocationFilter({ headingClassName }: LocationFilterProps) {
     updateURL(selectedSido, value)
   }
 
+  const styles = VARIANT_STYLES[variant]
+
   return (
     <div className="flex flex-1 flex-col gap-2">
       <h4 id="location-filter-heading" className={headingClassName ?? 'heading-h4'}>
         지역
       </h4>
-      <div className="flex flex-col gap-2.5 md:flex-row" role="group" aria-labelledby="location-filter-heading">
+      <div
+        className="flex flex-col gap-2.5 md:flex-row"
+        role="group"
+        aria-labelledby="location-filter-heading"
+      >
         {/* 시/도 선택 */}
         <div className="flex-1">
           <SelectDropdown
@@ -68,7 +91,7 @@ export function LocationFilter({ headingClassName }: LocationFilterProps) {
               label: province,
             }))}
             placeholder="시/도 선택"
-            buttonClassName="border-0 bg-primary-50 text-gray-900 px-3 py-2"
+            buttonClassName={styles.sidoButton}
           />
         </div>
 
@@ -86,7 +109,7 @@ export function LocationFilter({ headingClassName }: LocationFilterProps) {
             }))}
             placeholder={selectedSido ? '시/군/구 선택' : '시/도를 먼저 선택해주세요'}
             disabled={!selectedSido}
-            buttonClassName="border-0 disabled:bg-primary-50 bg-primary-50 text-gray-900 px-3 py-2 disabled:text-gray-500"
+            buttonClassName={styles.gugunButton}
           />
         </div>
       </div>

--- a/src/features/home/components/filter/PetTypeFilter.tsx
+++ b/src/features/home/components/filter/PetTypeFilter.tsx
@@ -1,12 +1,12 @@
 'use client'
 
-import Button from '@/components/commons/button/Button'
 import { PET_DETAILS, PET_TYPE_TABS, PETS, type PetTypeTabId } from '@/constants/constants'
 import { cn } from '@/lib/utils/cn'
 import { ProductPetTypeTabs } from '../tab/ProductPetTypeTabs'
 import { useFilterNavigation } from '@/hooks/useFilterNavigation'
 import { useState } from 'react'
 import { useMediaQuery } from '@/hooks/useMediaQuery'
+import Button from '@/components/commons/button/Button'
 
 const INITIAL_DISPLAY_COUNT = 13
 
@@ -17,27 +17,27 @@ interface PetTypeFilterProps {
   selectedDetailPet?: string | null
 }
 
-export function PetTypeFilter({ activeTab, headingClassName, selectedDetailPet, onTabChange }: PetTypeFilterProps) {
+// "전체" pill을 맨 앞에 두기 위한 sentinel — code: null
+const ALL_ITEM = { code: null, name: '전체' } as const
+
+export function PetTypeFilter({ activeTab, selectedDetailPet, onTabChange }: PetTypeFilterProps) {
   const { searchParams, pathname, push } = useFilterNavigation()
   const [showAll, setShowAll] = useState(false)
   const isMobile = useMediaQuery('(max-width: 767px)')
 
-  const handleProductPetDetailType = (e: React.MouseEvent, pet: string) => {
-    e.stopPropagation() // 이벤트 버블링 방지
-
-    // 같은 반려동물 클릭 시 선택 해제, 다른 반려동물 클릭 시 선택
-    const isDeselecting = selectedDetailPet === pet
-
+  // null 입력 → 필터 클리어, 같은 code 재클릭 → 토글로 클리어, 다른 code → set
+  const handleSelect = (e: React.MouseEvent, code: string | null) => {
+    e.stopPropagation()
     const params = new URLSearchParams(searchParams.toString())
-    if (isDeselecting) {
-      params.delete('petDetailType') // 선택 해제 시 URL에서 제거
+    if (code === null || selectedDetailPet === code) {
+      params.delete('petDetailType')
     } else {
-      params.set('petDetailType', pet) // 선택 시 URL에 추가
+      params.set('petDetailType', code)
     }
     push(`${pathname}?${params.toString()}`)
   }
-  const selectedPetTypeCode = PET_TYPE_TABS.find((tab) => tab.id === activeTab)?.code
 
+  const selectedPetTypeCode = PET_TYPE_TABS.find((tab) => tab.id === activeTab)?.code
   // 선택된 반려동물 타입에 해당하는 details만 필터링
   const filteredPetDetails =
     selectedPetTypeCode === 'ALL'
@@ -54,6 +54,9 @@ export function PetTypeFilter({ activeTab, headingClassName, selectedDetailPet, 
 
   const hasMoreItems = isMobile && selectedPetTypeCode === 'ALL' && filteredPetDetails.length > INITIAL_DISPLAY_COUNT
 
+  // "전체" pill을 첫 항목으로 prepend
+  const items: ReadonlyArray<{ code: string | null; name: string }> = [ALL_ITEM, ...displayedPetDetails]
+
   const [prevActiveTab, setPrevActiveTab] = useState(activeTab)
   if (prevActiveTab !== activeTab) {
     setPrevActiveTab(activeTab)
@@ -61,39 +64,39 @@ export function PetTypeFilter({ activeTab, headingClassName, selectedDetailPet, 
   }
 
   return (
-    <div className="flex flex-col gap-2.5">
-      <h2 className={headingClassName ?? 'heading-h4'}>반려동물 종류</h2>
-      <div className="flex flex-col gap-1 md:gap-4">
-        <ProductPetTypeTabs activeTab={activeTab} onTabChange={onTabChange} />
-        <div className="flex flex-wrap gap-1.5" role="tabpanel" id={`panel-${selectedPetTypeCode}`} aria-labelledby={activeTab}>
-          {displayedPetDetails.map((pet) => (
+    <div className="flex flex-col gap-5">
+      <ProductPetTypeTabs activeTab={activeTab} onTabChange={onTabChange} />
+      <div className="flex flex-wrap gap-2" role="tabpanel" id={`panel-${selectedPetTypeCode}`} aria-labelledby={activeTab}>
+        {items.map((pet) => {
+          const isActive = pet.code === null ? !selectedDetailPet : selectedDetailPet === pet.code
+          return (
             <Button
-              key={pet.code}
+              key={pet.code ?? 'all'}
               type="button"
               size="sm"
+              onClick={(e) => handleSelect(e, pet.code)}
+              aria-pressed={isActive}
               className={cn(
-                'border-primary-200 cursor-pointer border px-2.5 py-0.75 text-[13px] font-normal md:font-medium',
-                selectedDetailPet === pet.code
-                  ? 'bg-primary-300 font-bold text-white'
-                  : 'hover:bg-primary-300 text-gray-900 hover:text-white'
+                'cursor-pointer rounded-full px-6 py-2.5 whitespace-nowrap transition-all',
+                isActive
+                  ? 'bg-[#825500] font-bold text-white shadow-sm'
+                  : 'border border-[#d4c4b2] bg-white font-medium text-gray-600 hover:border-[#825500] hover:text-[#825500]'
               )}
-              onClick={(e) => handleProductPetDetailType(e, pet.code)}
-              aria-pressed={selectedDetailPet === pet.code}
             >
               {pet.name}
             </Button>
-          ))}
-          {hasMoreItems && !showAll ? (
-            <Button
-              type="button"
-              size="sm"
-              className="cursor-pointer bg-gray-100 py-0.75 px-2.5 text-[13px] text-gray-600 md:hidden"
-              onClick={() => setShowAll(true)}
-            >
-              더보기 ({filteredPetDetails.length - INITIAL_DISPLAY_COUNT}개)
-            </Button>
-          ) : null}
-        </div>
+          )
+        })}
+        {hasMoreItems && !showAll ? (
+          <Button
+            type="button"
+            size="sm"
+            onClick={() => setShowAll(true)}
+            className="cursor-pointer rounded-full bg-gray-100 px-5 py-2.5 text-gray-600 hover:bg-gray-200 md:hidden"
+          >
+            더보기 ({filteredPetDetails.length - INITIAL_DISPLAY_COUNT}개)
+          </Button>
+        ) : null}
       </div>
     </div>
   )

--- a/src/features/home/components/filter/PriceFilter.tsx
+++ b/src/features/home/components/filter/PriceFilter.tsx
@@ -4,13 +4,35 @@ import Button from '@/components/commons/button/Button'
 import { PRICE_TYPE, type PriceRange } from '@/constants/constants'
 import { cn } from '@/lib/utils/cn'
 import { useFilterNavigation } from '@/hooks/useFilterNavigation'
+import { CARD_CHIP_STYLES } from '@/components/product/filterChipStyles'
+
+type PriceFilterVariant = 'default' | 'card-chip'
 
 interface PriceFilterProps {
   headingClassName?: string
   selectedPriceRange?: PriceRange | null
+  variant?: PriceFilterVariant
 }
 
-export function PriceFilter({ headingClassName, selectedPriceRange }: PriceFilterProps) {
+const VARIANT_STYLES: Record<
+  PriceFilterVariant,
+  { container: string; chipBase: string; activeChip: string; inactiveChip: string }
+> = {
+  default: {
+    container: 'gap-sm grid grid-cols-2 flex-wrap md:flex',
+    chipBase: 'bg-primary-50 cursor-pointer text-xs md:text-sm font-medium',
+    activeChip: 'bg-primary-300 font-bold text-white',
+    inactiveChip: 'text-gray-900 hover:bg-primary-300 hover:text-white',
+  },
+  'card-chip': {
+    container: CARD_CHIP_STYLES.container,
+    chipBase: CARD_CHIP_STYLES.chip,
+    activeChip: CARD_CHIP_STYLES.chipActive,
+    inactiveChip: CARD_CHIP_STYLES.chipInactive,
+  },
+}
+
+export function PriceFilter({ headingClassName, selectedPriceRange, variant = 'default' }: PriceFilterProps) {
   const { searchParams, pathname, push } = useFilterNavigation()
 
   const handleMinPrice = (e: React.MouseEvent, priceRange: PriceRange) => {
@@ -33,29 +55,31 @@ export function PriceFilter({ headingClassName, selectedPriceRange }: PriceFilte
     }
     push(`${pathname}?${params.toString()}`)
   }
+
+  const styles = VARIANT_STYLES[variant]
+
   return (
     <div className="flex flex-col gap-2">
       <h4 id="price-filter-heading" className={headingClassName ?? 'heading-h4'}>
         가격대
       </h4>
-      <div className="gap-sm grid grid-cols-2 flex-wrap md:flex" role="group" aria-labelledby="price-filter-heading">
-        {PRICE_TYPE.map((item) => (
-          <Button
-            key={`${item.value.min}-${item.value.max}`}
-            type="button"
-            size="sm"
-            className={cn(
-              'bg-primary-50 cursor-pointer text-xs md:text-sm font-medium',
-              selectedPriceRange?.min === item.value.min && selectedPriceRange?.max === item.value.max
-                ? 'bg-primary-300 font-bold text-white'
-                : 'hover:bg-primary-300 text-gray-900 hover:text-white'
-            )}
-            onClick={(e) => handleMinPrice(e, item.value)}
-            aria-pressed={selectedPriceRange?.min === item.value.min && selectedPriceRange?.max === item.value.max}
-          >
-            {item.title}
-          </Button>
-        ))}
+      <div className={styles.container} role="group" aria-labelledby="price-filter-heading">
+        {PRICE_TYPE.map((item) => {
+          const isActive =
+            selectedPriceRange?.min === item.value.min && selectedPriceRange?.max === item.value.max
+          return (
+            <Button
+              key={`${item.value.min}-${item.value.max}`}
+              type="button"
+              size="sm"
+              className={cn(styles.chipBase, isActive ? styles.activeChip : styles.inactiveChip)}
+              onClick={(e) => handleMinPrice(e, item.value)}
+              aria-pressed={isActive}
+            >
+              {item.title}
+            </Button>
+          )
+        })}
       </div>
     </div>
   )

--- a/src/features/home/components/product-section/ProductsSection.tsx
+++ b/src/features/home/components/product-section/ProductsSection.tsx
@@ -1,11 +1,15 @@
 'use client'
 
+import { useState, useMemo } from 'react'
 import ProductList from '@/components/product/ProductList'
 import SelectDropdown from '@/components/commons/select/SelectDropdown'
+import Tabs from '@/components/Tabs'
 import { PRODUCT_TYPE_TABS, SORT_TYPE, type ProductTypeTabId } from '@/constants/constants'
 import type { Product } from '@/types/product'
 import { useFilterNavigation } from '@/hooks/useFilterNavigation'
 import { SearchX } from 'lucide-react'
+import { cn } from '@/lib/utils/cn'
+import Button from '@/components/commons/button/Button'
 
 interface ProductListHeaderProps {
   totalElements: number
@@ -13,7 +17,7 @@ interface ProductListHeaderProps {
 
 function ProductListHeader({ totalElements }: ProductListHeaderProps) {
   return (
-    <p className="text-text-secondary text-sm" aria-live="polite">
+    <p className="text-sm text-gray-500" aria-live="polite">
       {`총 ${totalElements}개의 상품`}
     </p>
   )
@@ -24,15 +28,23 @@ interface ProductsSectionProps {
   totalElements: number
   activeTab: ProductTypeTabId
   selectedSort?: string
+  onTabChange?: (tabId: string) => void
 }
 
-export function ProductsSection({ products, totalElements, activeTab, selectedSort = '최신순' }: ProductsSectionProps) {
+export function ProductsSection({
+  products,
+  totalElements,
+  activeTab,
+  selectedSort = '최신순',
+  onTabChange,
+}: ProductsSectionProps) {
   const { searchParams, pathname, push } = useFilterNavigation()
+  const [onlyOnSale, setOnlyOnSale] = useState(false)
 
   const activeTabCode = PRODUCT_TYPE_TABS.find((tab) => tab.id === activeTab)?.code
 
-  const handleSortChange = (value: string) => {
-    const sortItem = SORT_TYPE.find((sort) => sort.label === value)
+  const handleSortChange = (label: string) => {
+    const sortItem = SORT_TYPE.find((sort) => sort.label === label)
 
     if (!sortItem) return
     const params = new URLSearchParams(searchParams.toString())
@@ -52,32 +64,88 @@ export function ProductsSection({ products, totalElements, activeTab, selectedSo
     push(`${pathname}?${params.toString()}`)
   }
 
+  const visibleProducts = useMemo(() => {
+    if (!onlyOnSale) return products
+    return products.filter((product) => product.tradeStatus === 'SELLING' || product.tradeStatus === null)
+  }, [products, onlyOnSale])
+
   return (
-    <section role="tabpanel" id={`panel-${activeTabCode}`} aria-labelledby={activeTab} className="flex flex-col gap-5">
-      <div className="flex items-start justify-between">
-        <ProductListHeader totalElements={totalElements} />
-        <div className="w-36">
-          <SelectDropdown
-            value={selectedSort}
-            onChange={handleSortChange}
-            options={SORT_TYPE.map((sort) => ({
-              value: sort.label,
-              label: sort.label,
-            }))}
-            placeholder="최신순"
-            buttonClassName="border-0 bg-primary-50 text-gray-900 px-3 py-2 text-[13px]"
-          />
+    <section role="tabpanel" id={`panel-${activeTabCode}`} aria-labelledby={activeTab} className="flex flex-col gap-6">
+      {/* 탭 + 토글 + 정렬 */}
+      <div className="flex flex-col justify-between gap-4 border-b border-[#d4c4b2] pb-5 md:flex-row md:items-center">
+        <Tabs
+          tabs={PRODUCT_TYPE_TABS}
+          activeTab={activeTab}
+          onTabChange={(tabId) => onTabChange?.(tabId)}
+          ariaLabel="상품 타입 분류"
+          variant="card-pill"
+        />
+
+        <div className="flex flex-wrap items-center gap-4 md:gap-6">
+          <label className="group flex cursor-pointer items-center gap-2.5">
+            <span className="relative inline-block">
+              <input
+                type="checkbox"
+                checked={onlyOnSale}
+                onChange={(e) => setOnlyOnSale(e.target.checked)}
+                className="peer sr-only"
+              />
+              <span className="block h-6 w-11 rounded-full bg-gray-200 transition-colors peer-checked:bg-[#825500]"></span>
+              <span className="absolute top-0.5 left-0.5 h-5 w-5 rounded-full bg-white transition-transform peer-checked:translate-x-5"></span>
+            </span>
+            <span className="text-sm font-bold text-gray-600 group-hover:text-[#825500]">판매중만 보기</span>
+          </label>
+
+          <div className="hidden h-4 w-px bg-[#d4c4b2]/60 md:block" />
+
+          {/* 모바일: SelectDropdown — 공간 효율 + 프로젝트 컨벤션 일치 */}
+          <div className="w-32 md:hidden">
+            <SelectDropdown
+              value={selectedSort}
+              onChange={handleSortChange}
+              options={SORT_TYPE.map((sort) => ({ value: sort.label, label: sort.label }))}
+              placeholder="최신순"
+              buttonClassName="border-0 bg-[#f6efe2] text-gray-900 px-3 py-2 text-sm"
+            />
+          </div>
+
+          {/* 데스크탑: 인라인 옵션 리스트 */}
+          <div className="hidden items-center gap-3 md:flex">
+            {SORT_TYPE.map((sort, idx) => {
+              const isActive = selectedSort === sort.label
+              return (
+                <span key={sort.id} className="flex items-center gap-3">
+                  <Button
+                    type="button"
+                    variant="link"
+                    size="sm"
+                    onClick={() => handleSortChange(sort.label)}
+                    className={cn(
+                      'cursor-pointer whitespace-nowrap p-0 hover:no-underline',
+                      isActive ? 'font-bold text-[#825500]' : 'font-medium text-gray-500 hover:text-[#825500]'
+                    )}
+                  >
+                    {sort.label}
+                  </Button>
+                  {idx < SORT_TYPE.length - 1 ? <span className="h-3 w-px bg-[#d4c4b2]/60" /> : null}
+                </span>
+              )
+            })}
+          </div>
         </div>
       </div>
-      {products.length > 0 ? (
-        <ProductList products={products} />
+
+      <ProductListHeader totalElements={onlyOnSale ? visibleProducts.length : totalElements} />
+
+      {visibleProducts.length > 0 ? (
+        <ProductList products={visibleProducts} />
       ) : (
-        <div className="flex flex-col items-center justify-center gap-4 rounded-lg border-2 border-dashed border-gray-300 bg-white px-7 py-12 md:gap-6 md:py-16">
-          <div className="bg-primary-50 flex h-16 w-16 items-center justify-center rounded-full md:h-25 md:w-25">
-            <SearchX size={32} strokeWidth={1} className="text-primary-300 md:size-12.5" />
+        <div className="flex flex-col items-center justify-center gap-4 rounded-3xl border-2 border-dashed border-gray-200 bg-white px-7 py-16">
+          <div className="flex h-20 w-20 items-center justify-center rounded-full bg-[#fff5e0]">
+            <SearchX size={40} strokeWidth={1.5} className="text-[#825500]" />
           </div>
-          <div className="flex flex-col items-center gap-1 md:gap-2">
-            <p className="md:heading-h5 text-base font-semibold">검색 결과가 없습니다</p>
+          <div className="flex flex-col items-center gap-1">
+            <p className="text-base font-semibold text-gray-900 md:text-lg">검색 결과가 없습니다</p>
             <p className="text-sm text-gray-500">다른 필터 조건으로 검색해보세요</p>
           </div>
         </div>

--- a/src/features/home/components/tab/ProductPetTypeTabs.tsx
+++ b/src/features/home/components/tab/ProductPetTypeTabs.tsx
@@ -1,10 +1,9 @@
 'use client'
 
-import Button from '@/components/commons/button/Button'
 import { PET_TYPE_TABS, type PetTypeTabId } from '@/constants/constants'
 import { cn } from '@/lib/utils/cn'
 import { useRef, useState, useEffect } from 'react'
-import { useMediaQuery } from '@/hooks/useMediaQuery'
+import Button from '@/components/commons/button/Button'
 
 interface ProductPetTypeTabsProps {
   activeTab: PetTypeTabId
@@ -14,24 +13,26 @@ interface ProductPetTypeTabsProps {
 export function ProductPetTypeTabs({ activeTab, onTabChange }: ProductPetTypeTabsProps) {
   const scrollRef = useRef<HTMLDivElement>(null)
   const [showFade, setShowFade] = useState(true)
-  const isMd = useMediaQuery('(min-width: 768px)')
 
   useEffect(() => {
     const el = scrollRef.current
     if (!el) return
 
-    const handleScroll = () => {
+    const recomputeFade = () => {
       const isAtEnd = el.scrollLeft + el.clientWidth >= el.scrollWidth - 1
       setShowFade(!isAtEnd)
     }
 
-    const rafId = requestAnimationFrame(handleScroll)
-    el.addEventListener('scroll', handleScroll, { passive: true })
+    const rafId = requestAnimationFrame(recomputeFade)
+    el.addEventListener('scroll', recomputeFade, { passive: true })
+    // 뷰포트 변경 시 scrollWidth/clientWidth가 달라질 수 있어 재계산
+    window.addEventListener('resize', recomputeFade)
     return () => {
       cancelAnimationFrame(rafId)
-      el.removeEventListener('scroll', handleScroll)
+      el.removeEventListener('scroll', recomputeFade)
+      window.removeEventListener('resize', recomputeFade)
     }
-  }, [isMd])
+  }, [])
 
   return (
     <div className="relative">
@@ -39,31 +40,32 @@ export function ProductPetTypeTabs({ activeTab, onTabChange }: ProductPetTypeTab
         ref={scrollRef}
         role="tablist"
         aria-label="반려동물 타입 대분류"
-        className={cn(
-          'border-b-primary-200 scrollbar-hide flex gap-1.5 overflow-x-auto pb-1 md:gap-2.5 md:overflow-visible md:border-b-[1.5px]'
-        )}
+        className="scrollbar-hide flex overflow-x-auto border-b border-[#d4c4b2]"
       >
-        {PET_TYPE_TABS.map((tab) => (
-          <Button
-            key={tab.id}
-            size={isMd ? 'md' : 'sm'}
-            id={tab.id}
-            type="button"
-            onClick={() => onTabChange(tab.id)}
-            className={cn(
-              'bg-primary-100 flex-1 cursor-pointer rounded-full px-4 py-2 text-sm whitespace-nowrap md:text-base xl:rounded-2xl xl:bg-white',
-              activeTab === tab.id
-                ? 'bg-primary-500 xl:bg-primary-300 font-bold text-white'
-                : 'hover:bg-primary-500 hover:text-white text-gray-900'
-            )}
-            role="tab"
-            aria-selected={activeTab === tab.id}
-            aria-controls={`panel-${tab.code}`}
-            tabIndex={activeTab === tab.id ? 0 : -1}
-          >
-            {tab.label}
-          </Button>
-        ))}
+        {PET_TYPE_TABS.map((tab) => {
+          const isActive = activeTab === tab.id
+          return (
+            <Button
+              key={tab.id}
+              id={tab.id}
+              type="button"
+              size="sm"
+              onClick={() => onTabChange(tab.id)}
+              className={cn(
+                '-mb-px cursor-pointer rounded-none border-b-2 px-6 py-3 whitespace-nowrap md:px-8 md:text-base',
+                isActive
+                  ? 'border-[#825500] font-bold text-[#825500]'
+                  : 'border-transparent font-medium text-gray-500 hover:text-[#825500]'
+              )}
+              role="tab"
+              aria-selected={isActive}
+              aria-controls={`panel-${tab.code}`}
+              tabIndex={isActive ? 0 : -1}
+            >
+              {tab.label}
+            </Button>
+          )
+        })}
       </div>
       {showFade ? (
         <div className="pointer-events-none absolute top-0 right-0 bottom-0 w-12 bg-linear-to-l from-white via-white/80 to-transparent md:hidden" />

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -135,6 +135,8 @@ export const typeDefs = gql`
     viewCount: Int!
     favoriteCount: Int!
     isFavorite: Boolean
+    addressSido: String
+    addressGugun: String
   }
 
   type SellerInfo {

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -13,6 +13,8 @@ export interface Product {
   favoriteCount: number
   isFavorite: boolean
   viewCount?: number
+  addressSido?: string
+  addressGugun?: string
 }
 
 export interface ProductResponse {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,14 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "types": ["node"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "types": [
+      "node"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -12,7 +18,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -20,7 +26,9 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
   "include": [
@@ -31,5 +39,7 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## 📌 개요

- 메인 페이지 전체 디자인을 새 베이지/브라운 톤으로 리뉴얼
- 재사용성을 위해 공통 컴포넌트(Tabs / Button / ProductBadge / ProductInfo / ProductStateFilter / PriceFilter / LocationFilter)를 variant 패턴으로 확장
- 기존 컴포넌트의 책임 분리 및 코드 중복 제거

## 🔧 작업 내용

### 디자인 적용
- [x] HomeHero 섹션 신규 추가 (full-bleed 베이지 + 펫 이미지)
- [x] 펫 타입 필터: 언더라인 탭 + 칩 (전체 pill 통합)
- [x] 카테고리 필터: 아이콘 그리드 레이아웃 (전체 pill 통합)
- [x] 세부 필터: 흰 카드 + 3섹션 (상품 상태 / 가격대 / 지역)
- [x] 상품 목록 헤더: 모바일 SelectDropdown / 데스크탑 인라인 옵션 분기
- [x] 상품 카드: rounded-3xl + hover lift + 우상단 찜 토글 + 중앙 큰 거래상태 오버레이
- [x] 메타 영역: `지역 · 좋아요 N | 시간` 패턴 (백엔드 응답에 addressSido / addressGugun 노출)
- [x] 새 디자인용 로딩 스켈레톤 (HomeLoadingState — 5섹션 1:1 매칭)

### 컴포넌트 리팩토링
- [x] **ProductBadge**: items array API + 5개 tone (primary / light / info / warning / outline). 기존 호출부([ProductListItem](../blob/feature/686--main-page-redesign/src/components/product/ProductListItem.tsx))도 함께 마이그레이션
- [x] **ProductStateFilter / PriceFilter / LocationFilter**: `variant?: 'default' | 'card-chip'` prop 추가 (기본 default — 기존 호출부 영향 없음)
- [x] **Tabs**: `variant?: 'default' | 'card-pill'` prop 추가, 키보드 네비게이션(ArrowKeys / Home / End) 유지
- [x] **DetailFilter**: 인라인 핸들러 4개 모두 제거 → 각 sub-component에 위임
- [x] **DetailFilterButton**: 모바일 토글 헤더로 재구성 (dead code 부활)
- [x] **ProductInfo / ProductHeading / ProductThumbnail**: 시그니처 정리 + 책임 분리
- [x] 공통 카드 칩 스타일 추출 ([filterChipStyles.ts](../blob/feature/686--main-page-redesign/src/components/product/filterChipStyles.ts))
- [x] SORT_TYPE label 단축 (`가격 높은순` → `고가순` 등)
- [x] **ProductMetaItem**: `icon` prop optional + `iconClassName` 추가 (호출부 4곳 영향 없음)
- [x] **ProductPetTypeTabs**: window.resize 리스너 추가 (페이드 가시성 정확한 재계산)
- [x] 모든 raw `<button>` → Button 컴포넌트로 일괄 교체
- [x] 단축 변수명(c, p, g) → 의미 있는 풀네임으로 정리
- [x] type → interface 변환 (객체 shape 컨벤션 준수)

### 백엔드 (별도 레포 cmarket_api 배포 완료)
- [x] `ProductSearchItemDto`에 addressSido / addressGugun 필드 추가
- [x] `ProductSearchItemResponse`에 동일 필드 노출

## 📎 관련 이슈

- Close #686

## 📸 스크린샷 (선택)

| 변경 전 | 변경 후 |
| ------- | ------- |
| (생략) | (생략) |

## 💬 리뷰어 참고 사항

- **백워드 호환**: variant prop 추가 컴포넌트들은 모두 기본값이 `default`라 기존 호출부([MyPage](../blob/feature/686--main-page-redesign/src/features/my-page/MyPage.tsx) / [ProductPostForm](../blob/feature/686--main-page-redesign/src/features/product-post/) / [ProductListItem](../blob/feature/686--main-page-redesign/src/components/product/ProductListItem.tsx) 등)는 영향 없음
- **남은 작업** (별도 이슈/세션 예정): raw hex 색상값(`#825500`, `#d4c4b2`, `#f6f3f2` 등)을 Tailwind 토큰(`bg-brand-700` 형태)으로 일괄 교체. 이번 PR에는 의도적으로 raw hex 유지 (B 작업으로 분리)
- **tsconfig.json 변경**: Next.js dev 서버가 자동 적용한 `"jsx": "preserve" → "react-jsx"` (디자인 작업과 무관하나 함께 포함)
- 모바일 ↔ 데스크탑 정렬 UI는 DOM 분기(SelectDropdown vs 인라인) — 구조가 본질적으로 다른 케이스라 의도적 분기. 그 외 반응형은 모두 CSS 미디어쿼리만으로 처리