### PR TITLE
feat: 커뮤니티 페이지 리뉴얼 및 답글 시스템 개편(#698)

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -143,7 +143,7 @@ export default function Header() {
           'fixed top-0 flex w-full items-center justify-center pt-3 transition-colors duration-300 xl:pb-3',
           !isXl && (isSearchOpen ? 'pb-0' : 'pb-3'),
           // 홈 페이지 상단: 투명 (hero 위에 떠있음). 그 외: 솔리드 (cream bg + 보더)
-          showSolid ? 'border-b border-[#d4c4b2]/40 bg-[#fcf9f8]/95 backdrop-blur-sm' : 'bg-transparent',
+          showSolid ? 'border-outline-variant/40 bg-surface/95 border-b backdrop-blur-sm' : 'bg-transparent',
           Z_INDEX.HEADER
         )}
       >
@@ -185,7 +185,7 @@ export default function Header() {
               ) : null}
             </div>
 
-            {/* 가운데: 검색바 (xl+에서 중앙 배치) */}
+            {/* 가운데: 검색바 (xl+에서 중앙 배치). 검색바가 숨겨진 경우엔 spacer로 우측 컨트롤을 끝으로 push */}
             {!hideSearchBar && isXl ? (
               <div className="mx-auto max-w-130 flex-1">
                 <Suspense>
@@ -197,10 +197,9 @@ export default function Header() {
                   />
                 </Suspense>
               </div>
-            ) : null}
-
-            {/* xl 미만에서는 search/controls를 우측으로 push */}
-            {!isXl ? <div className="flex-1" /> : null}
+            ) : (
+              <div className="flex-1" aria-hidden="true" />
+            )}
 
             {/* 오른쪽: 검색 토글(모바일) + 사용자 컨트롤 */}
             <div className="flex shrink-0 items-center gap-1 xl:gap-4">

