### PR TITLE
chore: 공용 컴포넌트 a11y 1차 패스(#730)

### DIFF
--- a/src/components/Tabs.stories.tsx
+++ b/src/components/Tabs.stories.tsx
@@ -32,7 +32,15 @@ export const Default: Story = {
   },
   render: (args) => {
     const [active, setActive] = useState(args.activeTab)
-    return <Tabs {...args} activeTab={active} onTabChange={setActive} />
+    const activeCode = args.tabs.find((t) => t.id === active)?.code ?? ''
+    return (
+      <div className="flex flex-col gap-4">
+        <Tabs {...args} activeTab={active} onTabChange={setActive} />
+        <div role="tabpanel" id={`panel-${activeCode}`} aria-labelledby={active} className="rounded-lg border p-4 text-sm text-gray-700">
+          {active} 탭 콘텐츠
+        </div>
+      </div>
+    )
   },
 }
 
@@ -51,6 +59,14 @@ export const CardPill: Story = {
   },
   render: (args) => {
     const [active, setActive] = useState(args.activeTab)
-    return <Tabs {...args} activeTab={active} onTabChange={setActive} />
+    const activeCode = args.tabs.find((t) => t.id === active)?.code ?? ''
+    return (
+      <div className="flex flex-col gap-4">
+        <Tabs {...args} activeTab={active} onTabChange={setActive} />
+        <div role="tabpanel" id={`panel-${activeCode}`} aria-labelledby={active} className="rounded-lg border p-4 text-sm text-gray-700">
+          {active} 탭 콘텐츠
+        </div>
+      </div>
+    )
   },
 }

--- a/src/components/UnderlineTabs.stories.tsx
+++ b/src/components/UnderlineTabs.stories.tsx
@@ -26,7 +26,15 @@ export const Basic: Story = {
   },
   render: (args) => {
     const [active, setActive] = useState(args.activeTab)
-    return <UnderlineTabs {...args} activeTab={active} onTabChange={setActive} />
+    const activeCode = args.tabs.find((t) => t.id === active)?.code ?? ''
+    return (
+      <div className="flex flex-col gap-4">
+        <UnderlineTabs {...args} activeTab={active} onTabChange={setActive} />
+        <div role="tabpanel" id={`panel-${activeCode}`} aria-labelledby={active} className="rounded-lg border p-4 text-sm text-gray-700">
+          {active} 탭 콘텐츠
+        </div>
+      </div>
+    )
   },
 }
 
@@ -49,7 +57,15 @@ export const WithRightSlot: Story = {
   },
   render: (args) => {
     const [active, setActive] = useState(args.activeTab)
-    return <UnderlineTabs {...args} activeTab={active} onTabChange={setActive} />
+    const activeCode = args.tabs.find((t) => t.id === active)?.code ?? ''
+    return (
+      <div className="flex flex-col gap-4">
+        <UnderlineTabs {...args} activeTab={active} onTabChange={setActive} />
+        <div role="tabpanel" id={`panel-${activeCode}`} aria-labelledby={active} className="rounded-lg border p-4 text-sm text-gray-700">
+          {active} 탭 콘텐츠
+        </div>
+      </div>
+    )
   },
 }
 
@@ -68,6 +84,14 @@ export const ManyTabs: Story = {
   },
   render: (args) => {
     const [active, setActive] = useState(args.activeTab)
-    return <UnderlineTabs {...args} activeTab={active} onTabChange={setActive} />
+    const activeCode = args.tabs.find((t) => t.id === active)?.code ?? ''
+    return (
+      <div className="flex flex-col gap-4">
+        <UnderlineTabs {...args} activeTab={active} onTabChange={setActive} />
+        <div role="tabpanel" id={`panel-${activeCode}`} aria-labelledby={active} className="rounded-lg border p-4 text-sm text-gray-700">
+          {active} 탭 콘텐츠
+        </div>
+      </div>
+    )
   },
 }

