### PR TITLE
chore: 공용 입력/피드백 컴포넌트 4종 Stories 추가(#720)

### DIFF
--- a/src/components/Tabs.stories.tsx
+++ b/src/components/Tabs.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { useState } from 'react'
+import Tabs from './Tabs'
+
+const meta = {
+  title: 'Commons/Tabs',
+  component: Tabs,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: { control: 'inline-radio', options: ['default', 'card-pill'] },
+  },
+} satisfies Meta<typeof Tabs>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+const SAMPLE_TABS = [
+  { id: 'tab-all', label: '전체', code: 'ALL' },
+  { id: 'tab-question', label: '질문 있어요', code: 'QUESTION' },
+  { id: 'tab-info', label: '정보 공유', code: 'INFO' },
+] as const
+
+export const Default: Story = {
+  args: {
+    tabs: SAMPLE_TABS,
+    activeTab: 'tab-all',
+    onTabChange: () => {},
+    ariaLabel: '커뮤니티 분류',
+    variant: 'default',
+  },
+  render: (args) => {
+    const [active, setActive] = useState(args.activeTab)
+    return <Tabs {...args} activeTab={active} onTabChange={setActive} />
+  },
+}
+
+export const CardPill: Story = {
+  args: {
+    tabs: [
+      { id: 'tab-all', label: '전체', code: 'ALL' },
+      { id: 'tab-selling', label: '판매중', code: 'SELLING' },
+      { id: 'tab-reserved', label: '예약중', code: 'RESERVED' },
+      { id: 'tab-completed', label: '판매완료', code: 'COMPLETED' },
+    ],
+    activeTab: 'tab-all',
+    onTabChange: () => {},
+    ariaLabel: '거래 상태',
+    variant: 'card-pill',
+  },
+  render: (args) => {
+    const [active, setActive] = useState(args.activeTab)
+    return <Tabs {...args} activeTab={active} onTabChange={setActive} />
+  },
+}

--- a/src/components/commons/InlineNotification.stories.tsx
+++ b/src/components/commons/InlineNotification.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import InlineNotification from './InlineNotification'
+
+const meta = {
+  title: 'Commons/InlineNotification',
+  component: InlineNotification,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+  argTypes: {
+    type: { control: 'inline-radio', options: ['success', 'error', 'warning'] },
+  },
+} satisfies Meta<typeof InlineNotification>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Success: Story = {
+  args: {
+    type: 'success',
+    onClose: () => {},
+    durationMs: 60000,
+    children: <p className="font-semibold">상품을 성공적으로 등록했습니다.</p>,
+  },
+  render: (args) => (
+    <div className="w-80">
+      <InlineNotification {...args} />
+    </div>
+  ),
+}
+
+export const Error: Story = {
+  args: {
+    type: 'error',
+    onClose: () => {},
+    durationMs: 60000,
+    children: (
+      <div className="flex flex-col gap-0.5">
+        <p className="text-base font-semibold">상품 삭제에 실패했습니다.</p>
+        <p>잠시 후 다시 시도해주세요.</p>
+      </div>
+    ),
+  },
+  render: (args) => (
+    <div className="w-80">
+      <InlineNotification {...args} />
+    </div>
+  ),
+}
+
+export const Warning: Story = {
+  args: {
+    type: 'warning',
+    onClose: () => {},
+    durationMs: 60000,
+    children: <p className="font-semibold">진행 중인 거래가 있습니다. 먼저 완료해주세요.</p>,
+  },
+  render: (args) => (
+    <div className="w-80">
+      <InlineNotification {...args} />
+    </div>
+  ),
+}