--- a/src/components/product/components/ProductThumbnail.tsx
+++ b/src/components/product/components/ProductThumbnail.tsx
@@ -69,7 +69,7 @@ export function ProductThumbnail({
   return (
     <div
       className={cn(
-        'relative overflow-hidden bg-[#f6efe2]',
+        'bg-chip-surface relative overflow-hidden',
         vertical ? 'flex-none pb-[75%]' : 'flex-2 pb-[35%] md:flex-none md:pb-[75%]'
       )}
     >

--- a/src/features/community/CommunityDetail.tsx
+++ b/src/features/community/CommunityDetail.tsx
@@ -19,15 +19,13 @@ import ProfileAvatar from '@/components/commons/ProfileAvatar'
 import { useForm, useWatch } from 'react-hook-form'
 import type { CommentPostRequestData, CommunityDetailItem, Comment } from '@/types'
 import { useEffect, useRef, useState } from 'react'
-import { MessageSquareText, EllipsisVertical } from 'lucide-react'
+import { MessageSquareText } from 'lucide-react'
 const PostReportModal = dynamic(() => import('@/components/modal/PostReportModal'))
 const DeletePostConfirmModal = dynamic(() => import('@/components/modal/DeletePostConfirmModal'))
 import { useUserStore } from '@/store/userStore'
 import { useLoginModalStore } from '@/store/modalStore'
-import IconButton from '@/components/commons/button/IconButton'
 import { AnimatePresence } from 'framer-motion'
 import InlineNotification from '@/components/commons/InlineNotification'
-import { useOutsideClick } from '@/hooks/useOutsideClick'
 
 interface CommunityDetailProps {
   initialPostData?: CommunityDetailItem
@@ -49,14 +47,11 @@ export default function CommunityDetail({ initialPostData, initialCommentData }:
   const openLoginModal = useLoginModalStore((state) => state.openLoginModal)
   const pathname = usePathname()
   const searchParamsHook = useSearchParams()
-  const [isMoreMenuOpen, setIsMoreMenuOpen] = useState(false)
   const [isReportModalOpen, setIsReportModalOpen] = useState(false)
   const [isPostDeleteModalOpen, setIsPostDeleteModalOpen] = useState(false)
   const [postDeleteError, setIsPostDeleteError] = useState<React.ReactNode | null>(null)
   const [commentPostError, setCommentPostError] = useState<React.ReactNode | null>(null)
   const mobileInputRef = useRef<HTMLTextAreaElement>(null)
-  const modalRef = useRef<HTMLDivElement>(null)
-  useOutsideClick(isMoreMenuOpen, [modalRef], () => setIsMoreMenuOpen(false))
 
   const router = useRouter()
   const queryClient = useQueryClient()
@@ -121,10 +116,6 @@ export default function CommunityDetail({ initialPostData, initialCommentData }:
       )
     }
   }
-  const handleMoreToggle = () => {
-    setIsMoreMenuOpen((prev) => !prev)
-  }
-
   const handlePostEdit = (postId: number) => {
     router.push(`/community/${postId}/edit`)
   }
@@ -166,91 +157,80 @@ export default function CommunityDetail({ initialPostData, initialCommentData }:
 
   return (
     <>
-      <div className="min-h-screen bg-[#F3F4F6] pt-5 pb-16 md:pb-0">
+      <div className="min-h-screen bg-white pt-8 pb-16 md:pb-0">
         <div className="px-lg pb-4xl mx-auto max-w-7xl">
           <div className="flex flex-col justify-center gap-3.5">
-            <div className="flex flex-col gap-3.5 rounded-lg border border-gray-400 bg-white px-4 py-5 shadow-xl md:px-6">
-              <div className="relative flex items-center justify-between">
-                <Badge className="bg-primary-400 w-fit rounded-full text-xs text-white md:font-semibold">
-                  {getBoardType(data.boardType as 'QUESTION' | 'INFO')}
-                </Badge>
-                <IconButton aria-label="더보기" className="" size="sm" onClick={handleMoreToggle}>
-                  <EllipsisVertical size={16} className="text-gray-500" />
-                </IconButton>
-                {isMoreMenuOpen ? (
-                  <div
-                    className="absolute top-7 right-0 flex flex-col rounded border border-gray-200 bg-white shadow-md md:min-w-14"
-                    ref={modalRef}
-                  >
-                    {user?.id === data?.authorId ? (
-                      <>
-                        <button
-                          className="cursor-pointer px-3 py-1.5 text-sm whitespace-nowrap hover:bg-gray-50"
-                          type="button"
-                          onClick={() => {
-                            setIsMoreMenuOpen(false)
-                            handlePostEdit(Number(id))
-                          }}
-                        >
-                          수정
-                        </button>
-                        <button
-                          className="cursor-pointer px-3 py-1.5 text-sm whitespace-nowrap hover:bg-gray-50"
-                          type="button"
-                          onClick={() => {
-                            setIsMoreMenuOpen(false)
-                            setIsPostDeleteModalOpen(true)
-                          }}
-                        >
-                          삭제
-                        </button>
-                      </>
-                    ) : (
-                      <button
-                        className="cursor-pointer px-3 py-1.5 text-sm whitespace-nowrap hover:bg-gray-50"
-                        type="button"
-                        onClick={() => {
-                          setIsMoreMenuOpen(false)
-                          if (!user) {
-                            openLoginModal()
-                          } else {
-                            setIsReportModalOpen(true)
-                          }
-                        }}
-                      >
-                        신고하기
-                      </button>
-                    )}
-                  </div>
-                ) : null}
-              </div>
-              <div className="flex items-end justify-between">
+            <div className="flex flex-col gap-3.5 rounded-lg py-5">
+              <Badge className="bg-primary-400 w-fit rounded-full text-xs text-white md:font-semibold">
+                {getBoardType(data.boardType as 'QUESTION' | 'INFO')}
+              </Badge>
+              <h1 className="text-2xl leading-snug font-bold">{data.title}</h1>
+              <div className="border-outline-variant/40 flex items-end justify-between border-b pb-4">
                 <div className="flex items-center gap-3.5">
                   <ProfileAvatar
                     imageUrl={data.authorProfileImageUrl}
                     nickname={data.authorNickname}
                     size="lg"
-                    className="h-10 w-10 md:h-12 md:w-12"
+                    className="h-10 w-10 md:h-10 md:w-10"
                   />
                   {/* 유저 정보 */}
-                  <div className="flex flex-col justify-center gap-0.5">
-                    <p className="text-sm font-semibold md:text-base">{data.authorNickname}</p>
-                    <p className="text-xs text-gray-500 md:text-sm">{getTimeAgo(data.createdAt)}</p>
+                  <div className="flex flex-col gap-2">
+                    <p className="text-sm leading-none font-medium md:text-base">{data.authorNickname}</p>
+                    <div className="flex items-center gap-1">
+                      <p className="text-xs leading-none text-gray-500">{getTimeAgo(data.createdAt)}</p>
+                      <span aria-hidden="true" className="text-xs">
+                        ·
+                      </span>
+                      <p className="text-xs leading-none text-gray-500">조회 {data.viewCount}</p>
+                    </div>
                   </div>
                 </div>
-                <p className="text-xs text-gray-500 md:text-sm">조회 {data.viewCount}</p>
+                <div className="flex items-center gap-1">
+                  {user?.id === data?.authorId ? (
+                    <>
+                      <button
+                        className="text-primary-container cursor-pointer text-xs font-medium hover:underline"
+                        type="button"
+                        onClick={() => handlePostEdit(Number(id))}
+                      >
+                        수정
+                      </button>
+                      <span aria-hidden="true" className="text-xs">
+                        ·
+                      </span>
+                      <button
+                        className="text-primary-container cursor-pointer text-xs font-medium hover:underline"
+                        type="button"
+                        onClick={() => setIsPostDeleteModalOpen(true)}
+                      >
+                        삭제
+                      </button>
+                    </>
+                  ) : (
+                    <button
+                      className="cursor-pointer text-xs font-medium text-gray-500 hover:underline"
+                      type="button"
+                      onClick={() => {
+                        if (!user) {
+                          openLoginModal()
+                        } else {
+                          setIsReportModalOpen(true)
+                        }
+                      }}
+                    >
+                      신고하기
+                    </button>
+                  )}
+                </div>
               </div>
-              <h1 className="text-lg leading-snug font-bold">{data.title}</h1>
+              {/* <h1 className="text-lg leading-snug font-bold">{data.title}</h1> */}
               <MdPreview value={data.content} className="p-0" />
             </div>
 
-            <section
-              aria-label="댓글"
-              className="flex flex-col gap-3.5 rounded-lg border border-gray-400 bg-white px-3 py-5 shadow-xl md:px-6"
-            >
-              <div className="flex items-center gap-1 text-sm font-semibold text-gray-500">
+            <section aria-label="댓글" className="flex flex-col gap-3.5 py-5">
+              <div className="text-md flex items-center gap-1 font-semibold">
                 <span>댓글</span>
-                <span className="font-normal">{data.commentCount}</span>
+                <span className="text-primary-container font-semibold">{data.commentCount}</span>
               </div>
 
               {commentData?.comments && commentData.comments.length > 0 ? (
@@ -290,10 +270,13 @@ export default function CommunityDetail({ initialPostData, initialCommentData }:
               </div>
             </section>
 
-            {/* 모바일용 댓글 입력: 하단 고정 */}
+            {/* 모바일용 댓글 입력: BottomNav(h-14 + iOS safe-area) 바로 위에 고정 */}
             <div
-              className="fixed right-0 bottom-0 left-0 border-t border-gray-200 bg-white px-3 py-2 md:hidden"
-              style={{ zIndex: 30 }}
+              className="fixed right-0 left-0 border-t border-gray-200 bg-white px-3 py-2 md:hidden"
+              style={{
+                bottom: 'calc(3.5rem + env(safe-area-inset-bottom))',
+                zIndex: 30,
+              }}
             >
               <CommentForm
                 id="comment-input-mobile"

--- a/src/features/community/CommunityPage.tsx
+++ b/src/features/community/CommunityPage.tsx
@@ -1,25 +1,22 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { COMMUNITY_SEARCH_TYPE, COMMUNITY_SORT_TYPE, COMMUNITY_TABS, type CommunityTabId } from '@/constants/constants'
+import { COMMUNITY_SORT_TYPE, COMMUNITY_TABS, type CommunityTabId } from '@/constants/constants'
 import { CommunityTabs } from './components/CommunityTabs'
-import SearchBar from '@/components/header/components/SearchBar'
-import SelectDropdown from '@/components/commons/select/SelectDropdown'
 import { ROUTES } from '@/constants/routes'
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { api } from '@/lib/api/api'
-import { UserRound, Clock, MessageSquare, Eye, Dot, Plus, MessageSquareText } from 'lucide-react'
-import LoadMoreButton from '@/components/commons/button/LoadMoreButton'
+import { Eye, Loader2, MessageSquare, MessageSquareText, PenLine, Plus, Search } from 'lucide-react'
+import { useIntersectionObserver } from '@/hooks/useIntersectionObserver'
 import { getTimeAgo } from '@/lib/utils/getTimeAgo'
 import { useUserStore } from '@/store/userStore'
-
-import { useScrollDirection } from '@/hooks/useScrollDirection'
 import { cn } from '@/lib/utils/cn'
 import { Z_INDEX } from '@/constants/ui'
 import EmptyState from '@/components/EmptyState'
 import type { CommunityItem } from '@/types'
+import { CommunityPostThumbnail } from './components/CommunityPostThumbnail'
 
 interface CommunityListData {
   page: number
@@ -37,53 +34,47 @@ interface CommunityPageProps {
   initialInfoData?: CommunityListData | null
 }
 
+const SEARCH_TYPE = 'title_content'
+
 export default function CommunityPage({ initialQuestionData, initialInfoData }: CommunityPageProps) {
   const searchParams = useSearchParams()
   const router = useRouter()
   const tabParam = searchParams.get('tab') as CommunityTabId | null
-  // URL 파라미터에서 직접 계산 (상태 불필요)
   const activeCommunityTypeTab: CommunityTabId = tabParam === 'tab-info' ? 'tab-info' : 'tab-question'
-  const { isCollapsed: isFilterCollapsed } = useScrollDirection()
 
-  const sortBy = searchParams.get('sortBy')
-  const [selectedSort, setSelectedSort] = useState<string>(() => {
-    const sortItem = COMMUNITY_SORT_TYPE.find((sort) => {
-      return sort.id === sortBy
-    })
-
-    return sortItem?.label || '최신순'
-  })
-  const [selectSearchType, setSelectedSearchType] = useState<string>('제목')
-  const searchType = COMMUNITY_SEARCH_TYPE.find((type) => type.label === selectSearchType)?.id || 'title'
+  const sortBy = searchParams.get('sortBy') ?? 'latest'
   const currentKeyword = searchParams.get('communityKeyword') || ''
+
+  const [searchInput, setSearchInput] = useState(currentKeyword)
+
+  useEffect(() => {
+    setSearchInput(currentKeyword)
+  }, [currentKeyword])
+
   const handleTabChange = (tabId: string) => {
     router.replace(`?tab=${tabId}`)
-    // 탭 이동 시 정렬 및 검색 조건 초기화
-    setSelectedSort('최신순')
-    setSelectedSearchType('제목')
   }
 
-  const handleSortChange = (value: string) => {
-    const sortItem = COMMUNITY_SORT_TYPE.find((sort) => sort.label === value)
-
-    if (!sortItem) return
+  const handleSortChange = (sortId: string) => {
     const params = new URLSearchParams(searchParams.toString())
-    params.set('sortBy', sortItem.id)
+    params.set('sortBy', sortId)
     router.push(`?${params.toString()}`)
-    setSelectedSort?.(sortItem.label)
   }
 
-  const handleSearchTypeChange = (value: string) => {
-    const searchTypeItem = COMMUNITY_SEARCH_TYPE.find((type) => type.label === value)
-    if (!searchTypeItem) return
-    const params = new URLSearchParams(searchParams.toString())
-    params.set('searchType', searchTypeItem.id)
-    params.delete('communityKeyword')
-    router.push(`?${params.toString()}`)
-    setSelectedSearchType(searchTypeItem.label)
+  const handleSearchSubmit = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.nativeEvent.isComposing) return
+    if (e.key === 'Enter') {
+      const params = new URLSearchParams(searchParams.toString())
+      const keyword = e.currentTarget.value.trim()
+      if (keyword) {
+        params.set('communityKeyword', keyword)
+      } else {
+        params.delete('communityKeyword')
+      }
+      router.push(`?${params.toString()}`)
+    }
   }
 
-  // 질문 게시판
   const {
     data: questionData,
     fetchNextPage: fetchNextQuestion,
@@ -92,10 +83,17 @@ export default function CommunityPage({ initialQuestionData, initialInfoData }: 
     isLoading: isLoadingQuestion,
     error: errorQuestion,
   } = useInfiniteQuery({
-    queryKey: ['community', 'question', searchType, currentKeyword, sortBy],
+    queryKey: ['community', 'question', SEARCH_TYPE, currentKeyword, sortBy],
     queryFn: async ({ pageParam }) => {
       const response = await api.get('/community/posts', {
-        params: { page: pageParam, size: 10, boardType: 'QUESTION', searchType, keyword: currentKeyword || undefined, sortBy: sortBy || undefined },
+        params: {
+          page: pageParam,
+          size: 10,
+          boardType: 'QUESTION',
+          searchType: SEARCH_TYPE,
+          keyword: currentKeyword || undefined,
+          sortBy,
+        },
       })
       return response.data.data
     },
@@ -105,7 +103,6 @@ export default function CommunityPage({ initialQuestionData, initialInfoData }: 
     enabled: activeCommunityTypeTab === 'tab-question',
   })
 
-  // 정보 공유 게시판
   const {
     data: infoData,
     fetchNextPage: fetchNextInfo,
@@ -114,10 +111,17 @@ export default function CommunityPage({ initialQuestionData, initialInfoData }: 
     isLoading: isLoadingInfo,
     error: errorInfo,
   } = useInfiniteQuery({
-    queryKey: ['community', 'info', searchType, currentKeyword, sortBy],
+    queryKey: ['community', 'info', SEARCH_TYPE, currentKeyword, sortBy],
     queryFn: async ({ pageParam }) => {
       const response = await api.get('/community/posts', {
-        params: { page: pageParam, size: 10, boardType: 'INFO', searchType, keyword: currentKeyword || undefined, sortBy: sortBy || undefined },
+        params: {
+          page: pageParam,
+          size: 10,
+          boardType: 'INFO',
+          searchType: SEARCH_TYPE,
+          keyword: currentKeyword || undefined,
+          sortBy,
+        },
       })
       return response.data.data
     },
@@ -127,15 +131,14 @@ export default function CommunityPage({ initialQuestionData, initialInfoData }: 
     enabled: activeCommunityTypeTab === 'tab-info',
   })
 
-  // 현재 탭에 맞는 로딩/에러 상태 선택
   const currentData = activeCommunityTypeTab === 'tab-question' ? questionData : infoData
-
   const isLoading = activeCommunityTypeTab === 'tab-question' ? isLoadingQuestion : isLoadingInfo
-
   const error = activeCommunityTypeTab === 'tab-question' ? errorQuestion : errorInfo
+  const fetchNextPage = activeCommunityTypeTab === 'tab-question' ? fetchNextQuestion : fetchNextInfo
+  const hasNextPage = activeCommunityTypeTab === 'tab-question' ? hasNextQuestion : hasNextInfo
+  const isFetchingNextPage = activeCommunityTypeTab === 'tab-question' ? isFetchingNextQuestion : isFetchingNextInfo
 
-  // 현재 탭에 맞는 데이터 선택
-  const communityPosts = (() => {
+  const communityPosts: CommunityItem[] = (() => {
     switch (activeCommunityTypeTab) {
       case 'tab-question':
         return questionData?.pages.flatMap((page) => page.content) ?? []
@@ -146,18 +149,18 @@ export default function CommunityPage({ initialQuestionData, initialInfoData }: 
     }
   })()
 
-  // 현재 탭에 맞는 페이지네이션 함수/상태
-  const fetchNextPage = activeCommunityTypeTab === 'tab-question' ? fetchNextQuestion : fetchNextInfo
-
-  const hasNextPage = activeCommunityTypeTab === 'tab-question' ? hasNextQuestion : hasNextInfo
-
-  const isFetchingNextPage = activeCommunityTypeTab === 'tab-question' ? isFetchingNextQuestion : isFetchingNextInfo
-
-  // const { title: headerTitle, description: headerDescription } = getHeaderContent()
   const { isLogin } = useUserStore()
   const hasHydrated = useUserStore((state) => state._hasHydrated)
 
-  // 페이지 진입 시 스크롤 최상단으로 이동
+  // 무한스크롤 sentinel
+  const sentinelRef = useIntersectionObserver({
+    enabled: !!hasNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    onIntersect: () => fetchNextPage(),
+    threshold: 0.1,
+  })
+
   useEffect(() => {
     window.scrollTo(0, 0)
   }, [])
@@ -165,7 +168,7 @@ export default function CommunityPage({ initialQuestionData, initialInfoData }: 
   if (isLoading && !currentData) {
     return (
       <div className="flex min-h-screen items-center justify-center">
-        <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-blue-600"></div>
+        <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-[#633f00]"></div>
       </div>
     )
   }
@@ -174,8 +177,8 @@ export default function CommunityPage({ initialQuestionData, initialInfoData }: 
     return (
       <div className="flex min-h-screen items-center justify-center">
         <div className="flex flex-col items-center gap-4">
-          <p>게시글을 불러올 수 없습니다</p>
-          <button onClick={() => window.location.reload()} className="text-blue-600 hover:text-blue-800">
+          <p className="text-[#504537]">게시글을 불러올 수 없습니다</p>
+          <button onClick={() => window.location.reload()} className="text-[#633f00] hover:underline">
             새로고침
           </button>
         </div>
@@ -184,205 +187,148 @@ export default function CommunityPage({ initialQuestionData, initialInfoData }: 
   }
 
   return (
-    <div className="relative min-h-screen bg-[#F3F4F6] pt-0 md:pt-5">
+    <div className="min-h-screen bg-white">
       <h1 className="sr-only">커뮤니티 페이지</h1>
-      <div className="pb-4xl mx-auto max-w-7xl px-0 md:px-4">
-        <div className="flex w-full flex-col">
-          {/* 모바일: 필터 영역 */}
-          <div className={cn('md:hidden sticky top-16 bg-white', Z_INDEX.DROPDOWN)}>
-            {/* 접히는 필터 영역 */}
-            <div
-              className={cn(
-                'bg-white transition-all duration-300 ease-out',
-                isFilterCollapsed ? 'max-h-0 overflow-hidden' : 'max-h-75 overflow-visible'
-              )}
-            >
-              <div className="flex items-center gap-2 border-b border-gray-200 p-3.5">
-                <SelectDropdown
-                  value={selectedSort}
-                  onChange={handleSortChange}
-                  displayValue={selectedSort.replace(/ ?순$/, '')}
-                  options={COMMUNITY_SORT_TYPE.map((sort) => ({
-                    value: sort.label,
-                    label: sort.label,
-                  }))}
-                  buttonClassName="border-0 bg-primary-500 text-white text-sm font-medium rounded-full px-4 pr-8 py-2"
-                  optionClassName="whitespace-nowrap"
-                />
-                <CommunityTabs
-                  tabs={COMMUNITY_TABS}
-                  activeTab={activeCommunityTypeTab}
-                  onTabChange={handleTabChange}
-                  ariaLabel="커뮤니티 타입"
-                />
-              </div>
+      <main className="mx-auto w-full max-w-7xl px-4 py-8">
+        {/* Header */}
+        <section className="mb-4">
+          {/* <h2 className="mb-6 text-lg font-bold tracking-tight text-[#633f00]">질문/정보</h2> */}
+          <CommunityTabs
+            tabs={COMMUNITY_TABS}
+            activeTab={activeCommunityTypeTab}
+            onTabChange={handleTabChange}
+            ariaLabel="커뮤니티 타입"
+          />
+        </section>
 
-              <div className="flex flex-row-reverse items-center justify-between gap-3 border-b border-gray-200 px-3.5 pt-4 pb-3.5">
-                <div className="h-11 w-32">
-                  <SelectDropdown
-                    value={selectSearchType}
-                    onChange={handleSearchTypeChange}
-                    options={COMMUNITY_SEARCH_TYPE.map((sort) => ({
-                      value: sort.label,
-                      label: sort.label,
-                    }))}
-                    buttonClassName="border border-gray-300 bg-primary-50 text-gray-900 text-base px-3 py-2 h-11"
-                  />
+        {/* Search (단독 행) */}
+        <section className="mb-6">
+          <div className="relative w-full">
+            <Search size={18} className="absolute top-1/2 left-4 -translate-y-1/2 text-[#827565]" />
+            <input
+              type="text"
+              value={searchInput}
+              onChange={(e) => setSearchInput(e.target.value)}
+              onKeyDown={handleSearchSubmit}
+              placeholder="궁금한 내용을 검색해보세요"
+              enterKeyHint="search"
+              className="border-outline-variant/40 bg-surface-container-low w-full rounded-full border py-2 pr-4 pl-11 text-sm text-[#1c1b1b] placeholder:text-sm placeholder:text-[#827565] focus:border-[#633f00] focus:ring-2 focus:ring-[#633f00]/20 focus:outline-none"
+            />
+          </div>
+        </section>
+
+        {/* Sort filter + 글쓰기 (콘텐츠 컨트롤 행) */}
+        <section className="mb-4 flex items-end justify-between gap-3 text-sm">
+          <div className="flex items-center gap-3">
+            {COMMUNITY_SORT_TYPE.map((sort, idx) => {
+              const isActive = sort.id === sortBy
+              return (
+                <div key={sort.id} className="flex items-center gap-3">
+                  {idx > 0 ? <span aria-hidden="true" className="bg-outline-variant/60 h-3 w-px" /> : null}
+                  <button
+                    type="button"
+                    onClick={() => handleSortChange(sort.id)}
+                    className={cn(
+                      'cursor-pointer transition-colors',
+                      isActive ? 'font-bold text-[#633f00]' : 'font-medium text-[#504537] hover:text-[#633f00]'
+                    )}
+                  >
+                    {sort.label}
+                  </button>
                 </div>
-                <SearchBar
-                  id="community-search-mobile"
-                  placeholder="게시글 검색"
-                  borderColor="border-gray-300"
-                  className="h-11 max-w-full"
-                  paramName="communityKeyword"
-                />
-              </div>
-            </div>
+              )
+            })}
           </div>
-
-          {/* 데스크탑 */}
-          <div className="hidden md:flex mb-7 w-full flex-col gap-4">
-            <div className="flex items-center justify-between">
-              <CommunityTabs
-                tabs={COMMUNITY_TABS}
-                activeTab={activeCommunityTypeTab}
-                onTabChange={handleTabChange}
-                ariaLabel="커뮤니티 타입"
-              />
-              {hasHydrated && isLogin() ? (
-                <Link
-                  href={`${ROUTES.COMMUNITY_POST}?tab=${activeCommunityTypeTab}`}
-                  className="bg-primary-300 rounded-lg px-3 py-2 text-white"
-                >
-                  글쓰기
-                </Link>
-              ) : null}
-            </div>
-
-            <div className="flex flex-row items-center justify-between gap-5">
-              <div className="h-auto w-36">
-                <SelectDropdown
-                  value={selectSearchType}
-                  onChange={handleSearchTypeChange}
-                  options={COMMUNITY_SEARCH_TYPE.map((sort) => ({
-                    value: sort.label,
-                    label: sort.label,
-                  }))}
-                  buttonClassName="border border-gray-300 bg-primary-50 text-gray-900 text-base px-3 py-2 "
-                />
-              </div>
-              <SearchBar
-                id="community-search-desktop"
-                placeholder="게시글 제목이나 내용, 작성자로 검색해보세요"
-                borderColor="border-gray-300"
-                className="h-11 max-w-full"
-                paramName="communityKeyword"
-              />
-              <div className="w-36">
-                <SelectDropdown
-                  value={selectedSort}
-                  onChange={handleSortChange}
-                  options={COMMUNITY_SORT_TYPE.map((category) => ({
-                    value: category.label,
-                    label: category.label,
-                  }))}
-                  buttonClassName="border border-gray-300 bg-primary-50 text-gray-900 text-base px-3 py-2"
-                />
-              </div>
-            </div>
-          </div>
-          <div
-            id={`panel-${COMMUNITY_TABS.find((tab) => tab.id === activeCommunityTypeTab)?.code}`}
-            role="tabpanel"
-            aria-labelledby={activeCommunityTypeTab}
-          >
-            {communityPosts.length === 0 ? (
-              <div className={cn('px-3.5 md:px-0', 'mt-4 md:mt-0')}>
-                <EmptyState icon={MessageSquareText} title="아직 게시글이 없어요" description="첫 번째 이야기를 나눠보세요!" />
-              </div>
-            ) : (
-              <ul className={cn('flex flex-col gap-2.5 px-3.5 md:p-0', 'mt-4 md:mt-0')}>
-                {communityPosts.map((post) => (
-                  <li key={post.id}>
-                    {/* 데스크탑 카드 */}
-                    <div className="hidden md:block">
-                      <div className="flex flex-col justify-center gap-2.5 rounded-lg border border-gray-400 bg-white px-3.5 pt-3.5 pb-3.5 shadow-xl">
-                        <Link href={ROUTES.COMMUNITY_DETAIL_ID(post.id, post.title)} className="flex flex-col gap-0.5">
-                          <p className="line-clamp-2 text-lg leading-snug font-semibold">{post.title}</p>
-                          <p className="line-clamp-1 whitespace-pre-line text-gray-600/90">{post.contentPreview}</p>
-                          <div className="mt-3 flex items-center gap-2.5 text-sm">
-                            <div className="flex items-center gap-1 text-gray-500/90">
-                              <UserRound size={14} className="text-gray-500/90" strokeWidth={2.3} />
-                              <p>{post.authorNickname}</p>
-                            </div>
-                            <div className="flex items-center gap-1 text-gray-500/90">
-                              <Clock size={14} className="text-gray-500/90" strokeWidth={2.3} />
-                              <p>{getTimeAgo(post.createdAt)}</p>
-                            </div>
-                            <div className="flex items-center gap-1 text-gray-500/90">
-                              <MessageSquare size={14} className="text-gray-500/90" strokeWidth={2.3} />
-                              <p>{post.commentCount}</p>
-                            </div>
-                            <div className="flex items-center gap-1 text-gray-500/90">
-                              <Eye size={14} className="text-gray-500/90" strokeWidth={2.3} />
-                              <span>조회</span>
-                              <span>{post.viewCount}</span>
-                            </div>
-                          </div>
-                        </Link>
-                      </div>
-                    </div>
-                    {/* 모바일 카드 */}
-                    <div className="md:hidden">
-                      <div className="flex flex-col justify-center gap-2.5 rounded-lg border border-gray-400 bg-white px-3.5 pt-3.5 pb-3.5 shadow-xl">
-                        <Link href={ROUTES.COMMUNITY_DETAIL_ID(post.id, post.title)} className="flex flex-col gap-4">
-                          <div className="flex flex-col gap-1">
-                            <p className="line-clamp-2 text-base leading-snug font-medium">{post.title}</p>
-                            <p className="line-clamp-1 whitespace-pre-line text-sm text-gray-600/90">{post.contentPreview}</p>
-                          </div>
-                          <div className="flex items-center justify-between gap-2.5 text-xs">
-                            <div className="flex items-center text-gray-500/90">
-                              <p>{post.authorNickname}</p>
-                              <Dot size={12} />
-                              <p>{getTimeAgo(post.createdAt)}</p>
-                            </div>
-                            <div className="flex items-center gap-2.5">
-                              <div className="flex items-center gap-1 text-gray-500/90">
-                                <MessageSquare size={12} className="text-gray-500/90" strokeWidth={2.3} />
-                                <p>{post.commentCount}</p>
-                              </div>
-                              <div className="flex items-center gap-1 text-gray-500/90">
-                                <Eye size={12} className="text-gray-500/90" strokeWidth={2.3} />
-                                <span>{post.viewCount}</span>
-                              </div>
-                            </div>
-                          </div>
-                        </Link>
-                      </div>
-                    </div>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </div>
-          {hasNextPage ? (
-            <>
-              <div className="hidden md:block">
-                <LoadMoreButton onClick={() => fetchNextPage()} isLoading={isFetchingNextPage} className="mt-4 border-0" />
-              </div>
-              <div className="mt-4 px-3.5 md:hidden">
-                <LoadMoreButton onClick={() => fetchNextPage()} isLoading={isFetchingNextPage} className="border-0" />
-              </div>
-            </>
+          {hasHydrated && isLogin() ? (
+            <Link
+              href={`${ROUTES.COMMUNITY_POST}?tab=${activeCommunityTypeTab}`}
+              className="hidden items-center gap-1.5 rounded-full bg-[#633f00] px-4 py-2 text-sm font-bold whitespace-nowrap text-white shadow-sm transition-opacity hover:opacity-90 active:scale-95 md:flex"
+            >
+              <PenLine size={16} />
+              <span>글쓰기</span>
+            </Link>
           ) : null}
-        </div>
-      </div>
+        </section>
+
+        {/* Post list */}
+        <section
+          id={`panel-${COMMUNITY_TABS.find((tab) => tab.id === activeCommunityTypeTab)?.code}`}
+          role="tabpanel"
+          aria-labelledby={activeCommunityTypeTab}
+        >
+          {communityPosts.length === 0 ? (
+            <EmptyState icon={MessageSquareText} title="아직 게시글이 없어요" description="첫 번째 이야기를 나눠보세요!" />
+          ) : (
+            <ul className="grid grid-cols-1 gap-4">
+              {communityPosts.map((post) => (
+                <li key={post.id}>
+                  <Link
+                    href={ROUTES.COMMUNITY_DETAIL_ID(post.id, post.title)}
+                    className="group border-outline-variant/40 block rounded-2xl border bg-white p-5 shadow-sm transition-all hover:shadow-md md:p-4"
+                  >
+                    <div className="grid grid-cols-[minmax(0,1fr)_auto] items-stretch gap-4">
+                      <div className="min-w-0 flex-1">
+                        {/* Author + time */}
+                        <div className="mb-3 flex items-end gap-2.5">
+                          <div className="bg-chip-surface flex size-9 items-center justify-center rounded-full text-sm font-bold text-[#825500]">
+                            {post.authorNickname.charAt(0).toUpperCase()}
+                          </div>
+                          <div className="flex flex-col leading-tight">
+                            <span className="text-sm font-bold text-[#1c1b1b]">{post.authorNickname}</span>
+                            <span className="text-xs text-[#827565]">{getTimeAgo(post.createdAt)}</span>
+                          </div>
+                        </div>
+
+                        {/* Title */}
+                        <h3 className="mb-2 line-clamp-2 text-lg leading-snug font-semibold text-[#1c1b1b] transition-colors group-hover:text-[#633f00]">
+                          {post.title}
+                        </h3>
+
+                        {/* Preview */}
+                        <p className="line-clamp-2 text-sm leading-relaxed whitespace-pre-line text-[#504537]">
+                          {post.contentPreview}
+                        </p>
+
+                        <div className="mt-2 flex items-center gap-2">
+                          {/* Meta */}
+                          <div className="flex gap-1 text-[#827565]/60">
+                            <Eye size={16} strokeWidth={2} />
+                            <span className="text-xs font-bold text-[#827565]">{post.viewCount ?? 0}</span>
+                          </div>
+                          <div className="flex gap-1 text-[#827565]/60">
+                            <MessageSquare size={16} strokeWidth={2} />
+                            <span className="text-xs font-bold text-[#827565]">{post.commentCount}</span>
+                          </div>
+                        </div>
+                      </div>
+                      <CommunityPostThumbnail imageUrl={post.thumbnailImageUrl} title={post.title} />
+                    </div>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        {/* 무한스크롤 sentinel + 로딩 인디케이터 */}
+        {hasNextPage ? (
+          <div ref={sentinelRef} className="mt-8 flex justify-center" aria-hidden="true">
+            {isFetchingNextPage ? <Loader2 size={24} className="animate-spin text-[#633f00]" /> : null}
+          </div>
+        ) : null}
+      </main>
+
+      {/* Mobile FAB */}
       {hasHydrated && isLogin() ? (
         <Link
           href={`${ROUTES.COMMUNITY_POST}?tab=${activeCommunityTypeTab}`}
-          className={`bg-primary-200 fixed right-4 bottom-18 rounded-full px-3 py-3 text-white md:hidden ${Z_INDEX.FLOATING_BUTTON}`}
+          className={cn(
+            'fixed right-4 bottom-20 flex items-center justify-center rounded-full bg-[#633f00] p-4 text-white shadow-lg md:hidden',
+            Z_INDEX.FLOATING_BUTTON
+          )}
+          aria-label="글쓰기"
         >
-          <Plus />
+          <Plus size={24} />
         </Link>
       ) : null}
     </div>

--- a/src/features/community/components/CommentForm.tsx
+++ b/src/features/community/components/CommentForm.tsx
@@ -1,10 +1,13 @@
-import { useCallback, useRef, type RefObject } from 'react'
+import { useRef, type RefObject } from 'react'
 import type { UseFormRegister } from 'react-hook-form'
 import Button from '@/components/commons/button/Button'
+import { cn } from '@/lib/utils/cn'
 
 interface CommentFormValues {
   content: string
 }
+
+type CommentFormVariant = 'default' | 'compact'
 
 interface CommentFormProps {
   id: string
@@ -16,41 +19,94 @@ interface CommentFormProps {
   onSubmit: () => void
   onCancel?: () => void
   textareaRef?: RefObject<HTMLTextAreaElement | null>
+  variant?: CommentFormVariant
 }
 
 const MAX_ROWS = 4
 const LINE_HEIGHT = 20
-const PADDING_Y = 16
-const BASE_HEIGHT = LINE_HEIGHT + PADDING_Y
-const MAX_HEIGHT = LINE_HEIGHT * MAX_ROWS + PADDING_Y
+const DEFAULT_PADDING_Y = 16
+const COMPACT_PADDING_Y = 4
+const DEFAULT_BASE = LINE_HEIGHT + DEFAULT_PADDING_Y // 36px
+const DEFAULT_MAX = LINE_HEIGHT * MAX_ROWS + DEFAULT_PADDING_Y // 96px
+const COMPACT_BASE = LINE_HEIGHT + COMPACT_PADDING_Y // 24px
+const COMPACT_MAX = LINE_HEIGHT * MAX_ROWS + COMPACT_PADDING_Y // 84px
 
-export function CommentForm({ id, placeholder, legendText, register, value, onChangeValue, onSubmit, onCancel, textareaRef: externalRef }: CommentFormProps) {
+export function CommentForm({
+  id,
+  placeholder,
+  legendText,
+  register,
+  value,
+  onChangeValue,
+  onSubmit,
+  onCancel,
+  textareaRef: externalRef,
+  variant = 'default',
+}: CommentFormProps) {
   const internalRef = useRef<HTMLTextAreaElement | null>(null)
-  const textareaRef = externalRef || internalRef
   const registerProps = register ? register('content') : null
   const { ref, onChange, ...rest } = registerProps ?? { ref: undefined, onChange: undefined }
 
-  const handleAutoResize = useCallback(() => {
-    const textarea = textareaRef.current
-    if (!textarea) return
-    textarea.style.height = `${BASE_HEIGHT}px`
-    const newHeight = Math.min(textarea.scrollHeight, MAX_HEIGHT)
-    textarea.style.height = `${newHeight}px`
-  }, [textareaRef])
+  const isCompact = variant === 'compact'
+  const baseHeight = isCompact ? COMPACT_BASE : DEFAULT_BASE
+  const maxHeight = isCompact ? COMPACT_MAX : DEFAULT_MAX
 
+  const setRefs = (el: HTMLTextAreaElement | null) => {
+    if (ref) ref(el)
+    internalRef.current = el
+    if (externalRef) externalRef.current = el
+  }
+
+  const handleAutoResize = () => {
+    const textarea = internalRef.current
+    if (!textarea) return
+    textarea.style.height = `${baseHeight}px`
+    const newHeight = Math.min(textarea.scrollHeight, maxHeight)
+    textarea.style.height = `${newHeight}px`
+  }
+
+  if (isCompact) {
+    // 답글용 컴팩트 단일 행 디자인 (오늘의집 패턴)
+    return (
+      <form className="border-outline-variant/40 flex items-end gap-2 rounded-lg border bg-white px-3 py-2" onSubmit={onSubmit}>
+        <fieldset className="flex flex-1 items-center gap-2">
+          <legend className="sr-only">{legendText}</legend>
+          <textarea
+            id={id}
+            placeholder={placeholder}
+            className="scrollbar-hide flex-1 resize-none bg-transparent text-sm leading-6 placeholder:text-gray-400 focus:outline-none"
+            style={{ height: `${baseHeight}px`, maxHeight: `${maxHeight}px`, overflowY: 'auto' }}
+            ref={setRefs}
+            value={onChangeValue ? value : undefined}
+            onChange={(e) => {
+              if (onChange) onChange(e)
+              if (onChangeValue) onChangeValue(e.target.value)
+              handleAutoResize()
+            }}
+            {...rest}
+          />
+          <button type="submit" className="text-primary-container shrink-0 cursor-pointer text-sm font-bold">
+            등록
+          </button>
+        </fieldset>
+      </form>
+    )
+  }
+
+  // 기본 (댓글 입력) — 기존 디자인 유지
   return (
-    <form className="bg-transparent p-0 md:bg-primary-50 md:rounded-lg md:pt-5 md:pr-6 md:pb-4 md:pl-4" onSubmit={onSubmit}>
+    <form className="md:bg-primary-50 bg-transparent p-0 md:rounded-lg md:pt-5 md:pr-6 md:pb-4 md:pl-4" onSubmit={onSubmit}>
       <fieldset className="flex items-end gap-3.5 md:block">
         <legend className="sr-only">{legendText}</legend>
         <textarea
           id={id}
           placeholder={placeholder}
-          className="flex-1 rounded-lg bg-[#f0f4ff] px-3 py-2 leading-tight scrollbar-hide md:h-auto md:leading-normal md:bg-primary-50 md:rounded-none md:px-0 md:py-0 w-full resize-none focus:outline-none"
-          style={{ height: `${BASE_HEIGHT}px`, maxHeight: `${MAX_HEIGHT}px`, overflowY: 'auto' }}
-          ref={(e) => {
-            if (ref) ref(e)
-            textareaRef.current = e
-          }}
+          className={cn(
+            'scrollbar-hide w-full flex-1 resize-none rounded-lg bg-[#f0f4ff] px-3 py-2 leading-tight focus:outline-none',
+            'md:bg-primary-50 md:h-auto md:rounded-none md:px-0 md:py-0 md:leading-normal'
+          )}
+          style={{ height: `${baseHeight}px`, maxHeight: `${maxHeight}px`, overflowY: 'auto' }}
+          ref={setRefs}
           value={onChangeValue ? value : undefined}
           onChange={(e) => {
             if (onChange) onChange(e)

--- a/src/features/community/components/CommentItem.tsx
+++ b/src/features/community/components/CommentItem.tsx
@@ -3,14 +3,23 @@
 import { getTimeAgo } from '@/lib/utils/getTimeAgo'
 import { cn } from '@/lib/utils/cn'
 import type { Comment } from '@/types'
-import { EllipsisVertical } from 'lucide-react'
-import IconButton from '@/components/commons/button/IconButton'
 import ProfileAvatar from '@/components/commons/ProfileAvatar'
-import { useRef, useState } from 'react'
+import { useState } from 'react'
 import { useUserStore } from '@/store/userStore'
-import { useOutsideClick } from '@/hooks/useOutsideClick'
 import dynamic from 'next/dynamic'
 const DeleteReplyModal = dynamic(() => import('@/components/modal/DeleteReplyModal'))
+
+function renderContentWithMention(content: string) {
+  const match = content.match(/^(@\S+)([\s\S]*)$/)
+  if (!match) return content
+  const [, mention, rest] = match
+  return (
+    <>
+      <span className="text-primary-container">{mention}</span>
+      {rest}
+    </>
+  )
+}
 
 interface CommentItemProps {
   comment: Comment
@@ -37,20 +46,10 @@ export function CommentItem({
 }: CommentItemProps) {
   const user = useUserStore((state) => state.user)
   const isMyComment = user?.id === Number(comment.authorId)
-  const [isMoreMenuOpen, setIsMoreMenuOpen] = useState(false)
   const [isReplyDeleteModalOpen, setIsReplyDeleteModalOpen] = useState(false)
-
-  const handleMoreToggle = () => {
-    setIsMoreMenuOpen((prev) => !prev)
-  }
-
-  const modalRef = useRef<HTMLButtonElement>(null)
-
-  useOutsideClick(isMoreMenuOpen, [modalRef], () => setIsMoreMenuOpen(false))
 
   const handleDelete = () => {
     setIsReplyDeleteModalOpen(true)
-    setIsMoreMenuOpen(false)
   }
 
   const handleConfirmDelete = async (id: number) => {
@@ -61,54 +60,81 @@ export function CommentItem({
 
   return (
     <>
-      <div className={cn('flex items-start gap-3.5', showBorder && 'border-t border-gray-300 pt-3.5', !isReply && !isRepliesOpen && 'pb-3.5')}>
-        <ProfileAvatar imageUrl={comment.authorProfileImageUrl} nickname={comment.authorNickname} size="sm" className="shrink-0" />
+      <div
+        className={cn(
+          'flex items-start gap-3.5',
+          isReply
+            ? 'bg-surface-container-low rounded-lg px-4.5 py-4.5'
+            : cn(showBorder && 'border-t border-gray-300 pt-3.5', !isRepliesOpen && 'pb-3.5')
+        )}
+      >
+        <ProfileAvatar
+          imageUrl={comment.authorProfileImageUrl}
+          nickname={comment.authorNickname}
+          size="sm"
+          className="shrink-0"
+        />
 
         {/* 유저 정보 및 내용 */}
-        <div className="flex flex-col justify-center gap-1">
-          <div className="flex flex-col gap-0.5">
+        <div className="flex flex-col justify-center gap-2">
+          <div className="flex flex-col gap-2">
             <div className="flex items-center gap-1.5">
-              <p className="text-sm md:text-base font-semibold">{comment.authorNickname}</p>
+              <p className="text-sm font-semibold md:text-base">{comment.authorNickname}</p>
               {Number(comment.authorId) === user?.id ? (
-                <p className="bg-primary-200 rounded-full px-2.5 py-1 text-xs font-semibold text-white">작성자</p>
+                <p className="bg-primary-200 rounded-full px-2 py-0.5 text-xs font-semibold text-white">내 댓글</p>
               ) : null}
             </div>
-            <p className="text-xs md:text-sm text-gray-500">{getTimeAgo(comment.createdAt)}</p>
+            <p className="whitespace-pre-wrap">{renderContentWithMention(comment.content)}</p>
           </div>
-          <p>{comment.content}</p>
+          <div className="flex items-center gap-1">
+            <p className="text-xs font-medium text-gray-500">{getTimeAgo(comment.createdAt)}</p>
+            <span aria-hidden="true" className="text-xs">
+              ·
+            </span>
+            <div className="flex items-center gap-1">
+              {onHandleReply ? (
+                <button
+                  className="text-primary-container cursor-pointer text-xs font-medium hover:underline"
+                  type="button"
+                  onClick={onHandleReply}
+                >
+                  답글 달기
+                </button>
+              ) : null}
 
-          <div className="flex items-center gap-3.5">
-            {onHandleReply ? (
-              <button className="cursor-pointer text-sm text-blue-500" type="button" onClick={onHandleReply}>
-                답글쓰기
-              </button>
-            ) : null}
-            {/* 답글 버튼 (대댓글이 아니고, hasChildren이 있을 때만) */}
-            {!isReply && hasChildren ? (
-              <button className="cursor-pointer self-start text-sm text-blue-500 hover:underline" type="button" onClick={onToggleReplies}>
-                {isRepliesOpen ? '답글 접기' : `답글 ${childrenCount}개`}
-              </button>
-            ) : null}
+              {/* 답글 버튼 (대댓글이 아니고, hasChildren이 있을 때만) */}
+              {!isReply && hasChildren ? (
+                <>
+                  <span aria-hidden="true" className="text-xs">
+                    ·
+                  </span>
+                  <button
+                    className="text-primary-container cursor-pointer self-start text-xs font-medium hover:underline"
+                    type="button"
+                    onClick={onToggleReplies}
+                  >
+                    {isRepliesOpen ? '답글 접기' : `답글 ${childrenCount}개`}
+                  </button>
+                </>
+              ) : null}
+
+              {isMyComment ? (
+                <>
+                  <span aria-hidden="true" className="text-xs">
+                    ·
+                  </span>
+                  <button
+                    className="text-primary-container cursor-pointer text-xs font-medium hover:underline"
+                    type="button"
+                    onClick={handleDelete}
+                  >
+                    삭제
+                  </button>
+                </>
+              ) : null}
+            </div>
           </div>
         </div>
-
-        {isMyComment ? (
-          <div className="relative ml-auto">
-            <IconButton aria-label="더보기" className="" size="sm" onClick={handleMoreToggle}>
-              <EllipsisVertical size={16} className="text-gray-500" />
-            </IconButton>
-            {isMoreMenuOpen ? (
-              <button
-                className="absolute top-7 right-0 cursor-pointer rounded border border-gray-200 bg-white px-3 py-1.5 text-sm whitespace-nowrap shadow-md hover:bg-gray-50"
-                type="button"
-                onClick={() => handleDelete()}
-                ref={modalRef}
-              >
-                삭제
-              </button>
-            ) : null}
-          </div>
-        ) : null}
       </div>
       <DeleteReplyModal
         isOpen={isReplyDeleteModalOpen}

--- a/src/features/community/components/CommentList.tsx
+++ b/src/features/community/components/CommentList.tsx
@@ -8,7 +8,7 @@ import type { Comment, CommentPostRequestData } from '@/types'
 import { CommentItem } from './CommentItem'
 import { CommentForm } from './CommentForm'
 import { ReplyOverlay } from './ReplyOverlay'
-import { useForm } from 'react-hook-form'
+import { useForm, useWatch } from 'react-hook-form'
 import { useUserStore } from '@/store/userStore'
 import { useLoginModalStore } from '@/store/modalStore'
 import InlineNotification from '@/components/commons/InlineNotification'
@@ -23,6 +23,12 @@ interface CommentListProps {
   postId: string
 }
 
+interface ReplyTarget {
+  commentId: number
+  threadId: number
+  mention?: string
+}
+
 export function CommentList({ comments, postId }: CommentListProps) {
   const queryClient = useQueryClient()
   const user = useUserStore((state) => state.user)
@@ -30,19 +36,15 @@ export function CommentList({ comments, postId }: CommentListProps) {
   const openLoginModal = useLoginModalStore((state) => state.openLoginModal)
   const pathname = usePathname()
   const searchParams = useSearchParams()
-  const {
-    handleSubmit, // form onSubmit에 들어가는 함수 : 제출 시 실행할 함수를 감싸주는 함수
-    watch, // 필드 값을 구독하여 실시간으로 가져오는 함수
-    setValue, // 필드 값을 수동으로 설정하는 함수
-    reset,
-  } = useForm<ReplyRequestFormValues>({
+  const { handleSubmit, control, setValue, reset } = useForm<ReplyRequestFormValues>({
     mode: 'onChange',
     defaultValues: {
       content: '',
     },
   })
-  const replyContent = watch('content')
+  const replyContent = useWatch({ control, name: 'content' })
   const [openRepliesCommentId, setOpenRepliesCommentId] = useState<number | null>(null)
+  const [activeThreadId, setActiveThreadId] = useState<number | null>(null)
   const [replyingToId, setReplyingToId] = useState<number | null>(null)
   const [replyPostError, setReplyPostError] = useState<React.ReactNode | null>(null)
 
@@ -56,21 +58,20 @@ export function CommentList({ comments, postId }: CommentListProps) {
   })
 
   const replyMutation = useMutation({
-    mutationFn: (requestData: CommentPostRequestData) =>
-      api.post(`/community/posts/${postId}/comments`, { content: requestData.content, parentId: requestData.parentId }),
+    mutationFn: (data: { request: CommentPostRequestData; threadId: number }) =>
+      api.post(`/community/posts/${postId}/comments`, {
+        content: data.request.content,
+        parentId: data.request.parentId,
+      }),
     onSuccess: (_data, variables) => {
-      const parentId = variables.parentId
-      // 대댓글 목록 refetch
-      queryClient.invalidateQueries({ queryKey: ['community', postId, 'replies', parentId] })
-      // 댓글 목록도 refetch (childrenCount 업데이트를 위해)
+      const { threadId } = variables
+      queryClient.invalidateQueries({ queryKey: ['community', postId, 'replies', threadId] })
       queryClient.invalidateQueries({ queryKey: ['community', postId, 'comments'] })
-      // 게시글 상세 refetch (commentCount 업데이트를 위해)
       queryClient.invalidateQueries({ queryKey: ['community', postId] })
-      // 폼 초기화 및 닫기
       reset()
       setReplyingToId(null)
-      // 대댓글 목록 열기
-      setOpenRepliesCommentId(parentId ?? null)
+      setActiveThreadId(null)
+      setOpenRepliesCommentId(threadId)
     },
     onError: () => {
       setReplyPostError(
@@ -85,11 +86,8 @@ export function CommentList({ comments, postId }: CommentListProps) {
   const deleteMutation = useMutation({
     mutationFn: (commentId: number) => api.delete(`/community/comments/${commentId}`),
     onSuccess: () => {
-      // 댓글 목록 refetch
       queryClient.invalidateQueries({ queryKey: ['community', postId, 'comments'] })
-      // 대댓글 목록도 refetch
       queryClient.invalidateQueries({ queryKey: ['community', postId, 'replies'] })
-      // 게시글 상세 refetch (commentCount 업데이트를 위해)
       queryClient.invalidateQueries({ queryKey: ['community', postId] })
     },
   })
@@ -107,15 +105,23 @@ export function CommentList({ comments, postId }: CommentListProps) {
     }
   }
 
-  const handleOpenReplyForm = (commentId: number) => {
-    if (replyingToId === commentId) {
+  const openReplyForm = (target: ReplyTarget) => {
+    if (replyingToId === target.commentId) {
       setReplyingToId(null)
-      reset() // 폼 초기화
-    } else {
-      setReplyingToId(commentId)
-      // 답글 목록도 함께 열어서 오버레이에 기존 답글 표시
-      setOpenRepliesCommentId(commentId)
+      setActiveThreadId(null)
+      reset()
+      return
     }
+    setReplyingToId(target.commentId)
+    setActiveThreadId(target.threadId)
+    setOpenRepliesCommentId(target.threadId)
+    setValue('content', target.mention ? `@${target.mention} ` : '')
+  }
+
+  const closeReplyForm = () => {
+    setReplyingToId(null)
+    setActiveThreadId(null)
+    reset()
   }
 
   const handleToggleReplies = (commentId: number) => {
@@ -123,93 +129,121 @@ export function CommentList({ comments, postId }: CommentListProps) {
   }
 
   const onSubmit = (data: ReplyRequestFormValues) => {
-    if (!replyingToId) return
+    if (!replyingToId || !activeThreadId) return
     if (!data.content.trim()) return
     if (!user) {
       setRedirectUrl(pathname + (searchParams.toString() ? `?${searchParams.toString()}` : ''))
       openLoginModal()
       return
     }
-    const requestData: CommentPostRequestData = {
-      content: data.content,
-      parentId: replyingToId,
-    }
-    replyMutation.mutate(requestData)
+    replyMutation.mutate({
+      request: { content: data.content, parentId: replyingToId },
+      threadId: activeThreadId,
+    })
   }
 
   return (
     <>
-    <ul className="flex flex-col">
-      {comments.map((comment, index) => (
-        <li key={comment.id} className="flex flex-col">
-          <CommentItem
-            comment={comment}
-            hasChildren={comment.hasChildren}
-            childrenCount={comment.childrenCount}
-            onToggleReplies={() => handleToggleReplies(comment.id)}
-            isRepliesOpen={openRepliesCommentId === comment.id}
-            showBorder={index !== 0}
-            onHandleReply={() => handleOpenReplyForm(comment.id)}
-            onDelete={handleDeleteComment}
-          />
+      <ul className="flex flex-col">
+        {comments.map((comment, index) => (
+          <li key={comment.id} className="flex flex-col">
+            <CommentItem
+              comment={comment}
+              hasChildren={comment.hasChildren}
+              childrenCount={comment.childrenCount}
+              onToggleReplies={() => handleToggleReplies(comment.id)}
+              isRepliesOpen={openRepliesCommentId === comment.id}
+              showBorder={index !== 0}
+              onHandleReply={() =>
+                openReplyForm({
+                  commentId: comment.id,
+                  threadId: comment.id,
+                  mention: comment.authorNickname,
+                })
+              }
+              onDelete={handleDeleteComment}
+            />
 
-          {/* 대댓글 목록 */}
-          <div className={`grid transition-all duration-300 ${openRepliesCommentId === comment.id ? 'mt-3.5 grid-rows-[1fr]' : 'grid-rows-[0fr]'}`}>
-            <div className="overflow-hidden">
-              {openRepliesCommentId === comment.id && repliesData?.comments ? (
-                <ul className="flex flex-col gap-2 pb-3.5 pl-10">
-                  {repliesData.comments.map((reply, index) => (
-                    <li key={reply.id}>
-                      <CommentItem comment={reply} isReply showBorder={index !== 0} onDelete={handleDeleteComment} />
-                    </li>
-                  ))}
-                </ul>
-              ) : null}
-            </div>
-          </div>
-          {/* 데스크톱: 인라인 답글 폼 */}
-          {replyingToId === comment.id ? (
-            <div className="hidden pb-3.5 pl-10 md:block">
-              <AnimatePresence>
-                {replyPostError ? (
-                  <InlineNotification type="error" onClose={() => setReplyPostError(null)}>
-                    {replyPostError}
-                  </InlineNotification>
+            {/* 대댓글 목록 */}
+            <div
+              className={`grid transition-all duration-500 ease-out ${
+                openRepliesCommentId === comment.id ? 'mt-3.5 grid-rows-[1fr]' : 'grid-rows-[0fr]'
+              }`}
+            >
+              <div className="overflow-hidden">
+                {openRepliesCommentId === comment.id && repliesData?.comments ? (
+                  <ul className="flex flex-col gap-2 pb-3.5 pl-10">
+                    {repliesData.comments.map((reply, index) => (
+                      <li key={reply.id}>
+                        <CommentItem
+                          comment={reply}
+                          isReply
+                          showBorder={index !== 0}
+                          onDelete={handleDeleteComment}
+                          onHandleReply={() =>
+                            openReplyForm({
+                              commentId: reply.id,
+                              threadId: comment.id,
+                              mention: reply.authorNickname,
+                            })
+                          }
+                        />
+                      </li>
+                    ))}
+                  </ul>
                 ) : null}
-              </AnimatePresence>
-              <CommentForm
-                id={String(comment.id)}
-                placeholder="답글을 입력하세요"
-                legendText="대댓글 작성폼"
-                value={replyContent}
-                onChangeValue={(v) => setValue('content', v)}
-                onSubmit={handleSubmit(onSubmit)}
-                onCancel={() => handleOpenReplyForm(comment.id)}
-              />
+              </div>
             </div>
-          ) : null}
-        </li>
-      ))}
-    </ul>
+            {/* 데스크톱: 인라인 답글 폼 */}
+            {activeThreadId === comment.id ? (
+              <div className="hidden pb-3.5 pl-10 md:block">
+                <AnimatePresence>
+                  {replyPostError ? (
+                    <InlineNotification type="error" onClose={() => setReplyPostError(null)}>
+                      {replyPostError}
+                    </InlineNotification>
+                  ) : null}
+                </AnimatePresence>
+                <CommentForm
+                  id={String(comment.id)}
+                  placeholder="답글을 입력하세요"
+                  legendText="대댓글 작성폼"
+                  value={replyContent}
+                  onChangeValue={(v) => setValue('content', v)}
+                  onSubmit={handleSubmit(onSubmit)}
+                  variant="compact"
+                />
+              </div>
+            ) : null}
+          </li>
+        ))}
+      </ul>
 
-    {/* 모바일: 답글 오버레이 */}
-    {(() => {
-      if (!replyingToId) return null
-      const targetComment = comments.find((c) => c.id === replyingToId)
-      if (!targetComment) return null
-      return (
-        <div className="md:hidden">
-          <ReplyOverlay
-            comment={targetComment}
-            replies={openRepliesCommentId === replyingToId ? repliesData?.comments : undefined}
-            value={replyContent}
-            onChangeValue={(v) => setValue('content', v)}
-            onSubmit={handleSubmit(onSubmit)}
-            onClose={() => handleOpenReplyForm(replyingToId)}
-          />
-        </div>
-      )
-    })()}
+      {/* 모바일: 답글 오버레이 */}
+      {(() => {
+        if (!activeThreadId) return null
+        const targetComment = comments.find((c) => c.id === activeThreadId)
+        if (!targetComment) return null
+        return (
+          <div className="md:hidden">
+            <ReplyOverlay
+              comment={targetComment}
+              replies={openRepliesCommentId === activeThreadId ? repliesData?.comments : undefined}
+              value={replyContent}
+              onChangeValue={(v) => setValue('content', v)}
+              onSubmit={handleSubmit(onSubmit)}
+              onClose={closeReplyForm}
+              onReplyToReply={(reply) =>
+                openReplyForm({
+                  commentId: reply.id,
+                  threadId: targetComment.id,
+                  mention: reply.authorNickname,
+                })
+              }
+            />
+          </div>
+        )
+      })()}
     </>
   )
 }

--- a/src/features/community/components/CommunityPostThumbnail.tsx
+++ b/src/features/community/components/CommunityPostThumbnail.tsx
@@ -1,0 +1,43 @@
+import { cn } from '@/lib/utils/cn'
+import { IMAGE_SIZES, PLACEHOLDER_IMAGES, getImageSrcSet, toResizedWebpUrl } from '@/lib/utils/imageUrl'
+
+interface CommunityPostThumbnailProps {
+  imageUrl?: string | null
+  title: string
+  className?: string
+}
+
+export function CommunityPostThumbnail({ imageUrl, title, className }: CommunityPostThumbnailProps) {
+  if (!imageUrl) return null
+
+  return (
+    <div className={cn('relative aspect-square h-full shrink-0 overflow-hidden rounded-2xl bg-[#f4efe7]', className)}>
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={toResizedWebpUrl(imageUrl, 150)}
+        srcSet={getImageSrcSet(imageUrl)}
+        sizes={IMAGE_SIZES.smallThumbnail}
+        alt={title}
+        loading="lazy"
+        data-origin-src={imageUrl}
+        data-placeholder-src={PLACEHOLDER_IMAGES[150]}
+        onError={(e) => {
+          const img = e.currentTarget
+          const originSrc = img.dataset.originSrc
+          const placeholderSrc = img.dataset.placeholderSrc
+
+          if (originSrc && img.src !== originSrc) {
+            img.srcset = ''
+            img.src = originSrc
+            return
+          }
+
+          if (placeholderSrc && img.src !== placeholderSrc) {
+            img.src = placeholderSrc
+          }
+        }}
+        className="h-full w-full object-cover"
+      />
+    </div>
+  )
+}

--- a/src/features/community/components/CommunityTabs.tsx
+++ b/src/features/community/components/CommunityTabs.tsx
@@ -1,4 +1,3 @@
-import Button from '@/components/commons/button/Button'
 import { cn } from '@/lib/utils/cn'
 
 interface Tab {
@@ -13,33 +12,38 @@ interface TabsProps {
   onTabChange: (tabId: string) => void
   ariaLabel: string
   excludeTabId?: string
+  className?: string
 }
 
-export function CommunityTabs({ tabs, activeTab, onTabChange, ariaLabel, excludeTabId }: TabsProps) {
+export function CommunityTabs({ tabs, activeTab, onTabChange, ariaLabel, excludeTabId, className }: TabsProps) {
   const filteredTabs = excludeTabId ? tabs.filter((tab) => tab.id !== excludeTabId) : tabs
   return (
-    <div role="tablist" aria-label={ariaLabel} className={cn('border-b-primary-200 flex w-fit gap-2.5 md:border-b-2 md:pb-1')}>
-      {filteredTabs.map((tab) => (
-        <Button
-          key={tab.id}
-          id={tab.id}
-          size="md"
-          role="tab"
-          type="button"
-          onClick={() => onTabChange(tab.id)}
-          className={cn(
-            'cursor-pointer rounded-full bg-white text-sm md:text-base md:rounded-2xl md:bg-transparent',
-            activeTab === tab.id
-              ? 'md:bg-primary-300 bg-primary-500 font-medium text-white'
-              : 'hover:bg-primary-100 bg-gray-100 text-gray-900 md:bg-transparent'
-          )}
-          aria-selected={activeTab === tab.id}
-          aria-controls={`panel-${tab.code}`}
-          tabIndex={activeTab === tab.id ? 0 : -1}
-        >
-          {tab.label}
-        </Button>
-      ))}
+    <div
+      role="tablist"
+      aria-label={ariaLabel}
+      className={cn('border-outline-variant/30 flex gap-6 border-b md:gap-10', className)}
+    >
+      {filteredTabs.map((tab) => {
+        const isActive = activeTab === tab.id
+        return (
+          <button
+            key={tab.id}
+            id={tab.id}
+            type="button"
+            role="tab"
+            onClick={() => onTabChange(tab.id)}
+            aria-selected={isActive}
+            aria-controls={`panel-${tab.code}`}
+            tabIndex={isActive ? 0 : -1}
+            className={cn(
+              'cursor-pointer pb-3 text-base font-semibold transition-all md:pb-1',
+              isActive ? 'border-b-2 border-[#633f00] text-[#633f00]' : 'text-[#504537] hover:text-[#633f00]'
+            )}
+          >
+            {tab.label}
+          </button>
+        )
+      })}
     </div>
   )
 }

--- a/src/features/community/components/ReplyOverlay.tsx
+++ b/src/features/community/components/ReplyOverlay.tsx
@@ -13,9 +13,18 @@ interface ReplyOverlayProps {
   onChangeValue: (value: string) => void
   onSubmit: () => void
   onClose: () => void
+  onReplyToReply?: (reply: Comment) => void
 }
 
-export function ReplyOverlay({ comment, replies, value, onChangeValue, onSubmit, onClose }: ReplyOverlayProps) {
+export function ReplyOverlay({
+  comment,
+  replies,
+  value,
+  onChangeValue,
+  onSubmit,
+  onClose,
+  onReplyToReply,
+}: ReplyOverlayProps) {
   const totalCount = 1 + (replies?.length ?? 0)
 
   const onCloseRef = useRef(onClose)
@@ -57,7 +66,12 @@ export function ReplyOverlay({ comment, replies, value, onChangeValue, onSubmit,
           <ul className="mt-3 flex flex-col gap-2 pl-10">
             {replies.map((reply, index) => (
               <li key={reply.id}>
-                <CommentItem comment={reply} isReply showBorder={index !== 0} />
+                <CommentItem
+                  comment={reply}
+                  isReply
+                  showBorder={index !== 0}
+                  onHandleReply={onReplyToReply ? () => onReplyToReply(reply) : undefined}
+                />
               </li>
             ))}
           </ul>
@@ -73,6 +87,7 @@ export function ReplyOverlay({ comment, replies, value, onChangeValue, onSubmit,
           value={value}
           onChangeValue={onChangeValue}
           onSubmit={onSubmit}
+          variant="compact"
         />
       </div>
     </div>

--- a/src/features/community/components/StaticCommunityFallback.tsx
+++ b/src/features/community/components/StaticCommunityFallback.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import type { CommunityItem } from '@/types'
 import { getTimeAgo } from '@/lib/utils/getTimeAgo'
 import { ROUTES } from '@/constants/routes'
+import { CommunityPostThumbnail } from './CommunityPostThumbnail'
 
 /**
  * Suspense fallback용 서버 컴포넌트
@@ -35,37 +36,43 @@ export default function StaticCommunityFallback({ posts }: StaticCommunityFallba
                 {/* 데스크톱 카드 */}
                 <div className="hidden md:block">
                   <div className="flex flex-col justify-center gap-2.5 rounded-lg border border-gray-400 bg-white px-3.5 pt-3.5 pb-3.5 shadow-xl">
-                    <Link href={ROUTES.COMMUNITY_DETAIL_ID(post.id, post.title)} className="flex flex-col gap-1">
-                      <p className="font-semibold">{post.title}</p>
-                      <p className="line-clamp-1 text-gray-600">{post.contentPreview}</p>
-                      <div className="mt-3 flex items-center gap-2.5 text-sm text-gray-400">
-                        <p>{post.authorNickname}</p>
-                        <p>{getTimeAgo(post.createdAt)}</p>
-                        <span>{post.commentCount}</span>
-                        <span>{post.viewCount}</span>
+                    <Link href={ROUTES.COMMUNITY_DETAIL_ID(post.id, post.title)} className="grid grid-cols-[minmax(0,1fr)_auto] items-stretch gap-4">
+                      <div className="min-w-0 flex-1">
+                        <p className="font-semibold">{post.title}</p>
+                        <p className="line-clamp-1 text-gray-600">{post.contentPreview}</p>
+                        <div className="mt-3 flex items-center gap-2.5 text-sm text-gray-400">
+                          <p>{post.authorNickname}</p>
+                          <p>{getTimeAgo(post.createdAt)}</p>
+                          <span>{post.commentCount}</span>
+                          <span>{post.viewCount}</span>
+                        </div>
                       </div>
+                      <CommunityPostThumbnail imageUrl={post.thumbnailImageUrl} title={post.title} />
                     </Link>
                   </div>
                 </div>
                 {/* 모바일 카드 */}
                 <div className="md:hidden">
                   <div className="flex flex-col justify-center gap-2.5 rounded-lg border border-gray-400 bg-white px-3.5 pt-3.5 pb-3.5 shadow-xl">
-                    <Link href={ROUTES.COMMUNITY_DETAIL_ID(post.id, post.title)} className="flex flex-col gap-4">
-                      <div className="flex flex-col gap-1">
-                        <p className="line-clamp-1 text-base font-bold">{post.title}</p>
-                        <p className="line-clamp-1">{post.contentPreview}</p>
-                      </div>
-                      <div className="flex items-center justify-between gap-2.5 text-sm">
-                        <div className="flex items-center text-gray-400">
-                          <p>{post.authorNickname}</p>
-                          <span className="mx-0.5">·</span>
-                          <p>{getTimeAgo(post.createdAt)}</p>
+                    <Link href={ROUTES.COMMUNITY_DETAIL_ID(post.id, post.title)} className="grid grid-cols-[minmax(0,1fr)_auto] items-stretch gap-4">
+                      <div className="min-w-0 flex-1">
+                        <div className="flex flex-col gap-1">
+                          <p className="line-clamp-1 text-base font-bold">{post.title}</p>
+                          <p className="line-clamp-1">{post.contentPreview}</p>
                         </div>
-                        <div className="flex items-center gap-2.5 text-gray-400">
-                          <span>{post.commentCount}</span>
-                          <span>{post.viewCount}</span>
+                        <div className="mt-4 flex items-center justify-between gap-2.5 text-sm">
+                          <div className="flex items-center text-gray-400">
+                            <p>{post.authorNickname}</p>
+                            <span className="mx-0.5">·</span>
+                            <p>{getTimeAgo(post.createdAt)}</p>
+                          </div>
+                          <div className="flex items-center gap-2.5 text-gray-400">
+                            <span>{post.commentCount}</span>
+                            <span>{post.viewCount}</span>
+                          </div>
                         </div>
                       </div>
+                      <CommunityPostThumbnail imageUrl={post.thumbnailImageUrl} title={post.title} />
                     </Link>
                   </div>
                 </div>

--- a/src/features/home/components/HomeHero.tsx
+++ b/src/features/home/components/HomeHero.tsx
@@ -19,7 +19,7 @@ function focusHeaderSearch() {
 
 export default function HomeHero() {
   return (
-    <section aria-label="히어로" className="relative h-100 w-full bg-[#e3c19b] md:h-100">
+    <section aria-label="히어로" className="bg-hero-surface relative h-100 w-full md:h-100">
       <div className="relative mx-auto h-full xl:max-w-7xl xl:px-3.5">
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img

--- a/src/features/home/components/filter/DetailFilter.tsx
+++ b/src/features/home/components/filter/DetailFilter.tsx
@@ -42,7 +42,7 @@ export const DetailFilter = memo(function DetailFilterSection({
           id={FILTER_CONTENT_ID}
           role="group"
           aria-label="세부 필터 옵션"
-          className="relative rounded-3xl border border-[#d4c4b2] bg-white px-6 py-6 shadow-sm md:px-6 md:py-5"
+          className="border-outline-variant relative rounded-3xl border bg-white px-6 py-6 shadow-sm md:px-6 md:py-5"
         >
           {/* 데스크탑 필터 초기화 (카드 우상단 액션) */}
           <Button

--- a/src/features/home/components/filter/PetTypeFilter.tsx
+++ b/src/features/home/components/filter/PetTypeFilter.tsx
@@ -80,7 +80,7 @@ export function PetTypeFilter({ activeTab, selectedDetailPet, onTabChange }: Pet
                 'cursor-pointer rounded-full border px-3 py-1 text-xs font-medium whitespace-nowrap transition-all',
                 isActive
                   ? 'border-[#825500] bg-[#825500] text-white shadow-sm'
-                  : 'border-[#d4c4b2] bg-white text-gray-600 hover:border-[#825500] hover:text-[#825500]'
+                  : 'border-outline-variant bg-white text-gray-600 hover:border-[#825500] hover:text-[#825500]'
               )}
             >
               {pet.name}

--- a/src/features/home/components/tab/ProductPetTypeTabs.tsx
+++ b/src/features/home/components/tab/ProductPetTypeTabs.tsx
@@ -40,7 +40,7 @@ export function ProductPetTypeTabs({ activeTab, onTabChange }: ProductPetTypeTab
         ref={scrollRef}
         role="tablist"
         aria-label="반려동물 타입 대분류"
-        className="scrollbar-hide flex overflow-x-auto border-b border-[#d4c4b2]"
+        className="scrollbar-hide border-outline-variant flex overflow-x-auto border-b"
       >
         {PET_TYPE_TABS.map((tab) => {
           const isActive = activeTab === tab.id

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -7,6 +7,7 @@ export const typeDefs = gql`
     id: Int!
     title: String!
     contentPreview: String
+    thumbnailImageUrl: String
     authorNickname: String!
     boardType: String!
     viewCount: Int!

--- a/src/types/community.ts
+++ b/src/types/community.ts
@@ -3,6 +3,7 @@ export interface CommunityItem {
   id: number
   title: string
   contentPreview?: string
+  thumbnailImageUrl?: string | null
   authorNickname: string
   boardType?: string
   searchType: string


### PR DESCRIPTION
## 📌 개요

커뮤니티 페이지(목록 + 상세) 디자인 리뉴얼 및 댓글/답글 인터랙션 개선.
디자인 토큰(브라운 brand) 일관 적용, 인스타그램 스타일 flat-with-mention 답글 패턴 도입.

## 🔧 작업 내용

- [x] **커뮤니티 목록 페이지 리뉴얼**: 헤더 검색바 숨김(spacer 처리), 언더라인 탭, 검색바/정렬/글쓰기 행 분리, 무한스크롤 IntersectionObserver, 1열 카드(rounded-2xl, 닉네임 첫글자 fallback)
- [x] **커뮤니티 상세 페이지 리뉴얼**: 더보기(⋮) 메뉴 → 메타정보 우측 인라인 텍스트 액션(수정/삭제 또는 신고하기), 모바일 sticky 댓글 입력창 BottomNav safe-area 보정
- [x] **댓글 입력 컴포넌트 variant 분리**: `default`(기존 디자인 유지) / `compact`(답글 입력용 단일 행 보더 박스, 등록 버튼만)
- [x] **답글 시스템 개편**: depth 3 평탄 표시, `@닉네임 ` 자동 prefix, 멘션 텍스트 색상 강조, 답글 카드(`bg-surface-container-low rounded-lg`), 펼침 애니메이션 500ms ease-out
- [x] **댓글 삭제**: 더보기 메뉴 → 액션 행 우측 인라인(`text-red-500`)
- [x] **React Compiler 호환**: `useWatch`로 `watch()` 교체, 병합 ref 패턴 분리(`setRefs`)
- [x] **디자인 토큰 cleanup**: 하드코딩 hex `#f6efe2` → `bg-chip-surface` 토큰 5건(ProductThumbnail, HomeHero, DetailFilter, PetTypeFilter, ProductPetTypeTabs)

## 📎 관련 이슈

Closes #698

## 💬 리뷰어 참고 사항

- **백엔드 의존성**: 답글의 답글(depth 3) 평탄 표시는 백엔드 `findAllDescendantsByRoot` / `countAllDescendantsByRoot` 신규 메서드 필요. 별도 PR로 진행 중이라 백엔드 머지 후 정상 동작합니다.
- **답글 멘션 패턴**: 모든 답글(depth 1→2 포함)에 `@대상닉네임` 자동 prefix. 인스타그램 패턴 차용. `CommentItem`의 `renderContentWithMention` 함수가 content 시작 부분 `@nickname`을 분리해 `text-primary-container`로 렌더.
- **답글 카운트 의미 변경**: "답글 N개"가 직계 자식 수 → 후손 전체 수로 변경됨(평탄 표시와 일치). 백엔드 변경분과 짝.
- **디자인 토큰 cleanup 5건 포함**: 커뮤니티와 무관하지만 1줄씩 hex→토큰 교체라 같이 묶었습니다.