### PR TITLE
chore: 공용 UI 컴포넌트 6종 Stories 추가(#716)

### DIFF
--- a/src/components/EmptyState.stories.tsx
+++ b/src/components/EmptyState.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { Package, Heart, Search, MessageSquare } from 'lucide-react'
+import EmptyState from './EmptyState'
+
+const meta = {
+  title: 'Commons/EmptyState',
+  component: EmptyState,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+} satisfies Meta<typeof EmptyState>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const NoProducts: Story = {
+  args: {
+    icon: Package,
+    title: '등록한 상품이 없습니다',
+    description: '상품을 등록해보세요',
+  },
+}
+
+export const NoFavorites: Story = {
+  args: {
+    icon: Heart,
+    title: '찜한 상품이 없습니다',
+    description: '마음에 드는 상품을 찜해보세요',
+  },
+}
+
+export const NoSearchResults: Story = {
+  args: {
+    icon: Search,
+    title: '검색 결과가 없습니다',
+    description: '다른 키워드로 검색해보세요',
+  },
+}
+
+export const NoMessages: Story = {
+  args: {
+    icon: MessageSquare,
+    title: '대화 중인 채팅이 없습니다',
+  },
+}

--- a/src/components/commons/badge/Badge.stories.tsx
+++ b/src/components/commons/badge/Badge.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import Badge from './Badge'
+
+const meta = {
+  title: 'Commons/Badge',
+  component: Badge,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+} satisfies Meta<typeof Badge>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: { children: '판매중' },
+}
+
+export const Primary: Story = {
+  args: { children: '판매중', className: 'bg-primary text-white' },
+}
+
+export const Reserved: Story = {
+  args: { children: '예약중', className: 'bg-secondary-container text-on-secondary-container' },
+}
+
+export const Completed: Story = {
+  args: { children: '판매완료', className: 'bg-surface-container-high text-on-surface-muted' },
+}
+
+export const Outline: Story = {
+  args: { children: '새 상품', className: 'border border-outline-variant/60 bg-transparent text-on-surface' },
+}

--- a/src/components/commons/breadcrumb/Breadcrumb.stories.tsx
+++ b/src/components/commons/breadcrumb/Breadcrumb.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import Breadcrumb from './Breadcrumb'
+
+const meta = {
+  title: 'Commons/Breadcrumb',
+  component: Breadcrumb,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+} satisfies Meta<typeof Breadcrumb>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Single: Story = {
+  args: {
+    items: [{ label: '홈', href: '/' }],
+  },
+}
+
+export const TwoLevel: Story = {
+  args: {
+    items: [
+      { label: '홈', href: '/' },
+      { label: '중고거래', href: '/market' },
+    ],
+  },
+}
+
+export const ThreeLevel: Story = {
+  args: {
+    items: [
+      { label: '홈', href: '/' },
+      { label: '중고거래', href: '/market' },
+      { label: '사료/간식' },
+    ],
+  },
+}
+
+export const LongPath: Story = {
+  args: {
+    items: [
+      { label: '홈', href: '/' },
+      { label: '중고거래', href: '/market' },
+      { label: '포유류', href: '/market?pet=mammal' },
+      { label: '강아지', href: '/market?detail=dog' },
+      { label: '사료/간식' },
+    ],
+  },
+}

--- a/src/components/commons/button/IconButton.stories.tsx
+++ b/src/components/commons/button/IconButton.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { Heart, Bell, Search, X } from 'lucide-react'
+import IconButton from './IconButton'
+
+const meta = {
+  title: 'Commons/IconButton',
+  component: IconButton,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+  argTypes: {
+    size: { control: 'inline-radio', options: ['sm', 'md', 'lg'] },
+  },
+} satisfies Meta<typeof IconButton>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Small: Story = {
+  args: {
+    size: 'sm',
+    'aria-label': '검색',
+    children: <Search size={16} />,
+  },
+}
+
+export const Medium: Story = {
+  args: {
+    size: 'md',
+    'aria-label': '알림',
+    children: <Bell size={20} />,
+  },
+}
+
+export const Large: Story = {
+  args: {
+    size: 'lg',
+    'aria-label': '좋아요',
+    children: <Heart size={24} />,
+  },
+}
+
+export const WithHover: Story = {
+  args: {
+    size: 'md',
+    'aria-label': '닫기',
+    children: <X size={20} />,
+    className: 'hover:bg-surface-container-high transition-all',
+  },
+}

--- a/src/components/commons/button/LoadMoreButton.stories.tsx
+++ b/src/components/commons/button/LoadMoreButton.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import LoadMoreButton from './LoadMoreButton'
+
+const meta = {
+  title: 'Commons/LoadMoreButton',
+  component: LoadMoreButton,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+} satisfies Meta<typeof LoadMoreButton>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: { onClick: () => {} },
+}
+
+export const Loading: Story = {
+  args: { onClick: () => {}, isLoading: true },
+}
+
+export const CustomText: Story = {
+  args: { onClick: () => {}, text: '상품 더 보기', loadingText: '불러오는 중...' },
+}
+
+export const Disabled: Story = {
+  args: { onClick: () => {}, disabled: true },
+}

--- a/src/components/commons/spinner/Spinner.stories.tsx
+++ b/src/components/commons/spinner/Spinner.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import Spinner from './Spinner'
+
+const meta = {
+  title: 'Commons/Spinner',
+  component: Spinner,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+  argTypes: {
+    size: { control: 'inline-radio', options: ['sm', 'md', 'lg'] },
+  },
+} satisfies Meta<typeof Spinner>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Small: Story = {
+  args: { size: 'sm' },
+}
+
+export const Medium: Story = {
+  args: { size: 'md' },
+}
+
+export const Large: Story = {
+  args: { size: 'lg' },
+}
+
+export const CustomLabel: Story = {
+  args: { size: 'md', label: '상품을 불러오는 중...' },
+}


### PR DESCRIPTION
## 📌 개요

Storybook 후속 1차 — 공용 UI 컴포넌트 6종의 \`.stories.tsx\` 추가. 인라인 사용처 교체는 본 PR에 포함하지 않음.

## 🔧 작업 내용

- [x] \`Badge.stories.tsx\` — Default / Primary / Reserved / Completed / Outline
- [x] \`Spinner.stories.tsx\` — Small / Medium / Large / CustomLabel
- [x] \`IconButton.stories.tsx\` — Small / Medium / Large / WithHover
- [x] \`LoadMoreButton.stories.tsx\` — Default / Loading / CustomText / Disabled
- [x] \`EmptyState.stories.tsx\` — NoProducts / NoFavorites / NoSearchResults / NoMessages
- [x] \`Breadcrumb.stories.tsx\` — Single / TwoLevel / ThreeLevel / LongPath

## 📎 관련 이슈

- Closes #716

## 💬 리뷰어 참고 사항

- 각 컴포넌트의 시각 변형을 Storybook 카탈로그로 단독 검증 가능
- 디자인 토큰 변경 시 회귀 검증 도구로 활용
- **후속 작업 예정** (다음 PR):
  - \`SelectDropdown\`, \`Tabs\`, \`InlineNotification\`, \`ProfileAvatar\`
  - 도메인: \`ProductCard\`, \`ProductInfo\`, \`ProductBadge\`, \`ProductThumbnail\`