--- a/src/components/commons/InlineNotification.stories.tsx
+++ b/src/components/commons/InlineNotification.stories.tsx
@@ -53,7 +53,12 @@ export const Warning: Story = {
     type: 'warning',
     onClose: () => {},
     durationMs: 60000,
-    children: <p className="font-semibold">진행 중인 거래가 있습니다. 먼저 완료해주세요.</p>,
+    children: (
+      <div className="flex flex-col gap-0.5">
+        <p className="font-semibold">진행 중인 거래가 있습니다.</p>
+        <p>먼저 완료해주세요.</p>
+      </div>
+    ),
   },
   render: (args) => (
     <div className="w-80">

--- a/src/components/commons/InlineNotification.tsx
+++ b/src/components/commons/InlineNotification.tsx
@@ -54,7 +54,7 @@ export default function InlineNotification({ type, children, onClose, durationMs
         <div className={styles.iconWrapper}>
           <Icon className={cn('h-2 w-2 shrink-0', styles.icon)} />
         </div>
-        <div className="text-sm">{children}</div>
+        <div className="break-keep text-sm">{children}</div>
         <button
           type="button"
           aria-label="close notification"

--- a/src/components/commons/ProfileAvatar.stories.tsx
+++ b/src/components/commons/ProfileAvatar.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import ProfileAvatar from './ProfileAvatar'
+
+const meta = {
+  title: 'Commons/ProfileAvatar',
+  component: ProfileAvatar,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+  argTypes: {
+    size: { control: 'inline-radio', options: ['sm', 'md', 'lg'] },
+  },
+} satisfies Meta<typeof ProfileAvatar>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Small: Story = {
+  args: {
+    nickname: '행복한집사',
+    size: 'sm',
+  },
+}
+
+export const Medium: Story = {
+  args: {
+    nickname: '행복한집사',
+    size: 'md',
+  },
+}
+
+export const Large: Story = {
+  args: {
+    nickname: '행복한집사',
+    size: 'lg',
+  },
+}
+
+export const FallbackInitial: Story = {
+  args: {
+    nickname: 'A',
+    size: 'md',
+  },
+}
+
+export const SizeComparison: Story = {
+  args: { nickname: '행복한집사' },
+  render: () => (
+    <div className="flex items-center gap-4">
+      <ProfileAvatar nickname="행복한집사" size="sm" />
+      <ProfileAvatar nickname="행복한집사" size="md" />
+      <ProfileAvatar nickname="행복한집사" size="lg" />
+    </div>
+  ),
+}

--- a/src/components/commons/select/SelectDropdown.stories.tsx
+++ b/src/components/commons/select/SelectDropdown.stories.tsx
@@ -1,0 +1,87 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { useState } from 'react'
+import SelectDropdown from './SelectDropdown'
+
+const meta = {
+  title: 'Commons/SelectDropdown',
+  component: SelectDropdown,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+} satisfies Meta<typeof SelectDropdown>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+const PET_OPTIONS = [
+  { value: 'dog', label: '강아지' },
+  { value: 'cat', label: '고양이' },
+  { value: 'rabbit', label: '토끼' },
+  { value: 'hamster', label: '햄스터' },
+  { value: 'parrot', label: '앵무새' },
+]
+
+export const Basic: Story = {
+  args: {
+    value: 'dog',
+    onChange: () => {},
+    options: PET_OPTIONS,
+    placeholder: '반려동물을 선택하세요',
+  },
+  render: (args) => {
+    const [value, setValue] = useState(args.value)
+    return (
+      <div className="w-60">
+        <SelectDropdown {...args} value={value} onChange={setValue} />
+      </div>
+    )
+  },
+}
+
+export const WithPlaceholder: Story = {
+  args: {
+    value: '',
+    onChange: () => {},
+    options: PET_OPTIONS,
+    placeholder: '선택하세요',
+  },
+  render: (args) => {
+    const [value, setValue] = useState(args.value)
+    return (
+      <div className="w-60">
+        <SelectDropdown {...args} value={value} onChange={setValue} />
+      </div>
+    )
+  },
+}
+
+export const Disabled: Story = {
+  args: {
+    value: 'dog',
+    onChange: () => {},
+    options: PET_OPTIONS,
+    disabled: true,
+  },
+  render: (args) => (
+    <div className="w-60">
+      <SelectDropdown {...args} />
+    </div>
+  ),
+}
+
+export const CustomButtonStyle: Story = {
+  args: {
+    value: 'dog',
+    onChange: () => {},
+    options: PET_OPTIONS,
+    buttonClassName: 'border-0 bg-primary-50 text-gray-900',
+  },
+  render: (args) => {
+    const [value, setValue] = useState(args.value)
+    return (
+      <div className="w-60">
+        <SelectDropdown {...args} value={value} onChange={setValue} />
+      </div>
+    )
+  },
+}


### PR DESCRIPTION
## 📌 개요

Storybook 후속 2차 — 입력/피드백 계열 공용 컴포넌트의 \`.stories.tsx\` 추가. 인라인 사용처 교체는 본 PR에 포함하지 않음.

## 🔧 작업 내용

### Stories 추가
- [x] \`SelectDropdown.stories.tsx\` — Basic / WithPlaceholder / Disabled / CustomButtonStyle
- [x] \`Tabs.stories.tsx\` — Default variant / CardPill variant
- [x] \`InlineNotification.stories.tsx\` — Success / Error / Warning
- [x] \`ProfileAvatar.stories.tsx\` — Small / Medium / Large / FallbackInitial / SizeComparison

### 기타 개선
- [x] \`InlineNotification\` 본문 텍스트에 \`break-keep\` 추가 — 한국어 어절 중간 끊김 방지 (Stories 작성 중 발견)

## 📎 관련 이슈

- Closes #720

## 💬 리뷰어 참고 사항

- \`SelectDropdown\`은 \`createPortal\`로 listbox를 \`document.body\`에 그림. Storybook iframe 환경에서도 정상 동작 확인
- \`InlineNotification\` Warning Story 미리보기에서 좁은 컨테이너(\`w-80\`)일 때 한국어 어절이 중간에 끊기던 문제 → \`break-keep\` 추가로 해결
- **다음 PR (3차) 예정**: 도메인 — \`ProductCard\`, \`ProductInfo\`, \`ProductBadge\`, \`ProductThumbnail\`