### PR TITLE
chore: 모달 13종 Stories 추가 및 긴 텍스트 방어 처리(#728)

### DIFF
--- a/src/components/modal/AlertBox.stories.tsx
+++ b/src/components/modal/AlertBox.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { Info } from 'lucide-react'
+import AlertBox from './AlertBox'
+
+const meta = {
+  title: 'Commons/Modal/AlertBox',
+  component: AlertBox,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+} satisfies Meta<typeof AlertBox>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const SingleItem: Story = {
+  args: {
+    alertList: ['삭제된 상품은 복구할 수 없습니다'],
+  },
+  decorators: [
+    (StoryFn) => (
+      <div className="w-96">
+        <StoryFn />
+      </div>
+    ),
+  ],
+}
+
+export const MultipleItems: Story = {
+  args: {
+    alertList: [
+      '등록한 모든 상품이 삭제됩니다',
+      '거래 내역과 채팅 기록이 모두 삭제됩니다',
+      '찜한 상품 목록이 삭제됩니다',
+      '진행 중인 거래가 있다면 먼저 완료해 주세요',
+    ],
+  },
+  decorators: [
+    (StoryFn) => (
+      <div className="w-96">
+        <StoryFn />
+      </div>
+    ),
+  ],
+}
+
+export const InfoTone: Story = {
+  args: {
+    alertList: ['이 작업은 되돌릴 수 없습니다'],
+    title: '안내사항',
+    icon: Info,
+    iconColor: 'text-primary',
+    bgColor: 'bg-primary-50',
+    borderColor: 'border-primary-100',
+    titleColor: 'text-primary',
+    listColor: 'text-on-surface',
+  },
+  decorators: [
+    (StoryFn) => (
+      <div className="w-96">
+        <StoryFn />
+      </div>
+    ),
+  ],
+}

--- a/src/components/modal/BlockModal.stories.tsx
+++ b/src/components/modal/BlockModal.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import BlockModal from './BlockModal'
+
+const meta = {
+  title: 'Commons/Modal/BlockModal',
+  component: BlockModal,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+} satisfies Meta<typeof BlockModal>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Open: Story = {
+  args: {
+    isOpen: true,
+    userNickname: '행복한집사',
+    userId: 1,
+    onCancel: () => {},
+  },
+}
+
+export const MaxLengthNickname: Story = {
+  args: {
+    isOpen: true,
+    userNickname: '긴닉네임을가진사용자', // 닉네임 정책 최대치 10자 (validationRules: 2~10자)
+    userId: 2,
+    onCancel: () => {},
+  },
+}

--- a/src/components/modal/BlockModal.tsx
+++ b/src/components/modal/BlockModal.tsx
@@ -54,7 +54,7 @@ export default function BlockModal({ isOpen, onCancel, userNickname, userId }: B
   return (
     <dialog
       ref={dialogRef}
-      className="m-auto w-11/12 open:flex flex-col gap-4 rounded-lg bg-white p-5 backdrop:bg-gray-900/70 md:w-[16vw] md:min-w-max"
+      className="m-auto w-11/12 open:flex flex-col gap-4 rounded-lg bg-white p-5 backdrop:bg-gray-900/70 md:w-[16vw] md:min-w-96 md:max-w-md"
       onClick={(e) => {
         if (e.target === dialogRef.current) dialogRef.current.close()
       }}

--- a/src/components/modal/DeleteConfirmModal.stories.tsx
+++ b/src/components/modal/DeleteConfirmModal.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import DeleteConfirmModal from './DeleteConfirmModal'
+
+const meta = {
+  title: 'Commons/Modal/DeleteConfirmModal',
+  component: DeleteConfirmModal,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+} satisfies Meta<typeof DeleteConfirmModal>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+const sampleProduct = {
+  id: 1,
+  title: '폭신폭신 프리미엄 원목 강아지 침대',
+  price: 45000,
+  mainImageUrl: '/images/category/house.webp',
+}
+
+export const Open: Story = {
+  args: {
+    isOpen: true,
+    product: sampleProduct,
+    onConfirm: () => {},
+    onCancel: () => {},
+  },
+}
+
+export const WithError: Story = {
+  args: {
+    isOpen: true,
+    product: sampleProduct,
+    onConfirm: () => {},
+    onCancel: () => {},
+    error: (
+      <div className="flex flex-col gap-0.5">
+        <p className="text-base font-semibold">상품 삭제에 실패했습니다.</p>
+        <p>잠시 후 다시 시도해주세요.</p>
+      </div>
+    ),
+    onClearError: () => {},
+  },
+}

--- a/src/components/modal/DeletePostConfirmModal.stories.tsx
+++ b/src/components/modal/DeletePostConfirmModal.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import DeletePostConfirmModal from './DeletePostConfirmModal'
+
+const meta = {
+  title: 'Commons/Modal/DeletePostConfirmModal',
+  component: DeletePostConfirmModal,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+} satisfies Meta<typeof DeletePostConfirmModal>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Open: Story = {
+  args: {
+    isOpen: true,
+    postId: 1,
+    onConfirm: () => {},
+    onCancel: () => {},
+  },
+}
+
+export const WithError: Story = {
+  args: {
+    isOpen: true,
+    postId: 1,
+    onConfirm: () => {},
+    onCancel: () => {},
+    error: (
+      <div className="flex flex-col gap-0.5">
+        <p className="text-base font-semibold">게시글 삭제에 실패했습니다.</p>
+        <p>잠시 후 다시 시도해주세요.</p>
+      </div>
+    ),
+    onClearError: () => {},
+  },
+}

--- a/src/components/modal/DeleteReplyModal.stories.tsx
+++ b/src/components/modal/DeleteReplyModal.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import DeleteReplyModal from './DeleteReplyModal'
+
+const meta = {
+  title: 'Commons/Modal/DeleteReplyModal',
+  component: DeleteReplyModal,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+} satisfies Meta<typeof DeleteReplyModal>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Open: Story = {
+  args: {
+    isOpen: true,
+    replyId: 1,
+    onCancel: () => {},
+    onConfirm: async () => {},
+  },
+}

--- a/src/components/modal/DeleteReplyModal.tsx
+++ b/src/components/modal/DeleteReplyModal.tsx
@@ -41,7 +41,7 @@ export default function DeleteReplyModal({ isOpen, onCancel, replyId, onConfirm 
   return (
     <dialog
       ref={dialogRef}
-      className="m-auto w-11/12 open:flex flex-col gap-4 rounded-lg bg-white p-5 backdrop:bg-gray-900/70 md:w-[16vw] md:min-w-max"
+      className="m-auto w-11/12 open:flex flex-col gap-4 rounded-lg bg-white p-5 backdrop:bg-gray-900/70 md:w-[16vw] md:min-w-96 md:max-w-md"
       onClick={(e) => {
         if (e.target === dialogRef.current) dialogRef.current.close()
       }}

--- a/src/components/modal/DraftModal.stories.tsx
+++ b/src/components/modal/DraftModal.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import DraftModal from './DraftModal'
+
+const meta = {
+  title: 'Commons/Modal/DraftModal',
+  component: DraftModal,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+} satisfies Meta<typeof DraftModal>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Open: Story = {
+  args: {
+    initialBoardType: 'QUESTION',
+    showDraftModal: true,
+    setIsDraftChecked: () => {},
+    setShowDraftModal: () => {},
+    clearDraft: () => {},
+    getSavedDraft: () => ({
+      boardType: 'QUESTION',
+      title: '임시저장된 제목',
+      content: '임시저장된 본문',
+    }),
+    reset: () => {},
+  },
+}

--- a/src/components/modal/LoginModal.stories.tsx
+++ b/src/components/modal/LoginModal.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import LoginModal from './LoginModal'
+import { useLoginModalStore } from '@/store/modalStore'
+
+const meta = {
+  title: 'Commons/Modal/LoginModal',
+  component: LoginModal,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+} satisfies Meta<typeof LoginModal>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const LoginPrompt: Story = {
+  decorators: [
+    (StoryFn) => {
+      useLoginModalStore.setState({
+        isOpen: true,
+        modalType: 'login',
+        closeModal: () => {},
+        onConfirm: () => {},
+      })
+      return <StoryFn />
+    },
+  ],
+}
+
+export const LogoutPrompt: Story = {
+  decorators: [
+    (StoryFn) => {
+      useLoginModalStore.setState({
+        isOpen: true,
+        modalType: 'logout',
+        closeModal: () => {},
+        onConfirm: () => {},
+      })
+      return <StoryFn />
+    },
+  ],
+}

--- a/src/components/modal/ModalTitle.stories.tsx
+++ b/src/components/modal/ModalTitle.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import ModalTitle from './ModalTitle'
+
+const meta = {
+  title: 'Commons/Modal/ModalTitle',
+  component: ModalTitle,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+} satisfies Meta<typeof ModalTitle>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: { heading: '상품 삭제', description: '정말로 이 상품을 삭제하시겠습니까?' },
+}
+
+export const Withdraw: Story = {
+  args: { heading: '회원 탈퇴', description: '탈퇴 후에는 복구할 수 없습니다.' },
+}
+
+export const RichDescription: Story = {
+  args: {
+    heading: '게시글 신고',
+    description: (
+      <div className="flex flex-col gap-1 text-sm text-gray-600">
+        <p>신고 사유를 선택해주세요.</p>
+        <p>신고는 익명으로 처리됩니다.</p>
+      </div>
+    ),
+  },
+}

--- a/src/components/modal/ModalTitle.tsx
+++ b/src/components/modal/ModalTitle.tsx
@@ -13,7 +13,7 @@ export default function ModalTitle({ heading, description }: ModalTitleProps) {
         <TriangleAlert className="text-danger-600" />
         <p className="heading-h5">{heading}</p>
       </div>
-      <div>{description}</div>
+      <div className="break-keep wrap-break-word">{description}</div>
     </div>
   )
 }

--- a/src/components/modal/PostReportModal.stories.tsx
+++ b/src/components/modal/PostReportModal.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import PostReportModal from './PostReportModal'
+
+const meta = {
+  title: 'Commons/Modal/PostReportModal',
+  component: PostReportModal,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+} satisfies Meta<typeof PostReportModal>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Open: Story = {
+  args: {
+    isOpen: true,
+    postId: 1,
+    authorNickname: '행복한집사',
+    postTitle: '강아지 산책 시간 어느 정도가 좋을까요?',
+    onCancel: () => {},
+  },
+}

--- a/src/components/modal/ProductReportModal.stories.tsx
+++ b/src/components/modal/ProductReportModal.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import ProductReportModal from './ProductReportModal'
+
+const meta = {
+  title: 'Commons/Modal/ProductReportModal',
+  component: ProductReportModal,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+} satisfies Meta<typeof ProductReportModal>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Open: Story = {
+  args: {
+    isOpen: true,
+    productId: 1,
+    productTitle: '폭신폭신 프리미엄 원목 강아지 침대',
+    onCancel: () => {},
+  },
+}

--- a/src/components/modal/ReportModalBase.stories.tsx
+++ b/src/components/modal/ReportModalBase.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import ReportModalBase from './ReportModalBase'
+import { POST_REPORT_REASON } from '@/constants/constants'
+
+const meta = {
+  title: 'Commons/Modal/ReportModalBase',
+  component: ReportModalBase,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+} satisfies Meta<typeof ReportModalBase>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Open: Story = {
+  args: {
+    isOpen: true,
+    heading: '신고하기',
+    description: '신고 사유를 선택해주세요',
+    reasons: POST_REPORT_REASON,
+    onCancel: () => {},
+    onSubmit: async () => {},
+  },
+}
+
+export const WithError: Story = {
+  args: {
+    isOpen: true,
+    heading: '신고하기',
+    description: '신고 사유를 선택해주세요',
+    reasons: POST_REPORT_REASON,
+    onCancel: () => {},
+    onSubmit: async () => {},
+    error: (
+      <div className="flex flex-col gap-0.5">
+        <p className="text-base font-semibold">신고에 실패했습니다.</p>
+        <p>잠시 후 다시 시도해주세요.</p>
+      </div>
+    ),
+    onClearError: () => {},
+  },
+}

--- a/src/components/modal/UserReportModal.stories.tsx
+++ b/src/components/modal/UserReportModal.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import UserReportModal from './UserReportModal'
+
+const meta = {
+  title: 'Commons/Modal/UserReportModal',
+  component: UserReportModal,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+} satisfies Meta<typeof UserReportModal>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Open: Story = {
+  args: {
+    isOpen: true,
+    userNickname: '행복한집사',
+    userId: 1,
+    onCancel: () => {},
+  },
+}

--- a/src/components/modal/WithdrawModal.stories.tsx
+++ b/src/components/modal/WithdrawModal.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import WithdrawModal from './WithdrawModal'
+
+const meta = {
+  title: 'Commons/Modal/WithdrawModal',
+  component: WithdrawModal,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+} satisfies Meta<typeof WithdrawModal>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Open: Story = {
+  args: {
+    isOpen: true,
+    onConfirm: () => {},
+    onCancel: () => {},
+  },
+}
+
+export const WithError: Story = {
+  args: {
+    isOpen: true,
+    onConfirm: () => {},
+    onCancel: () => {},
+    error: (
+      <div className="flex flex-col gap-0.5">
+        <p className="text-base font-semibold">회원탈퇴에 실패했습니다.</p>
+        <p>잠시 후 다시 시도해주세요.</p>
+      </div>
+    ),
+    onClearError: () => {},
+  },
+}


### PR DESCRIPTION
## 📌 개요

Storybook 후속 6차 — 모달 계열 공용 컴포넌트의 \`.stories.tsx\` 추가 + 작성 중 발견한 긴 텍스트 시각 버그 방어 처리.

## 🔧 작업 내용

### Stories 추가 (13개)
- [x] \`ModalTitle.stories.tsx\` — Default / Withdraw / RichDescription
- [x] \`AlertBox.stories.tsx\` — SingleItem / MultipleItems / InfoTone
- [x] \`DeleteConfirmModal.stories.tsx\` — Open / WithError
- [x] \`DeletePostConfirmModal.stories.tsx\` — Open / WithError
- [x] \`DeleteReplyModal.stories.tsx\` — Open
- [x] \`BlockModal.stories.tsx\` — Open / MaxLengthNickname (정책 최대치 10자)
- [x] \`DraftModal.stories.tsx\` — Open
- [x] \`LoginModal.stories.tsx\` — LoginPrompt / LogoutPrompt (Zustand store mock)
- [x] \`WithdrawModal.stories.tsx\` — Open / WithError
- [x] \`ReportModalBase.stories.tsx\` — Open / WithError
- [x] \`PostReportModal.stories.tsx\` — Open
- [x] \`ProductReportModal.stories.tsx\` — Open
- [x] \`UserReportModal.stories.tsx\` — Open

### 컴포넌트 개선 (방어 안전망)
- [x] \`BlockModal\`, \`DeleteReplyModal\` — \`md:min-w-max\` → \`md:min-w-96 md:max-w-md\` (모달 너비 제한)
- [x] \`ModalTitle\` — description에 \`break-keep wrap-break-word\` 적용 (한국어 어절 보호 + 비정상 긴 단어 강제 줄바꿈)

## 📎 관련 이슈

- Closes #728

## 💬 리뷰어 참고 사항

- \`LoginModal\`은 Zustand store(\`useLoginModalStore\`)에서 상태 받음 — stories의 decorator에서 \`setState\`로 mock
- \`ReportModalBase\`는 \`ImageUploadField\` 의존 — 시각 카탈로그 검증만 (실제 업로드 X)
- \`MaxLengthNickname\` 스토리: 닉네임 정책(\`src/features/signup/validationRules.ts\`: 2~10자) 최대치 검증
- **다음 PR**: 7차 — 전체 등록 컴포넌트 a11y 종합 점검