### PR TITLE
feat: 마이페이지 좌측 nav에 차단한 사용자 항목 추가(#718)

### DIFF
--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -10,6 +10,7 @@ import {
   TriangleAlert,
   Check,
   Slash,
+  UserRoundX,
   LayoutDashboard,
   Handbag,
   Heart,
@@ -193,6 +194,7 @@ export const MY_PAGE_NAV = [
   { id: 'nav-purchases', label: '구매 내역', code: 'PURCHASES' },
   { id: 'nav-wishlist', label: '찜한 상품', code: 'FAVORITE' },
   { id: 'nav-activity', label: '내 활동', code: 'ACTIVITY' },
+  { id: 'nav-blocked', label: '차단한 사용자', code: 'BLOCKED' },
 ] as const
 export type MyPageNavId = (typeof MY_PAGE_NAV)[number]['id']
 export type MyPageNavCode = (typeof MY_PAGE_NAV)[number]['code']
@@ -343,6 +345,7 @@ export const myPageIconMap: Record<MyPageNavCode, LucideIcon> = {
   PURCHASES: Handbag,
   FAVORITE: Heart,
   ACTIVITY: Activity,
+  BLOCKED: UserRoundX,
 }
 
 /** 토스트 기본 설정 */

--- a/src/features/my-page/MyPage.tsx
+++ b/src/features/my-page/MyPage.tsx
@@ -254,6 +254,7 @@ function MyPage() {
     PURCHASES: 'tab-purchases',
     FAVORITE: 'tab-wishlist',
     ACTIVITY: null,
+    BLOCKED: 'tab-blocked',
   }
 
   const handleNavChange = (navId: MyPageNavId) => {


### PR DESCRIPTION
## 📌 개요

마이페이지 좌측 네비게이션에 "차단한 사용자" 항목을 별도 진입점으로 추가

## 🔧 작업 내용

- [x] \`MY_PAGE_NAV\`에 \`nav-blocked\` 항목 추가 (label: "차단한 사용자", code: "BLOCKED")
- [x] \`myPageIconMap\`에 \`BLOCKED: UserRoundX\` 아이콘 매핑
- [x] \`MyPage.tsx\`의 \`NAV_TO_TAB\` 매핑에 \`BLOCKED: 'tab-blocked'\` 추가 — 좌측 nav 클릭 시 차단 유저 패널 진입

## 📎 관련 이슈

- Closes #718

## 💬 리뷰어 참고 사항

- 기존엔 차단 유저 관리가 거래 내역 탭(tab-blocked) 안에 묻혀 있어 접근성 낮음
- 좌측 nav에 별도 진입점으로 노출해서 사용자 관리 기능을 명확하게 분리