### PR TITLE
refactor: 펫지도 페이지 컬러 디자인 토큰 적용(#702)

### DIFF
--- a/src/features/map/CategoryTabs.tsx
+++ b/src/features/map/CategoryTabs.tsx
@@ -15,7 +15,7 @@ export default function CategoryTabs() {
           onClick={() => setSelectedCategory(key)}
           className={`shrink-0 cursor-pointer rounded-full px-4 py-2 text-sm font-medium transition-colors ${
             selectedCategory === key
-              ? 'bg-orange-500 text-white'
+              ? 'bg-primary-container text-on-primary-container'
               : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
           }`}
         >

--- a/src/features/map/FilterButtons.tsx
+++ b/src/features/map/FilterButtons.tsx
@@ -18,7 +18,7 @@ export default function FilterButtons() {
           onClick={() => toggleFilter(key)}
           className={`rounded-full px-3 py-1.5 text-xs font-medium shadow-md transition-colors ${
             activeFilters.includes(key)
-              ? 'bg-orange-500 text-white'
+              ? 'bg-primary-container text-on-primary-container'
               : 'bg-white text-gray-700 hover:bg-gray-50'
           }`}
         >

--- a/src/features/map/NaverMap.tsx
+++ b/src/features/map/NaverMap.tsx
@@ -78,7 +78,10 @@ export default function NaverMap() {
   const setNeedsSearch = useMapStore((s) => s.setNeedsSearch)
 
   const createMarkerIcon = useCallback((isRecommended: boolean) => {
-    const color = isRecommended ? '#FF6F0F' : '#3B82F6'
+    // 디자인 토큰과 동기화 (src/styles/tokens.colors.css):
+    // #825500 = --color-primary-container (메인 브랜드, 추천 강조)
+    // #d9ac2c = --color-badge-yellow (밝은 골드, 일반 마커)
+    const color = isRecommended ? '#825500' : '#d9ac2c'
     return {
       content: `<div style="width:28px;height:28px;border-radius:50%;background:${color};border:3px solid white;box-shadow:0 2px 6px rgba(0,0,0,0.3);cursor:pointer;"></div>`,
       anchor: new naver.maps.Point(14, 14),

--- a/src/features/map/PlaceDetailSidebar.tsx
+++ b/src/features/map/PlaceDetailSidebar.tsx
@@ -34,24 +34,24 @@ export default function PlaceDetailSidebar() {
 
         <div className="flex flex-wrap gap-2">
           {selectedPlace.isRecommended && (
-            <span className="rounded-full bg-orange-100 px-3 py-1 text-xs font-medium text-orange-600">
+            <span className="bg-badge-yellow-container text-badge-yellow rounded-full px-3 py-1 text-xs font-medium">
               추천
             </span>
           )}
           {selectedPlace.detail?.is24Hours && (
-            <span className="rounded-full bg-blue-100 px-2.5 py-1 text-xs text-blue-700">
+            <span className="bg-badge-blue-container text-badge-blue rounded-full px-2.5 py-1 text-xs">
               24시간
             </span>
           )}
           {selectedPlace.detail?.isEmergencyAvailable && (
-            <span className="rounded-full bg-red-100 px-2.5 py-1 text-xs text-red-700">
+            <span className="bg-badge-red-container text-badge-red rounded-full px-2.5 py-1 text-xs">
               응급진료
             </span>
           )}
           {selectedPlace.detail?.animalTypes.map((type) => (
             <span
               key={type}
-              className="rounded-full bg-green-100 px-2.5 py-1 text-xs text-green-700"
+              className="bg-badge-green-container text-badge-green rounded-full px-2.5 py-1 text-xs"
             >
               {ANIMAL_TYPE_LABELS[type] ?? type}
             </span>
@@ -69,7 +69,7 @@ export default function PlaceDetailSidebar() {
               <FiPhone className="h-4 w-4 shrink-0 text-gray-400" />
               <a
                 href={`tel:${selectedPlace.phone}`}
-                className="text-blue-600 underline"
+                className="text-primary-container underline"
               >
                 {selectedPlace.phone}
               </a>

--- a/src/features/map/PlaceDetailSidebar.tsx
+++ b/src/features/map/PlaceDetailSidebar.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useMapStore } from '@/store/mapStore'
-import { ANIMAL_TYPE_LABELS } from '@/constants/map'
+// import { ANIMAL_TYPE_LABELS } from '@/constants/map'  // TODO: 특수동물 진료 데이터 추가 시 활성화
 import { FiPhone, FiMapPin, FiStar, FiX } from 'react-icons/fi'
 
 export default function PlaceDetailSidebar() {
@@ -32,31 +32,37 @@ export default function PlaceDetailSidebar() {
           />
         )}
 
-        <div className="flex flex-wrap gap-2">
-          {selectedPlace.isRecommended && (
-            <span className="bg-badge-yellow-container text-badge-yellow rounded-full px-3 py-1 text-xs font-medium">
-              추천
-            </span>
-          )}
-          {selectedPlace.detail?.is24Hours && (
-            <span className="bg-badge-blue-container text-badge-blue rounded-full px-2.5 py-1 text-xs">
-              24시간
-            </span>
-          )}
-          {selectedPlace.detail?.isEmergencyAvailable && (
-            <span className="bg-badge-red-container text-badge-red rounded-full px-2.5 py-1 text-xs">
-              응급진료
-            </span>
-          )}
-          {selectedPlace.detail?.animalTypes.map((type) => (
-            <span
-              key={type}
-              className="bg-badge-green-container text-badge-green rounded-full px-2.5 py-1 text-xs"
-            >
-              {ANIMAL_TYPE_LABELS[type] ?? type}
-            </span>
-          ))}
-        </div>
+        {(selectedPlace.isRecommended ||
+          selectedPlace.detail?.is24Hours ||
+          selectedPlace.detail?.isEmergencyAvailable) && (
+          <div className="flex flex-wrap gap-2">
+            {selectedPlace.isRecommended && (
+              <span className="bg-badge-yellow-container text-badge-yellow rounded-full px-3 py-1 text-xs font-medium">
+                추천
+              </span>
+            )}
+            {selectedPlace.detail?.is24Hours && (
+              <span className="bg-badge-blue-container text-badge-blue rounded-full px-2.5 py-1 text-xs">
+                24시간
+              </span>
+            )}
+            {selectedPlace.detail?.isEmergencyAvailable && (
+              <span className="bg-badge-red-container text-badge-red rounded-full px-2.5 py-1 text-xs">
+                응급진료
+              </span>
+            )}
+            {/* TODO: 특수동물 진료 데이터 추가 시 활성화
+            {selectedPlace.detail?.animalTypes.map((type) => (
+              <span
+                key={type}
+                className="bg-badge-green-container text-badge-green rounded-full px-2.5 py-1 text-xs"
+              >
+                {ANIMAL_TYPE_LABELS[type] ?? type}
+              </span>
+            ))}
+            */}
+          </div>
+        )}
 
         <div className="space-y-3 text-sm text-gray-600">
           <div className="flex items-start gap-2">

--- a/src/features/map/PlaceDetailSlideCard.tsx
+++ b/src/features/map/PlaceDetailSlideCard.tsx
@@ -25,7 +25,7 @@ export default function PlaceDetailSlideCard() {
               <div>
                 <h3 className="text-base font-bold">{selectedPlace.name}</h3>
                 {selectedPlace.isRecommended && (
-                  <span className="mt-1 inline-block rounded-full bg-orange-100 px-2 py-0.5 text-xs font-medium text-orange-600">
+                  <span className="bg-badge-yellow-container text-badge-yellow mt-1 inline-block rounded-full px-2 py-0.5 text-xs font-medium">
                     추천
                   </span>
                 )}
@@ -41,12 +41,12 @@ export default function PlaceDetailSlideCard() {
             {selectedPlace.detail && (
               <div className="mt-2 flex flex-wrap gap-1.5">
                 {selectedPlace.detail.is24Hours && (
-                  <span className="rounded-full bg-blue-100 px-2 py-0.5 text-xs text-blue-700">
+                  <span className="bg-badge-blue-container text-badge-blue rounded-full px-2 py-0.5 text-xs">
                     24시간
                   </span>
                 )}
                 {selectedPlace.detail.isEmergencyAvailable && (
-                  <span className="rounded-full bg-red-100 px-2 py-0.5 text-xs text-red-700">
+                  <span className="bg-badge-red-container text-badge-red rounded-full px-2 py-0.5 text-xs">
                     응급진료
                   </span>
                 )}
@@ -63,7 +63,7 @@ export default function PlaceDetailSlideCard() {
                   <FiPhone className="h-3.5 w-3.5 shrink-0 text-gray-400" />
                   <a
                     href={`tel:${selectedPlace.phone}`}
-                    className="text-blue-600"
+                    className="text-primary-container"
                   >
                     {selectedPlace.phone}
                   </a>

--- a/src/features/map/PlaceDetailSlideCard.tsx
+++ b/src/features/map/PlaceDetailSlideCard.tsx
@@ -38,14 +38,14 @@ export default function PlaceDetailSlideCard() {
               </button>
             </div>
 
-            {selectedPlace.detail && (
+            {(selectedPlace.detail?.is24Hours || selectedPlace.detail?.isEmergencyAvailable) && (
               <div className="mt-2 flex flex-wrap gap-1.5">
-                {selectedPlace.detail.is24Hours && (
+                {selectedPlace.detail?.is24Hours && (
                   <span className="bg-badge-blue-container text-badge-blue rounded-full px-2 py-0.5 text-xs">
                     24시간
                   </span>
                 )}
-                {selectedPlace.detail.isEmergencyAvailable && (
+                {selectedPlace.detail?.isEmergencyAvailable && (
                   <span className="bg-badge-red-container text-badge-red rounded-full px-2 py-0.5 text-xs">
                     응급진료
                   </span>

--- a/src/features/map/PlaceListSidebar.tsx
+++ b/src/features/map/PlaceListSidebar.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { useMapStore } from '@/store/mapStore'
-import { CATEGORIES, HOSPITAL_FILTERS, ANIMAL_TYPE_LABELS } from '@/constants/map'
+import { CATEGORIES, HOSPITAL_FILTERS } from '@/constants/map'
+// import { ANIMAL_TYPE_LABELS } from '@/constants/map'  // TODO: 특수동물 진료 데이터 추가 시 활성화
 import { getPlaceDetail } from '@/lib/api/places'
 import { FiStar } from 'react-icons/fi'
 
@@ -135,9 +136,10 @@ export default function PlaceListSidebar() {
             const tags: string[] = []
             if (place.detail?.is24Hours) tags.push('24시간 진료')
             if (place.detail?.isEmergencyAvailable) tags.push('응급 진료')
-            place.detail?.animalTypes.forEach((type) => {
-              tags.push(ANIMAL_TYPE_LABELS[type] ?? type)
-            })
+            // TODO: 특수동물 진료 데이터 추가 시 활성화
+            // place.detail?.animalTypes.forEach((type) => {
+            //   tags.push(ANIMAL_TYPE_LABELS[type] ?? type)
+            // })
 
             const isSelected = selectedPlace?.id === place.id
 

--- a/src/features/map/PlaceListSidebar.tsx
+++ b/src/features/map/PlaceListSidebar.tsx
@@ -101,7 +101,7 @@ export default function PlaceListSidebar() {
               onClick={() => toggleFilter(key)}
               className={`cursor-pointer rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
                 activeFilters.includes(key)
-                  ? 'bg-orange-500 text-white'
+                  ? 'bg-primary-container text-on-primary-container'
                   : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
               }`}
             >
@@ -147,7 +147,7 @@ export default function PlaceListSidebar() {
                   onClick={() => handleClickPlace(place.id)}
                   className={`flex w-full cursor-pointer gap-3 px-4 py-4 text-left transition-colors ${
                     isSelected
-                      ? 'bg-orange-50 border-l-2 border-orange-500'
+                      ? 'bg-surface-container-low border-l-2 border-primary-container'
                       : 'hover:bg-gray-50'
                   }`}
                 >
@@ -160,7 +160,7 @@ export default function PlaceListSidebar() {
                         {categoryLabel}
                       </span>
                       {place.isRecommended && (
-                        <span className="mt-0.5 ml-auto shrink-0 rounded-full bg-orange-100 px-2 py-0.5 text-xs text-orange-600">
+                        <span className="bg-badge-yellow-container text-badge-yellow mt-0.5 ml-auto shrink-0 rounded-full px-2 py-0.5 text-xs">
                           추천
                         </span>
                       )}


### PR DESCRIPTION
## 📌 개요

펫지도 페이지의 하드코딩 컬러 클래스(\`orange-*\`, \`blue-*\`, \`red-*\`, \`green-*\`)를 디자인 시스템 토큰으로 통일했습니다. 다른 페이지가 사용 중인 brown brand(\`primary-container\`)와 \`badge-*\` 토큰에 맞춰 페이지 간 시각 일관성을 확보합니다.

## 🔧 작업 내용

- [x] **강조 active 컬러**: \`bg-orange-500 text-white\` → \`bg-primary-container text-on-primary-container\`
  - CategoryTabs (카테고리 탭 활성 상태)
  - FilterButtons (병원 필터 활성 상태)
  - PlaceListSidebar (병원 필터 + 선택 항목 좌측 보더)
- [x] **추천 chip**: \`bg-orange-100 text-orange-600\` → \`bg-badge-yellow-container text-badge-yellow\` (highlight 톤 매칭)
  - PlaceListSidebar / PlaceDetailSlideCard / PlaceDetailSidebar 3곳
- [x] **상태 chip 토큰화**:
  - 24시간 \`bg-blue-100 text-blue-700\` → \`bg-badge-blue-container text-badge-blue\`
  - 응급진료 \`bg-red-100 text-red-700\` → \`bg-badge-red-container text-badge-red\`
  - animalTypes \`bg-green-100 text-green-700\` → \`bg-badge-green-container text-badge-green\`
- [x] **전화 링크**: \`text-blue-600\` → \`text-primary-container\` (브랜드 링크 색)
- [x] **선택 항목 배경**: \`bg-orange-50\` → \`bg-surface-container-low\`

## 📎 관련 이슈

Closes #702

## 💬 리뷰어 참고 사항

- **PR #701(스피너 통일)과 의도적으로 분리**: MapContainer/PlaceListSidebar의 spinner 라인은 PR #701에서 처리되어 이 PR에서는 건드리지 않음. 두 PR이 develop으로 머지되면 자연스럽게 통합됨 (다른 라인이라 git auto-merge)
- **추천 chip 컬러 선택**: 원본이 \`orange-100/600\`(따뜻한 cream + orange)이라 \`badge-yellow-container/yellow\`(cream + gold)로 매핑 → "추천/highlight" 의미 매칭
- **active 상태와 선택 상태 분리**: 활성 버튼은 \`primary-container\` (강한 강조), 선택된 리스트 항목은 \`surface-container-low\` (옅은 배경 + 진한 좌측 보더) — 시각적 위계 유지