### PR TITLE
feat: 상세페이지 디자인 리뉴얼(#696)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "rehype-sanitize": "^6.0.0",
         "remark-breaks": "^4.0.0",
         "sockjs-client": "^1.6.1",
+        "swiper": "^12.1.4",
         "tailwind-merge": "^3.4.0",
         "zustand": "^5.0.11"
       },
@@ -9636,6 +9637,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swiper": {
+      "version": "12.1.4",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-12.1.4.tgz",
+      "integrity": "sha512-bihiwoKMOQwW8FfdUbo1DgkVH25E+4ZELIq0oopL1KTKBteLuaTMi/wwFjMxtlhTkk45k3XQ89D1Fvv0spSqBA==",
+      "funding": [
+        {
+          "type": "custom",
+          "url": "https://sponsors.nolimits4web.com"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nolimits4web"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.7.0"
       }
     },
     "node_modules/tabbable": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "rehype-sanitize": "^6.0.0",
     "remark-breaks": "^4.0.0",
     "sockjs-client": "^1.6.1",
+    "swiper": "^12.1.4",
     "tailwind-merge": "^3.4.0",
     "zustand": "^5.0.11"
   },

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -91,3 +91,10 @@ input[type='date']::-webkit-calendar-picker-indicator {
   animation-fill-mode: forwards;
   animation-duration: var(--toast-duration, 4500ms);
 }
+
+/* 상품 상세 페이지 이미지 Swiper - 기본 navigation SVG 숨김 (Lucide 아이콘으로 대체) */
+.swiper-detail-image .swiper-button-prev,
+.swiper-detail-image .swiper-button-next {
+  display: none;
+}
+

--- a/src/components/commons/breadcrumb/Breadcrumb.tsx
+++ b/src/components/commons/breadcrumb/Breadcrumb.tsx
@@ -1,0 +1,50 @@
+import Link from 'next/link'
+import { ChevronRight } from 'lucide-react'
+import { Fragment } from 'react'
+import { cn } from '@/lib/utils/cn'
+
+export interface BreadcrumbItem {
+  label: string
+  href?: string
+}
+
+interface BreadcrumbProps {
+  items: BreadcrumbItem[]
+  className?: string
+}
+
+export default function Breadcrumb({ items, className }: BreadcrumbProps) {
+  if (items.length === 0) return null
+  return (
+    <nav aria-label="카테고리 경로" className={cn('text-sm', className)}>
+      <ol className="flex items-center gap-1.5 text-gray-500">
+        {items.map((item, idx) => {
+          const isLast = idx === items.length - 1
+          const linkBase = 'transition-colors hover:underline'
+          const lastStyle = 'font-bold text-[#633f00]'
+          return (
+            <Fragment key={`${item.label}-${idx}`}>
+              <li>
+                {item.href ? (
+                  <Link
+                    href={item.href}
+                    className={cn(linkBase, isLast ? lastStyle : 'hover:text-[#633f00]')}
+                  >
+                    {item.label}
+                  </Link>
+                ) : (
+                  <span className={isLast ? lastStyle : ''}>{item.label}</span>
+                )}
+              </li>
+              {!isLast ? (
+                <li aria-hidden="true" className="flex items-center text-gray-400">
+                  <ChevronRight size={14} strokeWidth={2} />
+                </li>
+              ) : null}
+            </Fragment>
+          )
+        })}
+      </ol>
+    </nav>
+  )
+}

--- a/src/components/product/ProductCard.tsx
+++ b/src/components/product/ProductCard.tsx
@@ -17,9 +17,10 @@ export interface ProductCardProps {
   data: Product
   'data-index'?: number
   vertical?: boolean
+  hideProductType?: boolean
 }
 