--- a/src/components/commons/InlineNotification.tsx
+++ b/src/components/commons/InlineNotification.tsx
@@ -44,6 +44,7 @@ export default function InlineNotification({ type, children, onClose, durationMs
 
   return (
     <motion.div
+      role="alert"
       initial={{ opacity: 0, x: 20 }}
       animate={{ opacity: 1, x: 0 }}
       exit={{ opacity: 0, x: 20 }}
@@ -57,7 +58,7 @@ export default function InlineNotification({ type, children, onClose, durationMs
         <div className="break-keep text-sm">{children}</div>
         <button
           type="button"
-          aria-label="close notification"
+          aria-label="알림 닫기"
           onClick={onClose}
           className={cn('ml-auto shrink-0 cursor-pointer rounded p-1 transition-colors focus:outline-none focus-visible:ring-2', styles.text)}
         >

--- a/src/components/commons/ToastNotification.tsx
+++ b/src/components/commons/ToastNotification.tsx
@@ -44,7 +44,7 @@ export default function ToastNotification({ type, title, children, durationMs, s
 
           <button
             type="button"
-            aria-label="close toast"
+            aria-label="토스트 닫기"
             onClick={onClose}
             className={cn(
               'ml-1 shrink-0 cursor-pointer rounded p-1 transition-colors',

--- a/src/components/modal/BlockModal.tsx
+++ b/src/components/modal/BlockModal.tsx
@@ -54,13 +54,14 @@ export default function BlockModal({ isOpen, onCancel, userNickname, userId }: B
   return (
     <dialog
       ref={dialogRef}
+      aria-labelledby="block-modal-title"
       className="m-auto w-11/12 open:flex flex-col gap-4 rounded-lg bg-white p-5 backdrop:bg-gray-900/70 md:w-[16vw] md:min-w-96 md:max-w-md"
       onClick={(e) => {
         if (e.target === dialogRef.current) dialogRef.current.close()
       }}
       onClose={onCancel}
     >
-      <ModalTitle heading="사용자 차단하기" description={`정말로 ${userNickname}를 차단하시겠습니까?`} />
+      <ModalTitle headingId="block-modal-title" heading="사용자 차단하기" description={`정말로 ${userNickname}를 차단하시겠습니까?`} />
       <AnimatePresence>
         {userBlockError ? (
           <InlineNotification type="error" onClose={() => setUserBlockError(null)}>

--- a/src/components/modal/DeleteConfirmModal.tsx
+++ b/src/components/modal/DeleteConfirmModal.tsx
@@ -32,6 +32,7 @@ export default function DeleteConfirmModal({ isOpen, product, onConfirm, onCance
   return (
     <dialog
       ref={dialogRef}
+      aria-labelledby="delete-confirm-modal-title"
       className="m-auto w-11/12 open:flex flex-col gap-4 rounded-lg bg-white p-5 backdrop:bg-gray-900/70 md:w-[16vw] md:min-w-96"
       onClick={(e) => {
         if (e.target === dialogRef.current) dialogRef.current.close()
@@ -40,7 +41,7 @@ export default function DeleteConfirmModal({ isOpen, product, onConfirm, onCance
     >
       {product ? (
         <>
-          <ModalTitle heading="상품 삭제" description="정말로 이 상품을 삭제하시겠습니까?" />
+          <ModalTitle headingId="delete-confirm-modal-title" heading="상품 삭제" description="정말로 이 상품을 삭제하시겠습니까?" />
           <AnimatePresence>
             {error ? (
               <InlineNotification type="error" onClose={() => onClearError?.()}>

--- a/src/components/modal/DeletePostConfirmModal.tsx
+++ b/src/components/modal/DeletePostConfirmModal.tsx
@@ -1,8 +1,6 @@
-import { useRef } from 'react'
+import { useEffect, useRef } from 'react'
 import Button from '../commons/button/Button'
 import ModalTitle from './ModalTitle'
-import { useOutsideClick } from '@/hooks/useOutsideClick'
-import { Z_INDEX } from '@/constants/ui'
 import { AnimatePresence } from 'framer-motion'
 import InlineNotification from '../commons/InlineNotification'
 
@@ -15,31 +13,55 @@ interface DeletePostConfirmProps {
   onClearError?: () => void
 }
 
-export default function DeletePostConfirmModal({ isOpen, postId, onConfirm, onCancel, error, onClearError }: DeletePostConfirmProps) {
-  const modalRef = useRef<HTMLDivElement>(null)
-  useOutsideClick(isOpen, [modalRef], onCancel)
-  if (!isOpen || !postId) return null
+export default function DeletePostConfirmModal({
+  isOpen,
+  postId,
+  onConfirm,
+  onCancel,
+  error,
+  onClearError,
+}: DeletePostConfirmProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null)
+
+  useEffect(() => {
+    const dialog = dialogRef.current
+    if (isOpen && postId && !dialog?.open) {
+      dialog?.showModal()
+    } else if (!isOpen && dialog?.open) {
+      dialog?.close()
+    }
+  }, [isOpen, postId])
 
   return (
-    <div className={`fixed inset-0 flex items-center justify-center bg-gray-900/70 ${Z_INDEX.MODAL}`}>
-      <div className="flex w-11/12 flex-col gap-4 rounded-lg bg-white p-5 md:w-[16vw] md:min-w-96" ref={modalRef}>
-        <ModalTitle heading="게시글 삭제" description="정말로 이 게시글을 삭제하시겠습니까?" />
-        <AnimatePresence>
-          {error ? (
-            <InlineNotification type="error" onClose={() => onClearError?.()}>
-              {error}
-            </InlineNotification>
-          ) : null}
-        </AnimatePresence>
-        <div className="flex justify-end gap-3">
-          <Button onClick={onCancel} size="sm" className="cursor-pointer rounded-lg border border-gray-300 bg-white">
-            취소
-          </Button>
-          <Button onClick={() => onConfirm(postId)} size="sm" className="bg-danger-600 cursor-pointer rounded-lg text-white">
-            삭제하기
-          </Button>
-        </div>
-      </div>
-    </div>
+    <dialog
+      ref={dialogRef}
+      aria-labelledby="delete-post-modal-title"
+      className="m-auto w-11/12 open:flex flex-col gap-4 rounded-lg bg-white p-5 backdrop:bg-gray-900/70 md:w-[16vw] md:min-w-96"
+      onClick={(e) => {
+        if (e.target === dialogRef.current) dialogRef.current.close()
+      }}
+      onClose={onCancel}
+    >
+      {postId ? (
+        <>
+          <ModalTitle headingId="delete-post-modal-title" heading="게시글 삭제" description="정말로 이 게시글을 삭제하시겠습니까?" />
+          <AnimatePresence>
+            {error ? (
+              <InlineNotification type="error" onClose={() => onClearError?.()}>
+                {error}
+              </InlineNotification>
+            ) : null}
+          </AnimatePresence>
+          <div className="flex justify-end gap-3">
+            <Button onClick={() => dialogRef.current?.close()} size="sm" className="cursor-pointer rounded-lg border border-gray-300 bg-white">
+              취소
+            </Button>
+            <Button onClick={() => onConfirm(postId)} size="sm" className="bg-danger-600 cursor-pointer rounded-lg text-white">
+              삭제하기
+            </Button>
+          </div>
+        </>
+      ) : null}
+    </dialog>
   )
 }

--- a/src/components/modal/DeleteReplyModal.tsx
+++ b/src/components/modal/DeleteReplyModal.tsx
@@ -41,13 +41,14 @@ export default function DeleteReplyModal({ isOpen, onCancel, replyId, onConfirm 
   return (
     <dialog
       ref={dialogRef}
+      aria-labelledby="delete-reply-modal-title"
       className="m-auto w-11/12 open:flex flex-col gap-4 rounded-lg bg-white p-5 backdrop:bg-gray-900/70 md:w-[16vw] md:min-w-96 md:max-w-md"
       onClick={(e) => {
         if (e.target === dialogRef.current) dialogRef.current.close()
       }}
       onClose={onCancel}
     >
-      <ModalTitle heading="댓글 삭제하기" description="정말로 이 댓글을 삭제하시겠습니까?" />
+      <ModalTitle headingId="delete-reply-modal-title" heading="댓글 삭제하기" description="정말로 이 댓글을 삭제하시겠습니까?" />
       <AnimatePresence>
         {replyDeleteError ? (
           <InlineNotification type="error" onClose={() => setReplyDeleteError(null)}>

--- a/src/components/modal/DraftModal.tsx
+++ b/src/components/modal/DraftModal.tsx
@@ -1,7 +1,7 @@
+'use client'
+
 import Button from '@/components/commons/button/Button'
-import { useRef } from 'react'
-import { useOutsideClick } from '@/hooks/useOutsideClick'
-import { Z_INDEX } from '@/constants/ui'
+import { useEffect, useRef } from 'react'
 import type { CommunityPostFormValues } from '@/types/forms'
 
 interface DraftModalProps {
@@ -23,14 +23,23 @@ export default function DraftModal({
   reset,
   initialBoardType,
 }: DraftModalProps) {
-  const modalRef = useRef<HTMLDivElement>(null)
-  useOutsideClick(showDraftModal, [modalRef], () => {
+  const dialogRef = useRef<HTMLDialogElement>(null)
+
+  useEffect(() => {
+    const dialog = dialogRef.current
+    if (showDraftModal && !dialog?.open) {
+      dialog?.showModal()
+    } else if (!showDraftModal && dialog?.open) {
+      dialog?.close()
+    }
+  }, [showDraftModal])
+
+  const closeAndDiscard = () => {
     clearDraft(initialBoardType)
     setIsDraftChecked(true)
     setShowDraftModal(false)
-  })
+  }
 
-  // 임시저장 불러오기
   const handleLoadDraft = () => {
     const draft = getSavedDraft(initialBoardType)
     reset(draft)
@@ -38,34 +47,35 @@ export default function DraftModal({
     setShowDraftModal(false)
   }
 
-  // 새로 작성하기 (임시저장 삭제)
-  const handleDiscardDraft = () => {
-    clearDraft(initialBoardType)
-    setIsDraftChecked(true)
-    setShowDraftModal(false)
-  }
-
   return (
-    <div className={`fixed inset-0 flex items-center justify-center bg-gray-900/70 ${Z_INDEX.MODAL}`}>
-      <div ref={modalRef} className="flex w-11/12 flex-col items-center gap-6 rounded-lg bg-white p-5 md:w-[16vw] md:min-w-80">
-        <div className="flex w-full flex-col items-center gap-2">
-          <h2 className="heading-h4">임시저장된 글이 있습니다</h2>
-          <p>이어서 작성하시겠습니까?</p>
-        </div>
-        <div className="flex w-full gap-3">
-          <Button type="button" size="md" className="flex-1 cursor-pointer border border-gray-300" onClick={handleDiscardDraft}>
-            취소
-          </Button>
-          <Button
-            type="button"
-            size="md"
-            className="bg-primary-300 flex flex-1 items-center justify-center rounded-lg px-4 py-2.5 text-white"
-            onClick={handleLoadDraft}
-          >
-            확인
-          </Button>
-        </div>
+    <dialog
+      ref={dialogRef}
+      aria-labelledby="draft-modal-title"
+      className="m-auto w-11/12 open:flex flex-col items-center gap-6 rounded-lg bg-white p-5 backdrop:bg-gray-900/70 md:w-[16vw] md:min-w-80"
+      onClick={(e) => {
+        if (e.target === dialogRef.current) dialogRef.current.close()
+      }}
+      onClose={closeAndDiscard}
+    >
+      <div className="flex w-full flex-col items-center gap-2">
+        <h2 id="draft-modal-title" className="heading-h4">
+          임시저장된 글이 있습니다
+        </h2>
+        <p>이어서 작성하시겠습니까?</p>
       </div>
-    </div>
+      <div className="flex w-full gap-3">
+        <Button type="button" size="md" className="flex-1 cursor-pointer border border-gray-300" onClick={closeAndDiscard}>
+          취소
+        </Button>
+        <Button
+          type="button"
+          size="md"
+          className="bg-primary-300 flex flex-1 items-center justify-center rounded-lg px-4 py-2.5 text-white"
+          onClick={handleLoadDraft}
+        >
+          확인
+        </Button>
+      </div>
+    </dialog>
   )
 }

--- a/src/components/modal/LoginModal.tsx
+++ b/src/components/modal/LoginModal.tsx
@@ -41,6 +41,7 @@ export default function LoginModal() {
   return (
     <dialog
       ref={dialogRef}
+      aria-labelledby="login-modal-title"
       className="m-auto w-11/12 open:flex flex-col items-center gap-6 rounded-lg bg-white p-5 backdrop:bg-gray-900/70 md:w-[16vw] md:min-w-80"
       onClick={(e) => {
         if (e.target === dialogRef.current) dialogRef.current.close()
@@ -48,7 +49,7 @@ export default function LoginModal() {
       onClose={closeModal}
     >
       <div className="flex w-full flex-col items-center gap-2">
-        <h2 className="heading-h4">{heading}</h2>
+        <h2 id="login-modal-title" className="heading-h4">{heading}</h2>
         <p>{description}</p>
       </div>
       <div className="flex w-full gap-3">

--- a/src/components/modal/ModalTitle.tsx
+++ b/src/components/modal/ModalTitle.tsx
@@ -4,14 +4,17 @@ import { TriangleAlert } from 'lucide-react'
 interface ModalTitleProps {
   heading: string
   description: ReactNode
+  headingId?: string
 }
 
-export default function ModalTitle({ heading, description }: ModalTitleProps) {
+export default function ModalTitle({ heading, description, headingId }: ModalTitleProps) {
   return (
     <div className="flex flex-col gap-2">
       <div className="flex items-center gap-2">
         <TriangleAlert className="text-danger-600" />
-        <p className="heading-h5">{heading}</p>
+        <p id={headingId} className="heading-h5">
+          {heading}
+        </p>
       </div>
       <div className="break-keep wrap-break-word">{description}</div>
     </div>

--- a/src/components/modal/ReportModalBase.tsx
+++ b/src/components/modal/ReportModalBase.tsx
@@ -69,6 +69,7 @@ export default function ReportModalBase({ isOpen, heading, description, reasons,
   return (
     <dialog
       ref={dialogRef}
+      aria-labelledby="report-modal-title"
       className="m-auto w-11/12 max-h-[90vh] open:flex flex-col gap-4 overflow-y-auto rounded-lg bg-white p-5 backdrop:bg-gray-900/70 md:w-1/5 md:min-w-96"
       onClick={(e) => {
         if (e.target === dialogRef.current) dialogRef.current.close()
@@ -78,7 +79,7 @@ export default function ReportModalBase({ isOpen, heading, description, reasons,
         onCancel()
       }}
     >
-      <ModalTitle heading={heading} description={description} />
+      <ModalTitle headingId="report-modal-title" heading={heading} description={description} />
       <AnimatePresence>
         {error ? (
           <InlineNotification type="error" onClose={() => onClearError?.()}>

--- a/src/components/modal/WithdrawModal.tsx
+++ b/src/components/modal/WithdrawModal.tsx
@@ -60,6 +60,7 @@ export default function WithdrawModal({ isOpen, onConfirm, onCancel, error, onCl
   return (
     <dialog
       ref={dialogRef}
+      aria-labelledby="withdraw-modal-title"
       className="m-auto w-11/12 open:flex flex-col gap-4 rounded-lg bg-white p-5 backdrop:bg-gray-900/70 md:w-[16vw] md:min-w-96"
       onClick={(e) => {
         if (e.target === dialogRef.current) dialogRef.current.close()
@@ -69,7 +70,7 @@ export default function WithdrawModal({ isOpen, onConfirm, onCancel, error, onCl
         onCancel()
       }}
     >
-      <ModalTitle heading="회원탈퇴" description="정말로 탈퇴하시겠습니까?" />
+      <ModalTitle headingId="withdraw-modal-title" heading="회원탈퇴" description="정말로 탈퇴하시겠습니까?" />
       <AnimatePresence>
         {error ? (
           <InlineNotification type="error" onClose={() => onClearError?.()}>

--- a/src/features/my-page/components/MyDashboard.tsx
+++ b/src/features/my-page/components/MyDashboard.tsx
@@ -239,17 +239,19 @@ export default function MyDashboard({ profile, myProducts, myRequests, myFavorit
             </Link>
           }
         />
-        {currentData.length === 0 ? (
-          <p className="text-on-surface-muted py-12 text-center text-sm">표시할 항목이 없습니다.</p>
-        ) : (
-          <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-            {currentData.map((product, index) => (
-              <li key={product.id}>
-                <ProductCard data-index={index} data={product} />
-              </li>
-            ))}
-          </ul>
-        )}
+        <div role="tabpanel" id={`panel-${activeTab}`} aria-labelledby={activeTab}>
+          {currentData.length === 0 ? (
+            <p className="text-on-surface-muted py-12 text-center text-sm">표시할 항목이 없습니다.</p>
+          ) : (
+            <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+              {currentData.map((product, index) => (
+                <li key={product.id}>
+                  <ProductCard data-index={index} data={product} />
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
       </section>
 
       {/* 활동 요약 */}

--- a/src/features/product-post/components/imageUploadField/components/DropzoneArea.tsx
+++ b/src/features/product-post/components/imageUploadField/components/DropzoneArea.tsx
@@ -138,7 +138,7 @@ export default function DropzoneArea<T extends FieldValues>({
 
   return (
     <div {...getRootProps()} className="cursor-pointer rounded-lg">
-      <input {...getInputProps()} />
+      <input {...getInputProps({ 'aria-label': '이미지 파일 업로드' })} />
       <SortableImageList previewUrls={previewUrls} onDragEnd={handleDragEnd} onRemoveImage={handleRemoveImage} />
     </div>
   )


### PR DESCRIPTION
## 📌 개요

등록된 공용 컴포넌트에 대해 Storybook \`@storybook/addon-a11y\` 자동 검사 기반 1차 a11y 패스. role / aria-labelledby / form label / 한국어 통일 보강.

## 🔧 작업 내용

### High Priority — 핵심 role/aria 추가
- [x] \`ModalTitle\` — \`headingId\` prop 추가 (aria-labelledby 연결용)
- [x] \`DraftModal\` — div → native \`<dialog>\` + \`aria-labelledby\` (role/aria-modal/focus trap 자동 처리)
- [x] \`DeletePostConfirmModal\` — div → native \`<dialog>\` + \`aria-labelledby\`
- [x] \`InlineNotification\` — \`role="alert"\` 추가
- [x] 11개 native dialog 모달 — \`aria-labelledby\` 일괄 추가 (DeleteConfirmModal/DeleteReplyModal/BlockModal/WithdrawModal/ReportModalBase/LoginModal 등)

### Medium Priority — 보완
- [x] \`Tabs.stories.tsx\`, \`UnderlineTabs.stories.tsx\` — 실제 \`role="tabpanel"\` + 매칭되는 id 추가 (\`aria-valid-attr-value\` violation 해결)
- [x] \`MyDashboard\` — 거래 그리드를 tabpanel로 감쌈 (UnderlineTabs aria-controls 매칭)
- [x] \`DropzoneArea\` (ImageUploadField) — hidden file input에 \`aria-label="이미지 파일 업로드"\` (Report 모달의 form label violation 해결)
- [x] \`ToastNotification\` / \`InlineNotification\` X 버튼 aria-label 한국어로 통일 ("close ..." → "... 닫기")

## 📎 관련 이슈

- Closes #730

## 💬 리뷰어 참고 사항

- \`ToastNotification\`은 추가 role 미부여 — \`ToastContainer\`가 이미 \`role="status" aria-live="polite"\` 보유
- **추후 작업 후보** (별도 PR):
  - 색상 대비 — a11y panel 자동 체크 결과 위반 시 토큰 조정
  - 키보드 인터랙션 (Tab/Enter/Esc) 실측
  - 스크린리더 실제 청취 검증 (VoiceOver/NVDA)
  - Focus management (모달 open/close 시 focus 흐름)