### PR TITLE
refactor: 로딩 스피너 디자인 시스템 통일(#700)

### DIFF
--- a/src/components/commons/spinner/Spinner.tsx
+++ b/src/components/commons/spinner/Spinner.tsx
@@ -1,0 +1,31 @@
+import { cn } from '@/lib/utils/cn'
+
+type SpinnerSize = 'sm' | 'md' | 'lg'
+
+interface SpinnerProps {
+  size?: SpinnerSize
+  className?: string
+  label?: string
+}
+
+const SIZE_CLASSES: Record<SpinnerSize, string> = {
+  sm: 'h-6 w-6 border-2',
+  md: 'h-8 w-8 border-[3px]',
+  lg: 'h-12 w-12 border-4',
+}
+
+export default function Spinner({ size = 'md', className, label = '로딩 중' }: SpinnerProps) {
+  return (
+    <div
+      role="status"
+      aria-label={label}
+      className={cn(
+        'border-outline-variant border-t-primary-container animate-spin rounded-full',
+        SIZE_CLASSES[size],
+        className
+      )}
+    >
+      <span className="sr-only">{label}</span>
+    </div>
+  )
+}

--- a/src/features/UserPage.tsx
+++ b/src/features/UserPage.tsx
@@ -18,6 +18,7 @@ const BlockModal = dynamic(() => import('@/components/modal/BlockModal'))
 import { useUserStore } from '@/store/userStore'
 import { AnimatePresence } from 'framer-motion'
 import InlineNotification from '@/components/commons/InlineNotification'
+import Spinner from '@/components/commons/spinner/Spinner'
 import { ROUTES } from '@/constants/routes'
 
 function UserPage() {
@@ -90,7 +91,7 @@ function UserPage() {
   if ((isLoadingUserData && !userData) || (isLoadingUserProductData && !userProductData)) {
     return (
       <div className="flex min-h-screen items-center justify-center">
-        <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-blue-600"></div>
+        <Spinner size="md" />
       </div>
     )
   }

--- a/src/features/chatting-page/ChattingPage.tsx
+++ b/src/features/chatting-page/ChattingPage.tsx
@@ -16,6 +16,7 @@ import ChatInput from './components/ChatInput'
 import { uploadImage } from '@/lib/api/products'
 import { cn } from '@/lib/utils/cn'
 import { Z_INDEX } from '@/constants/ui'
+import Spinner from '@/components/commons/spinner/Spinner'
 import imageCompression from 'browser-image-compression'
 
 const WS_URL = process.env.NEXT_PUBLIC_WS_URL || 'http://localhost:8080/ws-stomp'
@@ -211,7 +212,7 @@ export default function ChattingPage() {
   if (isLoadingRooms && !rooms) {
     return (
       <div className="flex min-h-screen items-center justify-center">
-        <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-blue-600"></div>
+        <Spinner size="md" />
       </div>
     )
   }

--- a/src/features/chatting-page/components/ChatLog.tsx
+++ b/src/features/chatting-page/components/ChatLog.tsx
@@ -8,6 +8,7 @@ import { useUserStore } from '@/store/userStore'
 import { IMAGE_SIZES, imageLoader, toResizedWebpUrl, PLACEHOLDER_IMAGES } from '@/lib/utils/imageUrl'
 import { AnimatePresence } from 'framer-motion'
 import InlineNotification from '@/components/commons/InlineNotification'
+import Spinner from '@/components/commons/spinner/Spinner'
 
 interface ChatLogProps {
   isLoadingMessages: boolean
@@ -145,11 +146,7 @@ export function ChatLog({
     return (
       <div className="px-lg py-md tablet:py-xl mx-auto max-w-7xl">
         <div className="flex items-center justify-center py-20">
-          <div
-            className="h-8 w-8 animate-spin rounded-full border-b-2 border-blue-600"
-            role="status"
-            aria-label="상품 로딩 중"
-          ></div>
+          <Spinner size="md" label="상품 로딩 중" />
         </div>
       </div>
     )

--- a/src/features/chatting-page/components/ChatRooms.tsx
+++ b/src/features/chatting-page/components/ChatRooms.tsx
@@ -6,6 +6,7 @@ import { cn } from '@/lib/utils/cn'
 import { chatSocketStore } from '@/store/chatSocketStore'
 import { useIntersectionObserver } from '@/hooks/useIntersectionObserver'
 import { Z_INDEX } from '@/constants/ui'
+import Spinner from '@/components/commons/spinner/Spinner'
 
 interface ChatRoomsProps {
   rooms: fetchChatRoom[]
@@ -105,11 +106,7 @@ export function ChatRooms({
         <div ref={targetRef} className="h-10" aria-hidden="true" />
         {isFetchingNextPage ? (
           <div className="flex items-center justify-center py-8">
-            <div
-              className="h-8 w-8 animate-spin rounded-full border-b-2 border-blue-600"
-              aria-label="채팅방 로딩 중"
-              role="status"
-            />
+            <Spinner size="md" label="채팅방 로딩 중" />
           </div>
         ) : null}
       </div>

--- a/src/features/community/CommunityDetail.tsx
+++ b/src/features/community/CommunityDetail.tsx
@@ -26,6 +26,7 @@ import { useUserStore } from '@/store/userStore'
 import { useLoginModalStore } from '@/store/modalStore'
 import { AnimatePresence } from 'framer-motion'
 import InlineNotification from '@/components/commons/InlineNotification'
+import Spinner from '@/components/commons/spinner/Spinner'
 
 interface CommunityDetailProps {
   initialPostData?: CommunityDetailItem
@@ -137,7 +138,7 @@ export default function CommunityDetail({ initialPostData, initialCommentData }:
   if (isLoadingCommunityData || isLoadingCommentData) {
     return (
       <div className="flex min-h-screen items-center justify-center">
-        <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-blue-600"></div>
+        <Spinner size="md" />
       </div>
     )
   }

--- a/src/features/community/CommunityPage.tsx
+++ b/src/features/community/CommunityPage.tsx
@@ -8,13 +8,14 @@ import { CommunityTabs } from './components/CommunityTabs'
 import { ROUTES } from '@/constants/routes'
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { api } from '@/lib/api/api'
-import { Eye, Loader2, MessageSquare, MessageSquareText, PenLine, Plus, Search } from 'lucide-react'
+import { Eye, MessageSquare, MessageSquareText, PenLine, Plus, Search } from 'lucide-react'
 import { useIntersectionObserver } from '@/hooks/useIntersectionObserver'
 import { getTimeAgo } from '@/lib/utils/getTimeAgo'
 import { useUserStore } from '@/store/userStore'
 import { cn } from '@/lib/utils/cn'
 import { Z_INDEX } from '@/constants/ui'
 import EmptyState from '@/components/EmptyState'
+import Spinner from '@/components/commons/spinner/Spinner'
 import type { CommunityItem } from '@/types'
 import { CommunityPostThumbnail } from './components/CommunityPostThumbnail'
 
@@ -168,7 +169,7 @@ export default function CommunityPage({ initialQuestionData, initialInfoData }: 
   if (isLoading && !currentData) {
     return (
       <div className="flex min-h-screen items-center justify-center">
-        <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-[#633f00]"></div>
+        <Spinner size="md" />
       </div>
     )
   }
@@ -313,7 +314,7 @@ export default function CommunityPage({ initialQuestionData, initialInfoData }: 
         {/* 무한스크롤 sentinel + 로딩 인디케이터 */}
         {hasNextPage ? (
           <div ref={sentinelRef} className="mt-8 flex justify-center" aria-hidden="true">
-            {isFetchingNextPage ? <Loader2 size={24} className="animate-spin text-[#633f00]" /> : null}
+            {isFetchingNextPage ? <Spinner size="sm" /> : null}
           </div>
         ) : null}
       </main>

--- a/src/features/home/Home.tsx
+++ b/src/features/home/Home.tsx
@@ -18,6 +18,7 @@ import Button from '@/components/commons/button/Button'
 import { useUserStore } from '@/store/userStore'
 import { Z_INDEX } from '@/constants/ui'
 import HomeSkeleton from './components/product-section/HomeSkeleton'
+import Spinner from '@/components/commons/spinner/Spinner'
 import { productListQueryKey, extractProductSearchParams } from '@/lib/queries/productQueryKeys'
 
 function Home() {
@@ -265,11 +266,8 @@ function Home() {
           <div ref={targetRef} className="h-10" aria-hidden="true" />
 
           {isFetchingNextPage ? (
-            <div className="flex items-center justify-center py-8">
-              <div role="status" aria-live="polite">
-                <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-[#825500]" aria-hidden="true"></div>
-                <span className="sr-only">상품 로딩 중</span>
-              </div>
+            <div className="flex items-center justify-center py-8" aria-live="polite">
+              <Spinner size="md" label="상품 로딩 중" />
             </div>
           ) : null}
         </div>

--- a/src/features/map/MapContainer.tsx
+++ b/src/features/map/MapContainer.tsx
@@ -11,6 +11,7 @@ import PlaceDetailSidebar from './PlaceDetailSidebar'
 import PlaceDetailSlideCard from './PlaceDetailSlideCard'
 import { useMapStore, getFilterParams } from '@/store/mapStore'
 import { getPlaces } from '@/lib/api/places'
+import Spinner from '@/components/commons/spinner/Spinner'
 
 export default function MapContainer() {
   const [mapReady, setMapReady] = useState(false)
@@ -104,7 +105,7 @@ export default function MapContainer() {
             ) : (
               <div className="flex h-full items-center justify-center bg-gray-50">
                 <div className="text-center">
-                  <div className="mx-auto mb-3 h-8 w-8 animate-spin rounded-full border-4 border-gray-200 border-t-orange-500" />
+                  <Spinner size="md" className="mx-auto mb-3" label="지도 로딩 중" />
                   <p className="text-sm text-gray-500">
                     지도를 불러오는 중...
                   </p>

--- a/src/features/map/PlaceListSidebar.tsx
+++ b/src/features/map/PlaceListSidebar.tsx
@@ -4,6 +4,7 @@ import { useMapStore } from '@/store/mapStore'
 import { CATEGORIES, HOSPITAL_FILTERS, ANIMAL_TYPE_LABELS } from '@/constants/map'
 import { getPlaceDetail } from '@/lib/api/places'
 import { FiStar } from 'react-icons/fi'
+import Spinner from '@/components/commons/spinner/Spinner'
 
 function getCategoryLabel(category: string) {
   return CATEGORIES.find((c) => c.key === category)?.label ?? category
@@ -113,7 +114,7 @@ export default function PlaceListSidebar() {
 
       {isLoading ? (
         <div className="flex items-center justify-center py-20">
-          <div className="h-6 w-6 animate-spin rounded-full border-2 border-gray-200 border-t-orange-500" />
+          <Spinner size="sm" />
         </div>
       ) : markers.length === 0 ? (
         <div className="px-4 py-20 text-center">

--- a/src/features/my-page/MyPage.tsx
+++ b/src/features/my-page/MyPage.tsx
@@ -15,6 +15,7 @@ const WithdrawModal = dynamic(() => import('@/components/modal/WithdrawModal'))
 import ProfileData from '@/components/profile/ProfileData'
 import { AnimatePresence } from 'framer-motion'
 import InlineNotification from '@/components/commons/InlineNotification'
+import Spinner from '@/components/commons/spinner/Spinner'
 
 function MyPage() {
   const [deleteError, setDeleteError] = useState<React.ReactNode | null>(null)
@@ -240,7 +241,7 @@ function MyPage() {
   if ((isLoadingMyData && !myData) || (isLoadingMyProductData && !myProductsData)) {
     return (
       <div className="flex min-h-screen items-center justify-center">
-        <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-blue-600"></div>
+        <Spinner size="md" />
       </div>
     )
   }

--- a/src/features/product-post/ProductPost.tsx
+++ b/src/features/product-post/ProductPost.tsx
@@ -12,6 +12,7 @@ import type { ProductDetailItem } from '@/types'
 import { useUserStore } from '@/store/userStore'
 import { ArrowLeft } from 'lucide-react'
 import { cn } from '@/lib/utils/cn'
+import Spinner from '@/components/commons/spinner/Spinner'
 import { Z_INDEX } from '@/constants/ui'
 
 function ProductPost() {
@@ -79,7 +80,7 @@ function ProductPost() {
   if (isEditMode && !productData) {
     return (
       <div className="flex min-h-screen items-center justify-center">
-        <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-blue-600" />
+        <Spinner size="md" />
       </div>
     )
   }

--- a/src/features/product-post/components/ProductPostForm.tsx
+++ b/src/features/product-post/components/ProductPostForm.tsx
@@ -12,6 +12,7 @@ import { fetchGraphQL } from '@/lib/api/graphql'
 import { cn } from '@/lib/utils/cn'
 import { useEffect, useMemo, useState } from 'react'
 import TradeInfoSection from './tradeInfoSection/TradeInfoSection'
+import Spinner from '@/components/commons/spinner/Spinner'
 import { IMAGE_PROCESSING_DELAY } from '@/constants/constants'
 
 export interface ProductPostFormValues {
@@ -136,7 +137,7 @@ export function ProductPostForm({ isEditMode, productId: id, initialData }: Prod
     return (
       <div className="flex min-h-screen items-center justify-center">
         <div className="flex flex-col items-center gap-4">
-          <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-blue-600"></div>
+          <Spinner size="md" />
           <p className="text-gray-600">상품을 {isEditMode ? '수정' : '등록'}하고 있습니다...</p>
         </div>
       </div>

--- a/src/features/product-post/components/ProductRequestForm.tsx
+++ b/src/features/product-post/components/ProductRequestForm.tsx
@@ -12,6 +12,7 @@ import type { ProductDetailItem, RequestProductPostRequestData } from '@/types'
 import { fetchGraphQL } from '@/lib/api/graphql'
 import { cn } from '@/lib/utils/cn'
 import { useEffect, useMemo, useState } from 'react'
+import Spinner from '@/components/commons/spinner/Spinner'
 import { IMAGE_PROCESSING_DELAY } from '@/constants/constants'
 
 export interface ProductRequestFormValues {
@@ -136,7 +137,7 @@ export function ProductRequestForm({ isEditMode, productId: id, initialData }: P
     return (
       <div className="flex min-h-screen items-center justify-center">
         <div className="flex flex-col items-center gap-4">
-          <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-blue-600"></div>
+          <Spinner size="md" />
           <p className="text-gray-600">상품을 {isEditMode ? '수정' : '등록'}하고 있습니다...</p>
         </div>
       </div>

--- a/src/features/profile-update/ProfileUpdate.tsx
+++ b/src/features/profile-update/ProfileUpdate.tsx
@@ -10,6 +10,7 @@ import ProfileUpdatePasswordForm from './components/ProfileUpdatePasswordForm'
 import { useMediaQuery } from '@/hooks/useMediaQuery'
 import { useRouter, usePathname } from 'next/navigation'
 import WithdrawModal, { type WithDrawFormValues } from '@/components/modal/WithdrawModal'
+import Spinner from '@/components/commons/spinner/Spinner'
 import { ROUTES } from '@/constants/routes'
 
 function ProfileUpdate() {
@@ -86,7 +87,7 @@ function ProfileUpdate() {
   if (isLoadingMyData) {
     return (
       <div className="flex min-h-screen items-center justify-center">
-        <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-blue-600"></div>
+        <Spinner size="md" />
       </div>
     )
   }


### PR DESCRIPTION
## 📌 개요

프로젝트 전반에 분산된 14개 인라인 로딩 스피너 마크업을 공통 \`<Spinner>\` 컴포넌트로 통일하고, 디자인 시스템 색상 토큰(브라운 brand)을 일관 적용했습니다.

## 🔧 작업 내용

- [x] **공통 \`<Spinner>\` 컴포넌트 신설**: \`src/components/commons/spinner/Spinner.tsx\`
  - size variant: \`sm\`(24px) / \`md\`(32px) / \`lg\`(48px)
  - 도넛 패턴 + 디자인 토큰: \`border-outline-variant border-t-primary-container\`
  - 접근성: \`role="status"\`, \`aria-label\`, sr-only 텍스트 내장
- [x] **14개 호출처를 컴포넌트로 교체**
  - 페이지 로딩 (md): UserPage, ProductPost, ProductRequestForm, ProductPostForm, ChattingPage, ChatLog, ProfileUpdate, MyPage, CommunityDetail, CommunityPage
  - 무한스크롤 (md): Home (\`상품 로딩 중\`), ChatRooms (\`채팅방 로딩 중\`), CommunityPage (sm)
  - 지도 (md/sm): MapContainer (\`지도 로딩 중\`), PlaceListSidebar
- [x] **CommunityPage**: \`Loader2\` lucide-react import 제거 (다른 곳 미사용)

## 📎 관련 이슈

Closes #700

## 💬 리뷰어 참고 사항

- **컬러 통일**: 기존 \`blue-600\`(10곳), 하드코딩 \`#825500\`/\`#633f00\`(2곳), \`orange-500\`(2곳) 모두 \`primary-container\` 토큰으로 통일
- **패턴 통일**: \`border-b-2\`(초승달) / \`border-4\`(도넛) / \`Loader2\` 아이콘 혼재 → 도넛 패턴 단일화
- **접근성 개선**: 일부 호출처에 누락되었던 \`role="status"\`, \`aria-label\`, sr-only 텍스트가 컴포넌트 차원에서 보장됨
- **size 매핑 근거**: 기존 \`h-8 w-8\`은 md, \`h-6 w-6\` / lucide \`size={24}\`는 sm. 추후 lg가 필요한 케이스는 컴포넌트만 사용하면 됨