-function ProductCard({ data, 'data-index': dataIndex, vertical = false }: ProductCardProps) {
+function ProductCard({ data, 'data-index': dataIndex, vertical = false, hideProductType }: ProductCardProps) {
   const router = useRouter()
   const { isFavorite, handleToggleFavorite } = useFavorite({
     productId: data?.id,
@@ -79,7 +80,7 @@ function ProductCard({ data, 'data-index': dataIndex, vertical = false }: Produc
           productTypeName={productTypeName}
           productStatusName={productStatusName}
           isFavorite={isFavorite}
-          hideProductType={vertical}
+          hideProductType={hideProductType ?? vertical}
           location={location}
         />
         <ProductThumbnail

--- a/src/components/product/ProductList.tsx
+++ b/src/components/product/ProductList.tsx
@@ -11,9 +11,10 @@ interface ProductListProps {
   products: Product[]
   showMoreButton?: boolean
   sellerId?: number
+  hideProductType?: boolean
 }
 
-export default function ProductList({ products, showMoreButton = false, sellerId }: ProductListProps) {
+export default function ProductList({ products, showMoreButton = false, sellerId, hideProductType }: ProductListProps) {
   const { isLogin, setRedirectUrl } = useUserStore()
   const { openLoginModal } = useLoginModalStore()
   const router = useRouter()
@@ -32,7 +33,7 @@ export default function ProductList({ products, showMoreButton = false, sellerId
     >
       {products.map((product, index) => (
         <li key={product.id}>
-          <ProductCard data-index={index} data={product} />
+          <ProductCard data-index={index} data={product} hideProductType={hideProductType} />
         </li>
       ))}
       {showMoreButton && sellerId && products.length >= 4 ? (

--- a/src/components/product/components/ProductBadge.tsx
+++ b/src/components/product/components/ProductBadge.tsx
@@ -2,18 +2,28 @@ import Badge from '@/components/commons/badge/Badge'
 import { cn } from '@/lib/utils/cn'
 
 export type ProductBadgeTone = 'primary' | 'light' | 'info' | 'warning' | 'outline'
+export type ProductBadgeSize = 'sm' | 'md'
+
+const TONE_BASE = 'rounded font-bold'
+
+const SIZE_CLASSES: Record<ProductBadgeSize, string> = {
+  // 메인 카드/리스트용 (작음)
+  sm: 'px-2 py-0.5 text-[10px]',
+  // 상세페이지용 (살짝 큼)
+  md: 'px-2.5 py-1 text-xs',
+}
 
 const TONE_CLASSES: Record<ProductBadgeTone, string> = {
-  // 기존 ProductListItem 디자인 (진한 브라운 채움)
-  primary: 'rounded-md bg-primary-700 px-1.5 py-1 text-[11px] font-semibold text-white',
-  // 기존 ProductListItem 디자인 (연한 채움)
-  light: 'rounded-md bg-primary-200 px-1.5 py-1 text-[11px] font-semibold text-gray-900',
-  // 새 디자인 판매 (블루 톤)
-  info: 'rounded bg-[#cbe2fa] px-2 py-0.5 text-[10px] font-bold text-[#33495c]',
-  // 새 디자인 판매요청 (앰버 톤)
-  warning: 'rounded border border-[#f0d9a8] bg-[#fff5e0] px-2 py-0.5 text-[10px] font-bold text-[#825500]',
-  // 새 디자인 상품상태 (아웃라인)
-  outline: 'rounded border border-[#d4c4b2] bg-transparent px-2 py-0.5 text-[10px] font-bold text-gray-600',
+  // 진한 브라운 채움 (펫 타입 등)
+  primary: 'bg-primary-700 text-white',
+  // 연한 브라운 채움 (상품 상태 등)
+  light: 'bg-primary-200 text-gray-900',
+  // 블루 톤 (판매)
+  info: 'bg-[#cbe2fa] text-[#33495c]',
+  // 앰버 톤 (판매요청)
+  warning: 'border border-[#f0d9a8] bg-[#fff5e0] text-[#825500]',
+  // 아웃라인 (상품상태/카테고리 등)
+  outline: 'border border-[#d4c4b2] bg-transparent text-gray-600',
 }
 
 export interface ProductBadgeItem {
@@ -23,15 +33,19 @@ export interface ProductBadgeItem {
 
 interface ProductBadgeProps {
   items: ProductBadgeItem[]
+  size?: ProductBadgeSize
   className?: string
 }
 
-export function ProductBadge({ items, className }: ProductBadgeProps) {
+export function ProductBadge({ items, size = 'sm', className }: ProductBadgeProps) {
   if (items.length === 0) return null
   return (
     <div className={cn('z-1 flex flex-wrap items-center gap-xs', className)}>
       {items.map((item, idx) => (
-        <Badge key={`${item.label}-${idx}`} className={cn('whitespace-nowrap', TONE_CLASSES[item.tone])}>
+        <Badge
+          key={`${item.label}-${idx}`}
+          className={cn('whitespace-nowrap', TONE_BASE, SIZE_CLASSES[size], TONE_CLASSES[item.tone])}
+        >
           {item.label}
         </Badge>
       ))}

--- a/src/components/product/components/ProductInfo.tsx
+++ b/src/components/product/components/ProductInfo.tsx
@@ -25,12 +25,12 @@ export function ProductInfo({
   hideProductType = false,
   location,
 }: ProductInfoProps) {
-  const badgeItems: ProductBadgeItem[] = hideProductType
-    ? []
-    : [
-        { label: productTypeName, tone: productTypeName === '판매요청' ? 'warning' : 'info' },
-        { label: productStatusName, tone: 'outline' },
-      ]
+  const badgeItems: ProductBadgeItem[] = [
+    ...(hideProductType
+      ? []
+      : [{ label: productTypeName, tone: (productTypeName === '판매요청' ? 'warning' : 'info') as ProductBadgeItem['tone'] }]),
+    { label: productStatusName, tone: 'outline' },
+  ]
 
   const metaTextClass = 'text-xs font-medium'
 

--- a/src/features/home/components/product-section/ProductsSection.tsx
+++ b/src/features/home/components/product-section/ProductsSection.tsx
@@ -72,7 +72,7 @@ export function ProductsSection({
   return (
     <section role="tabpanel" id={`panel-${activeTabCode}`} aria-labelledby={activeTab} className="flex flex-col gap-2">
       {/* 탭 + 토글 + 정렬 */}
-      <div className="flex flex-col justify-between gap-4 border-b border-[#d4c4b2] pb-2 md:flex-row md:items-center md:pt-15">
+      <div className="border-outline-variant flex flex-col justify-between gap-4 border-b pb-2 md:flex-row md:items-center md:pt-15">
         <Tabs
           tabs={PRODUCT_TYPE_TABS}
           activeTab={activeTab}
@@ -96,7 +96,7 @@ export function ProductsSection({
             <span className="text-sm font-bold text-gray-600 group-hover:text-[#825500]">판매중만 보기</span>
           </label>
 
-          <div className="hidden h-4 w-px bg-[#d4c4b2]/60 md:block" />
+          <div className="bg-outline-variant/60 hidden h-4 w-px md:block" />
 
           {/* 모바일: SelectDropdown — 공간 효율 + 프로젝트 컨벤션 일치 */}
           <div className="w-32 md:hidden">
@@ -127,7 +127,7 @@ export function ProductsSection({
                   >
                     {sort.label}
                   </Button>
-                  {idx < SORT_TYPE.length - 1 ? <span className="h-3 w-px bg-[#d4c4b2]/60" /> : null}
+                  {idx < SORT_TYPE.length - 1 ? <span className="bg-outline-variant/60 h-3 w-px" /> : null}
                 </span>
               )
             })}

--- a/src/features/product-detail/ProductDetail.tsx
+++ b/src/features/product-detail/ProductDetail.tsx
@@ -6,8 +6,6 @@ import { api } from '@/lib/api/api'
 import Footer from '@/components/footer/Footer'
 import ProductDetailMobileMeta from './components/ProductDetailMobileMeta'
 import MainImage from './components/MainImage'
-import SubImages from './components/SubImages'
-import SellerProfileCard from './components/SellerProfileCard'
 import ProductBadges from './components/ProductBadges'
 import ProductSummary from './components/ProductSummary'
 import ProductDescription from './components/ProductDescription'
@@ -15,6 +13,11 @@ import ProductActions from './components/ProductActions'
 import SellerOtherProducts from './components/SellerOtherProducts'
 import { useEffect } from 'react'
 import type { ProductDetailItem } from '@/types/product'
+import { getProductType } from '@/lib/utils/getProductType'
+import { getTradeStatus } from '@/lib/utils/getTradeStatus'
+import { getPetTypeName } from '@/lib/utils/getPetTypeName'
+import { getCategory } from '@/lib/utils/getCategory'
+import Breadcrumb from '@/components/commons/breadcrumb/Breadcrumb'
 
 interface ProductDetailProps {
   initialData: ProductDetailItem
@@ -43,23 +46,44 @@ function ProductDetail({ initialData }: ProductDetailProps) {
     <>
       <div className="px-lg pb-4xl mx-auto max-w-7xl pt-8">
         <div className="flex flex-col gap-20">
-          <div className="flex flex-col justify-center gap-8 md:flex-row">
-            <div className="flex flex-1 flex-col gap-4 md:max-w-150">
-              <MainImage {...data} />
-              <SubImages {...data} />
-              <SellerProfileCard sellerInfo={data.sellerInfo} />
-            </div>
-
-            <div className="flex flex-1 flex-col gap-5">
-              <div className="flex flex-col gap-3 md:gap-6">
-                <div className="flex flex-col gap-3.5">
-                  <ProductBadges {...data} />
-                  <ProductSummary data={data} />
-                </div>
-                <ProductDescription description={data.description} />
-                <ProductDetailMobileMeta productId={data.id} productTitle={data.title} viewCount={data.viewCount} favoriteCount={data.favoriteCount} />
+          <div className="flex flex-col gap-4">
+            <Breadcrumb
+              items={[
+                {
+                  label: getPetTypeName(data.petDetailType),
+                  href: `/?petDetailType=${encodeURIComponent(data.petDetailType)}`,
+                },
+                { label: getCategory(data.category), href: `/?categories=${encodeURIComponent(data.category)}` },
+              ]}
+              className="md:max-w-150"
+            />
+            <div className="flex flex-col justify-center gap-8 md:flex-row">
+              <div className="flex flex-1 flex-col gap-4 md:max-w-150">
+                <MainImage
+                  mainImageUrl={data.mainImageUrl}
+                  subImageUrls={data.subImageUrls}
+                  title={data.title}
+                  tradeStatus={getTradeStatus(data.tradeStatus)}
+                  productTypeName={getProductType(data.productType)}
+                />
               </div>
-              <ProductActions {...data} />
+
+              <div className="flex flex-1 flex-col gap-5">
+                <div className="flex flex-col gap-3 md:gap-6">
+                  <div className="flex flex-col gap-3.5">
+                    <ProductBadges productType={data.productType} productStatus={data.productStatus} />
+                    <ProductSummary data={data} />
+                  </div>
+                  <ProductDescription description={data.description} />
+                  <ProductDetailMobileMeta
+                    productId={data.id}
+                    productTitle={data.title}
+                    viewCount={data.viewCount}
+                    favoriteCount={data.favoriteCount}
+                  />
+                </div>
+                <ProductActions {...data} />
+              </div>
             </div>
           </div>
           <SellerOtherProducts {...data} />

--- a/src/features/product-detail/components/MainImage.tsx
+++ b/src/features/product-detail/components/MainImage.tsx
@@ -1,48 +1,158 @@
 'use client'
 
-import { useCallback, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
+import { Swiper, SwiperSlide } from 'swiper/react'
+import { Pagination, Navigation } from 'swiper/modules'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { getImageSrcSet, IMAGE_SIZES, toResizedWebpUrl, PLACEHOLDER_IMAGES } from '@/lib/utils/imageUrl'
+import { cn } from '@/lib/utils/cn'
+import 'swiper/css'
+import 'swiper/css/pagination'
+import 'swiper/css/navigation'
+
+const SWIPER_WHITE_THEME: React.CSSProperties = {
+  // Pagination 흰색 기반 (Navigation은 커스텀 Lucide 아이콘으로 대체)
+  ['--swiper-pagination-color' as string]: '#ffffff',
+  ['--swiper-pagination-bullet-inactive-color' as string]: '#ffffff',
+  ['--swiper-pagination-bullet-inactive-opacity' as string]: '0.5',
+}
 
 interface MainImageProps {
   mainImageUrl: string | null
+  subImageUrls: string[]
   title: string
+  tradeStatus: string | null
+  productTypeName: string
 }
 
-export default function MainImage({ mainImageUrl, title }: MainImageProps) {
+interface SlideProps {
+  imageUrl: string
+  title: string
+  index: number
+}
+
+function Slide({ imageUrl, title, index }: SlideProps) {
   const [imgErrorStep, setImgErrorStep] = useState(0) // 0: CDN, 1: 원본, 2: placeholder
 
   const getSrc = () => {
-    if (!mainImageUrl || imgErrorStep >= 2) return PLACEHOLDER_IMAGES[800]
-    if (imgErrorStep === 1) return mainImageUrl
-    return toResizedWebpUrl(mainImageUrl, 800)
+    if (!imageUrl || imgErrorStep >= 2) return PLACEHOLDER_IMAGES[800]
+    if (imgErrorStep === 1) return imageUrl
+    return toResizedWebpUrl(imageUrl, 800)
   }
 
   const getSrcSet = () => {
-    if (!mainImageUrl || imgErrorStep > 0) return ''
-    return getImageSrcSet(mainImageUrl)
+    if (!imageUrl || imgErrorStep > 0) return ''
+    return getImageSrcSet(imageUrl)
   }
+
+  const handleImgRef = useCallback(
+    (img: HTMLImageElement | null) => {
+      if (img && img.complete && img.naturalWidth === 0 && imgErrorStep < 2) {
+        setImgErrorStep((prev) => prev + 1)
+      }
+    },
+    [imgErrorStep]
+  )
+
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      ref={handleImgRef}
+      src={getSrc()}
+      srcSet={getSrcSet()}
+      sizes={IMAGE_SIZES.mainImage}
+      alt={`${title} - ${index + 1}`}
+      fetchPriority={index === 0 ? 'high' : 'auto'}
+      loading={index === 0 ? 'eager' : 'lazy'}
+      className="absolute inset-0 h-full w-full object-cover"
+      onError={() => {
+        if (imgErrorStep < 2) {
+          setImgErrorStep((prev) => prev + 1)
+        }
+      }}
+    />
+  )
+}
+
+export default function MainImage({ mainImageUrl, subImageUrls, title, tradeStatus, productTypeName }: MainImageProps) {
+  // 대표 + 서브 이미지를 단일 array로 결합 (첫 항목 = 기존 mainImage)
+  const images = [mainImageUrl, ...subImageUrls].filter((url): url is string => Boolean(url))
+  const slides = images.length > 0 ? images : [PLACEHOLDER_IMAGES[800]]
+  const hasMultiple = slides.length > 1
+
+  const prevRef = useRef<HTMLButtonElement>(null)
+  const nextRef = useRef<HTMLButtonElement>(null)
+
+  const getDisplayTradeStatus = () => {
+    if (productTypeName === '판매요청') {
+      if (tradeStatus === '판매완료') return '요청완료'
+      if (!tradeStatus) return '요청중'
+    }
+    return tradeStatus || ''
+  }
+  const displayTradeStatus = getDisplayTradeStatus()
+  const isOverlayShown = tradeStatus === '예약중' || tradeStatus === '판매완료' || displayTradeStatus === '요청완료'
+  const overlayBg = tradeStatus === '예약중' ? 'bg-black/40' : 'bg-black/60'
+  const isLargerBadge = tradeStatus === '판매완료' || displayTradeStatus === '요청완료'
+  const badgeSizeClass = isLargerBadge ? 'px-6 py-2.5 text-sm' : 'px-4 py-1.5 text-xs'
 
   return (
     <div className="relative overflow-hidden rounded-xl pb-[100%]">
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img
-        ref={useCallback((img: HTMLImageElement | null) => {
-          if (img && img.complete && img.naturalWidth === 0 && imgErrorStep < 2) {
-            setImgErrorStep((prev) => prev + 1)
-          }
-        }, [imgErrorStep])}
-        src={getSrc()}
-        srcSet={getSrcSet()}
-        sizes={IMAGE_SIZES.mainImage}
-        alt={title}
-        fetchPriority="high"
-        className="absolute inset-0 h-full w-full object-cover"
-        onError={() => {
-          if (imgErrorStep < 2) {
-            setImgErrorStep((prev) => prev + 1)
-          }
-        }}
-      />
+      <div className="absolute inset-0">
+        <Swiper
+          modules={[Pagination, Navigation]}
+          pagination={{ clickable: true }}
+          navigation={{ prevEl: prevRef.current, nextEl: nextRef.current }}
+          onBeforeInit={(swiper) => {
+            if (swiper.params.navigation && typeof swiper.params.navigation !== 'boolean') {
+              swiper.params.navigation.prevEl = prevRef.current
+              swiper.params.navigation.nextEl = nextRef.current
+            }
+          }}
+          slidesPerView={1}
+          spaceBetween={0}
+          loop={hasMultiple}
+          className="swiper-detail-image h-full w-full"
+          style={SWIPER_WHITE_THEME}
+        >
+          {slides.map((imageUrl, index) => (
+            <SwiperSlide key={`${imageUrl}-${index}`} className="relative">
+              <Slide imageUrl={imageUrl} title={title} index={index} />
+            </SwiperSlide>
+          ))}
+        </Swiper>
+      </div>
+
+      {/* 커스텀 navigation 버튼 — Lucide 아이콘 */}
+      {hasMultiple ? (
+        <>
+          <button
+            ref={prevRef}
+            type="button"
+            aria-label="이전 이미지"
+            className="absolute top-1/2 left-2 z-20 flex h-12 w-12 -translate-y-1/2 cursor-pointer items-center justify-center text-white transition-opacity hover:opacity-80"
+          >
+            <ChevronLeft size={44} strokeWidth={1.5} />
+          </button>
+          <button
+            ref={nextRef}
+            type="button"
+            aria-label="다음 이미지"
+            className="absolute top-1/2 right-2 z-20 flex h-12 w-12 -translate-y-1/2 cursor-pointer items-center justify-center text-white transition-opacity hover:opacity-80"
+          >
+            <ChevronRight size={44} strokeWidth={1.5} />
+          </button>
+        </>
+      ) : null}
+
+      {/* 거래상태 중앙 큰 오버레이 (메인 카드 ProductThumbnail과 동일 패턴) */}
+      {isOverlayShown ? (
+        <div className={cn('pointer-events-none absolute inset-0 z-30 flex items-center justify-center', overlayBg)}>
+          <span className={cn('rounded-full bg-white/95 font-bold text-gray-900 shadow-md', badgeSizeClass)}>
+            {displayTradeStatus}
+          </span>
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/src/features/product-detail/components/ProductActions.tsx
+++ b/src/features/product-detail/components/ProductActions.tsx
@@ -34,11 +34,14 @@ export default function ProductActions({ id, isFavorite: initialIsFavorite, sell
 
   const handleChat = async () => {
     try {
-      const { createChatRoom: chatRoom } = await fetchGraphQL<{ createChatRoom: { chatRoomId: number } }>(`
+      const { createChatRoom: chatRoom } = await fetchGraphQL<{ createChatRoom: { chatRoomId: number } }>(
+        `
         mutation CreateChatRoom($productId: Int!) {
           createChatRoom(productId: $productId) { chatRoomId }
         }
-      `, { productId: id })
+      `,
+        { productId: id }
+      )
       sessionStorage.setItem('chatRoom', JSON.stringify(chatRoom))
       router.push(ROUTES.CHAT_ROOM_ID(chatRoom.chatRoomId))
     } catch {
@@ -49,19 +52,23 @@ export default function ProductActions({ id, isFavorite: initialIsFavorite, sell
   return (
     <div className="gap-sm flex">
       <Button
+        size="md"
+        className="bg-primary-400 flex-1 cursor-pointer text-white"
+        onClick={isMyProduct ? () => handleEdit(id) : handleChat}
+      >
+        {isMyProduct ? '수정하기' : '채팅하기'}
+      </Button>
+      <Button
         icon={Heart}
         iconProps={{
           color: isFavorite ? '#fc8181' : undefined,
           fill: isFavorite ? '#fc8181' : 'none',
         }}
         size="md"
-        className="cursor-pointer border border-gray-300 bg-white"
+        className="cursor-pointer rounded-full border border-gray-300 bg-white"
         aria-label="찜하기"
         onClick={handleToggleFavorite}
       />
-      <Button size="md" className="bg-primary-400 flex-1 cursor-pointer text-white" onClick={isMyProduct ? () => handleEdit(id) : handleChat}>
-        {isMyProduct ? '수정하기' : '채팅하기'}
-      </Button>
     </div>
   )
 }

--- a/src/features/product-detail/components/ProductBadges.tsx
+++ b/src/features/product-detail/components/ProductBadges.tsx
@@ -1,45 +1,20 @@
-import { getTradeStatus } from '@/lib/utils/getTradeStatus'
-import { getTradeStatusColor } from '@/lib/utils/getTradeStatusColor'
-import { getPetTypeName } from '@/lib/utils/getPetTypeName'
-import { getCategory } from '@/lib/utils/getCategory'
 import { getProductStatus } from '@/lib/utils/getProductStatus'
 import { getProductType } from '@/lib/utils/getProductType'
-import Badge from '@/components/commons/badge/Badge'
-import { cn } from '@/lib/utils/cn'
+import { ProductBadge, type ProductBadgeItem } from '@/components/product/components/ProductBadge'
 
 interface ProductBadgesProps {
-  tradeStatus: string | null
-  petDetailType: string
-  category: string
-  productStatus: string
   productType: string
+  productStatus: string
 }
 
-export default function ProductBadges({ tradeStatus, petDetailType, category, productStatus, productType }: ProductBadgesProps) {
+export default function ProductBadges({ productType, productStatus }: ProductBadgesProps) {
   const productTypeName = getProductType(productType)
-  const productTradeName = getTradeStatus(tradeStatus)
-  const productTradeColor = getTradeStatusColor(tradeStatus)
-  const petTypeName = getPetTypeName(petDetailType)
-  const categoryName = getCategory(category)
   const productStatusName = getProductStatus(productStatus)
 
-  const getDisplayTradeStatus = () => {
-    if (productTypeName === '판매요청') {
-      if (productTradeName === '판매완료') return '요청완료'
-      if (tradeStatus === null || tradeStatus === '') return '요청중'
-    }
-    return productTradeName || ''
-  }
-  const displayTradeStatus = getDisplayTradeStatus()
+  const items: ProductBadgeItem[] = [
+    { label: productTypeName, tone: productTypeName === '판매요청' ? 'warning' : 'info' },
+    { label: productStatusName, tone: 'light' },
+  ]
 
-  return (
-    <div className="flex flex-col gap-2">
-      {displayTradeStatus ? <Badge className={cn('w-fit px-[15px] py-[10px] text-base font-semibold leading-none text-white', productTradeColor)}>{displayTradeStatus}</Badge> : null}
-      <div className="flex items-center gap-2 md:gap-1">
-        <Badge className={cn('bg-primary-700 px-2 py-1.5 text-[13px] font-semibold leading-none text-white')}>{petTypeName}</Badge>
-        <Badge className={cn('border bg-white px-2 py-1.5 text-[13px] font-semibold leading-none text-gray-900')}>{categoryName}</Badge>
-        <Badge className={cn('bg-primary-200 px-2 py-1.5 text-[13px] font-semibold leading-none')}>{productStatusName}</Badge>
-      </div>
-    </div>
-  )
+  return <ProductBadge items={items} size="md" />
 }

--- a/src/features/product-detail/components/ProductMetadataList.tsx
+++ b/src/features/product-detail/components/ProductMetadataList.tsx
@@ -1,4 +1,4 @@
-import { Clock, Heart, MapPin, Eye } from 'lucide-react'
+import { Heart, Eye } from 'lucide-react'
 import { getTimeAgo } from '@/lib/utils/getTimeAgo'
 import { ProductMetaItem } from '@/components/product/ProductMetaItem'
 
@@ -19,10 +19,28 @@ export default function ProductMetadataList({
 }: ProductMetadataListProps) {
   return (
     <div className="flex flex-wrap items-center gap-2 md:gap-3">
-      <ProductMetaItem icon={MapPin} iconSize={14} label={`${addressSido} ${addressGugun}`} textClassName="text-xs md:text-sm font-normal" />
-      <ProductMetaItem icon={Clock} iconSize={14} label={getTimeAgo(createdAt)} textClassName="text-xs md:text-sm font-normal" />
-      <span className="hidden md:flex"><ProductMetaItem icon={Eye} iconSize={14} label={`조회 ${viewCount}`} textClassName="text-xs md:text-sm font-normal" /></span>
-      <span className="hidden md:flex"><ProductMetaItem icon={Heart} iconSize={14} label={`찜 ${favoriteCount}`} textClassName="text-xs md:text-sm font-normal" /></span>
+      {/* <ProductMetaItem icon={MapPin} iconSize={14} label={`${addressSido} ${addressGugun}`} textClassName="text-xs md:text-sm font-normal" />
+      <ProductMetaItem icon={Clock} iconSize={14} label={getTimeAgo(createdAt)} textClassName="text-xs md:text-sm font-normal" /> */}
+      <ProductMetaItem label={getTimeAgo(createdAt)} textClassName="text-xs md:text-sm font-normal" />
+      <ProductMetaItem label={`${addressSido} ${addressGugun}`} textClassName="text-xs md:text-sm font-normal" />
+      <span className="hidden md:flex">
+        <ProductMetaItem
+          icon={Eye}
+          iconSize={14}
+          label={`${viewCount}`}
+          textClassName="text-xs md:text-sm font-normal"
+          iconClassName="text-gray-400"
+        />
+      </span>
+      <span className="hidden md:flex">
+        <ProductMetaItem
+          icon={Heart}
+          iconSize={14}
+          label={`${favoriteCount}`}
+          textClassName="text-xs md:text-sm font-normal"
+          iconClassName="text-gray-400"
+        />
+      </span>
     </div>
   )
 }

--- a/src/features/product-detail/components/ProductSummary.tsx
+++ b/src/features/product-detail/components/ProductSummary.tsx
@@ -1,10 +1,10 @@
 'use client'
 
 import { useState } from 'react'
-import { Flag } from 'lucide-react'
 import ProductMetadataList from './ProductMetadataList'
 import ProductTitle from './ProductTitle'
 import dynamic from 'next/dynamic'
+import SellerProfileCard from './SellerProfileCard'
 const ProductReportModal = dynamic(() => import('@/components/modal/ProductReportModal'))
 
 interface ProductHeaderProps {
@@ -18,6 +18,13 @@ interface ProductHeaderProps {
     createdAt: string
     viewCount: number
     favoriteCount: number
+    sellerInfo: {
+      sellerId: number
+      sellerNickname: string
+      sellerProfileImageUrl: string
+      addressSido: string | null
+      addressGugun: string | null
+    }
   }
 }
 
@@ -25,7 +32,7 @@ export default function ProductSummary({ data }: ProductHeaderProps) {
   const [isReportOpen, setIsReportOpen] = useState(false)
 
   return (
-    <div className="flex flex-col gap-3.5">
+    <div className="flex flex-col gap-2">
       <ProductTitle title={data.title} productType={data.productType} price={data.price} />
       <div className="flex items-center justify-between">
         <ProductMetadataList
@@ -40,10 +47,14 @@ export default function ProductSummary({ data }: ProductHeaderProps) {
           onClick={() => setIsReportOpen(true)}
           className="hidden cursor-pointer items-center gap-1 text-sm text-gray-400 hover:text-red-500 md:flex"
         >
-          <Flag size={14} />
           <span>신고하기</span>
         </button>
       </div>
+
+      <div className="mt-3">
+        <SellerProfileCard sellerInfo={data.sellerInfo} />
+      </div>
+
       <ProductReportModal
         isOpen={isReportOpen}
         productId={data.id}

--- a/src/features/product-detail/components/ProductTitle.tsx
+++ b/src/features/product-detail/components/ProductTitle.tsx
@@ -1,4 +1,3 @@
-import { getProductType } from '@/lib/utils/getProductType'
 import { formatPrice } from '@/lib/utils/formatPrice'
 
 interface ProductTitleProps {
@@ -7,17 +6,14 @@ interface ProductTitleProps {
   price: number
 }
 
-export default function ProductTitle({ title, productType, price }: ProductTitleProps) {
-  const productTypeName = getProductType(productType)
+export default function ProductTitle({ title, price }: ProductTitleProps) {
   return (
-    <div className="flex flex-col gap-3.5">
-      <h1 className="heading-h3 text-gray-900">{title}</h1>
-      <div className="flex flex-col">
-        <span className="text-base font-semibold text-gray-500">{productTypeName}</span>
-        <strong className="text-primary-300 heading-h3 max-w-[90%] overflow-hidden">
-          <span>{formatPrice(price)}</span>원
-        </strong>
-      </div>
+    <div className="flex flex-col gap-2">
+      <h1 className="heading-h4 leading-none text-gray-900">{title}</h1>
+      <strong className="text-primary-300 heading-h3 max-w-[90%] overflow-hidden leading-none">
+        <span className="leading-none">{formatPrice(price)}</span>원
+      </strong>
+      {/* <span className="text-base font-semibold text-gray-500">{productTypeName}</span> */}
     </div>
   )
 }

--- a/src/features/product-detail/components/SellerOtherProducts.tsx
+++ b/src/features/product-detail/components/SellerOtherProducts.tsx
@@ -2,8 +2,10 @@ import type { Product } from '@/types'
 import { Package } from 'lucide-react'
 import ProductList from '@/components/product/ProductList'
 import EmptyState from '@/components/EmptyState'
+import { getProductType } from '@/lib/utils/getProductType'
 
 interface SellerOtherProductsProps {
+  productType: string
   sellerOtherProducts: Product[]
   sellerInfo: {
     sellerId: number
@@ -12,19 +14,28 @@ interface SellerOtherProductsProps {
   }
 }
 
-export default function SellerOtherProducts({ sellerInfo, sellerOtherProducts }: SellerOtherProductsProps) {
+export default function SellerOtherProducts({ productType, sellerInfo, sellerOtherProducts }: SellerOtherProductsProps) {
+  const isRequest = getProductType(productType) === '판매요청'
+  const heading = isRequest
+    ? `${sellerInfo?.sellerNickname}님이 찾고 있는 다른 상품`
+    : `${sellerInfo?.sellerNickname}님이 판매 중인 다른 상품`
+  const emptyDescription = isRequest
+    ? `${sellerInfo?.sellerNickname}님이 찾고 있는 다른 상품이 아직 없습니다.`
+    : `${sellerInfo?.sellerNickname}님이 판매 중인 다른 상품이 아직 없습니다.`
+
   return (
     <div className="pb-4xl">
-      <h2 className="mb-lg text-[18px] leading-[26px] font-bold">{sellerInfo?.sellerNickname}님의 다른 판매 상품</h2>
+      <h2 className="mb-lg text-[18px] leading-[26px] font-bold">{heading}</h2>
 
       {sellerOtherProducts?.length !== 0 ? (
-        <ProductList products={sellerOtherProducts.slice(0, 3)} showMoreButton sellerId={sellerInfo.sellerId} />
-      ) : (
-        <EmptyState
-          icon={Package}
-          title="등록된 다른 상품이 없어요"
-          description={`${sellerInfo?.sellerNickname}님이 판매 중인 다른 상품이 아직 없습니다.`}
+        <ProductList
+          products={sellerOtherProducts.slice(0, 3)}
+          showMoreButton
+          sellerId={sellerInfo.sellerId}
+          hideProductType
         />
+      ) : (
+        <EmptyState icon={Package} title="등록된 다른 상품이 없어요" description={emptyDescription} />
       )}
     </div>
   )

--- a/src/features/product-detail/components/SellerProfileCard.tsx
+++ b/src/features/product-detail/components/SellerProfileCard.tsx
@@ -3,7 +3,6 @@
 import { useState } from 'react'
 import Image from 'next/image'
 import { IMAGE_SIZES, imageLoader, toResizedWebpUrl } from '@/lib/utils/imageUrl'
-import Button from '@/components/commons/button/Button'
 import { useRouter } from 'next/navigation'
 import { useUserStore } from '@/store/userStore'
 import { useLoginModalStore } from '@/store/modalStore'
@@ -13,6 +12,8 @@ interface SellerProfileCardProps {
     sellerId: number
     sellerNickname: string
     sellerProfileImageUrl: string
+    addressSido: string | null
+    addressGugun: string | null
   }
 }
 
@@ -32,33 +33,40 @@ export default function SellerProfileCard({ sellerInfo }: SellerProfileCardProps
   }
 
   return sellerInfo?.sellerId !== user?.id ? (
-      <div className="flex items-center justify-between rounded-lg border border-gray-200 bg-white p-3">
-        <div className="flex items-center gap-2">
-          <div className="bg-primary-50 relative flex h-10 w-10 items-center justify-center overflow-hidden rounded-full">
-            {sellerInfo.sellerProfileImageUrl ? (
-              <Image
-                src={imgError ? sellerInfo.sellerProfileImageUrl : toResizedWebpUrl(sellerInfo.sellerProfileImageUrl, 150)}
-                loader={imgError ? undefined : imageLoader}
-                sizes={IMAGE_SIZES.tinyThumbnail}
-                alt={sellerInfo?.sellerNickname}
-                fill
-                className="object-cover"
-                onError={() => setImgError(true)}
-                unoptimized={imgError}
-              />
-            ) : (
-              <div className="heading-h5 font-normal!">{sellerInfo?.sellerNickname.charAt(0).toUpperCase()}</div>
-            )}
-          </div>
-          <h2 className="font-medium text-gray-900">{sellerInfo?.sellerNickname}</h2>
+    <div className="flex cursor-pointer items-center justify-between" onClick={() => goToUserPage(sellerInfo.sellerId)}>
+      <div className="flex items-center gap-2">
+        <div className="bg-primary-50 relative flex h-10 w-10 items-center justify-center overflow-hidden rounded-full">
+          {sellerInfo.sellerProfileImageUrl ? (
+            <Image
+              src={imgError ? sellerInfo.sellerProfileImageUrl : toResizedWebpUrl(sellerInfo.sellerProfileImageUrl, 150)}
+              loader={imgError ? undefined : imageLoader}
+              sizes={IMAGE_SIZES.tinyThumbnail}
+              alt={sellerInfo?.sellerNickname}
+              fill
+              className="object-cover"
+              onError={() => setImgError(true)}
+              unoptimized={imgError}
+            />
+          ) : (
+            <div className="heading-h5 font-normal!">{sellerInfo?.sellerNickname.charAt(0).toUpperCase()}</div>
+          )}
         </div>
-        <Button
+        <div className="flex flex-col gap-2">
+          <h2 className="leading-none font-medium text-gray-900">{sellerInfo?.sellerNickname}</h2>
+          {sellerInfo.addressSido || sellerInfo.addressGugun ? (
+            <span className="text-xs leading-none text-gray-500">
+              {[sellerInfo.addressSido, sellerInfo.addressGugun].filter(Boolean).join(' ')}
+            </span>
+          ) : null}
+        </div>
+      </div>
+      {/* <Button
           size="sm"
           className="h-fit cursor-pointer border border-gray-200 bg-white text-xs md:text-sm text-gray-900"
           onClick={() => goToUserPage(sellerInfo.sellerId)}
         >
           판매자 프로필 보기
-        </Button>
-      </div>
+        </Button> */}
+    </div>
   ) : null
 }

--- a/src/styles/utilities/typography.css
+++ b/src/styles/utilities/typography.css
@@ -1,5 +1,5 @@
-@layer utilities {
-  /* 헤딩 */
+/* 헤딩 — components layer에 둬서 Tailwind utility(leading-*, text-* 등)로 자유롭게 덮어쓸 수 있게 함 */
+@layer components {
   .heading-h1 {
     font-size: var(--text-h1);
     line-height: var(--text-h1--line-height);
@@ -48,7 +48,10 @@
     font-weight: var(--text-h5--weight);
     letter-spacing: var(--text-h5--tracking);
   }
+}
 
+/* 진짜 utility 클래스들 — 그대로 utilities layer 유지 */
+@layer utilities {
   .blind {
     position: absolute;
     border: 0px;

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -47,6 +47,8 @@ export interface ProductDetailItem extends Product {
     sellerId: number
     sellerNickname: string
     sellerProfileImageUrl: string
+    addressSido: string | null
+    addressGugun: string | null
   }
   sellerOtherProducts: Product[]
 }


### PR DESCRIPTION
## 📌 개요
상품 상세페이지 전반을 리뉴얼합니다. 메인 이미지 캐러셀, 카테고리 브레드크럼, 뱃지 시스템 통일, 판매자 프로필 재배치, 다른 상품 목록 개선이 핵심.

## 🔧 작업 내용

### 메인 이미지 영역
- 단일 이미지 → **Swiper 캐러셀** (대표+서브 이미지를 단일 array로 결합)
- Pagination dots 흰색 기반 + Lucide ChevronLeft/Right (44px / strokeWidth 1.5)
- 거래상태 오버레이/뱃지 유지 (판매완료·요청완료는 살짝 큰 사이즈)
- swiper@^12.1.4 추가

### 우측 컬럼
- **Breadcrumb** 추가 (`강아지 > 외출용품`), 메인 이미지 위쪽 좌측 정렬, 클릭 시 메인 페이지 필터 적용 이동
- ProductBadges 재구성: 거래상태 큰 뱃지 제거(이미지로 이동), `판매/판매요청 + 상품상태` 인라인 표시
- SellerProfileCard 위치 이동: 좌측 → 우측 컬럼의 ProductMetadataList 아래
- 판매자 주소 표시 (`addressSido / addressGugun`)

### 다른 상품 목록 (SellerOtherProducts)
- 같은 productType만 표시 (백엔드 필터 연동)
- 동적 제목:
  - 판매 → "{닉네임}님이 판매 중인 다른 상품"
  - 판매요청 → "{닉네임}님이 찾고 있는 다른 상품"
- 카드의 productType 뱃지 숨김, 상품상태 뱃지는 유지
- ProductList/ProductCard에 `hideProductType` prop 추가

### 공용 컴포넌트
- **Breadcrumb 공용 컴포넌트 신설** ([src/components/commons/breadcrumb/Breadcrumb.tsx](https://github.com/jjub0217/cuddle-market/blob/feature/696--product-detail-redesign/src/components/commons/breadcrumb/Breadcrumb.tsx))
- **ProductBadge 통일**: 5종 tone 동일 사이즈/모서리/폰트굵기 (TONE_BASE 추출) + `size` prop 추가
- **ProductInfo**: `hideProductType` 시 productType만 숨기고 productStatus는 유지
- **typography.css**: `.heading-h*` 클래스 `@layer components`로 이동 → Tailwind utility로 line-height 등 override 가능

### 기타
- ProductActions 찜하기 버튼 `rounded-full`
- ProductTitle, ProductMetadataList 작은 시각 조정
- types/product.ts: `sellerInfo`에 `addressSido / addressGugun` 추가

## 🔗 백엔드 의존성 (cmarket_api 별도 PR로 배포 완료)
- `SellerInfoResponse`에 `addressSido / addressGugun` 필드 추가
- `ProductRepository.findBySellerIdAndProductType...IdNot` 메서드 (productType 필터)
- `ProductListItemResponse`에 `productType` 필드 추가

## 📎 관련 이슈
Closes #696

## 💬 리뷰어 참고 사항
- 본 PR은 18개 파일에 영향이 있지만 모두 "상세페이지 리뉴얼" 단일 테마. 분리 시 ProductDetail.tsx / ProductBadge.tsx 등 공통 파일 충돌 위험이 커서 단일 PR로 진행
- ProductCard/ProductList의 `hideProductType` prop은 신규 추가일 뿐, 기존 호출부에 영향 없음
- ProductBadge size 통일 — 기존 ProductInfo는 sm 그대로, 상세 페이지만 md 사용
- `.heading-h*` layer 변경은 Tailwind layer 우선순위 활용 (utilities > components) — 기존 사용처에 시각 변화 없음