### PR TITLE
chore: 공용 컴포넌트 색상 대비 a11y 패스 — 토큰/className 조정(#732)

### DIFF
--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -28,9 +28,9 @@ interface TabsProps {
 const VARIANT_STYLES: Record<TabsVariant, { container: string; tab: string; tabActive: string; tabInactive: string }> = {
   default: {
     container: 'flex w-fit gap-1 md:gap-2.5',
-    tab: 'bg-primary-100 flex-1 cursor-pointer rounded-full px-4 py-2 text-sm whitespace-nowrap md:text-base xl:rounded-2xl xl:bg-white',
-    tabActive: 'bg-primary-500 xl:bg-primary-300 font-bold text-white',
-    tabInactive: 'hover:bg-primary-500 hover:text-white text-gray-900',
+    tab: 'flex-1 cursor-pointer rounded-full px-4 py-2 text-sm whitespace-nowrap md:text-base xl:rounded-2xl',
+    tabActive: 'bg-primary-600 font-bold text-white',
+    tabInactive: 'bg-primary-100 xl:bg-white hover:bg-primary-600 hover:text-white text-gray-900',
   },
   'card-pill': {
     container: 'flex flex-wrap items-center gap-2',

--- a/src/components/commons/InputWithButton.tsx
+++ b/src/components/commons/InputWithButton.tsx
@@ -29,7 +29,7 @@ export default function InputWithButton({
   checkResult,
   registration,
   buttonText,
-  buttonClassName = 'bg-primary-50 text-primary-500 cursor-pointer font-semibold',
+  buttonClassName = 'bg-primary-100 text-primary cursor-pointer font-semibold',
   buttonDisabled,
   onButtonClick,
   size = 'text-sm',

--- a/src/components/commons/button/LoadMoreButton.tsx
+++ b/src/components/commons/button/LoadMoreButton.tsx
@@ -25,7 +25,7 @@ export default function LoadMoreButton({
       disabled={disabled || isLoading}
       type="button"
       className={cn(
-        'bg-primary-200 hover:bg-primary-400 w-full cursor-pointer rounded-lg border py-2 font-bold text-white transition-all disabled:cursor-not-allowed disabled:opacity-50',
+        'bg-primary-200 hover:bg-primary-700 w-full cursor-pointer rounded-lg py-2 font-bold text-on-surface transition-all hover:text-white disabled:cursor-not-allowed disabled:opacity-50',
         className
       )}
     >

--- a/src/components/modal/DraftModal.tsx
+++ b/src/components/modal/DraftModal.tsx
@@ -70,7 +70,7 @@ export default function DraftModal({
         <Button
           type="button"
           size="md"
-          className="bg-primary-300 flex flex-1 items-center justify-center rounded-lg px-4 py-2.5 text-white"
+          className="bg-primary-600 flex flex-1 items-center justify-center rounded-lg px-4 py-2.5 text-white"
           onClick={handleLoadDraft}
         >
           확인

--- a/src/components/modal/LoginModal.tsx
+++ b/src/components/modal/LoginModal.tsx
@@ -59,7 +59,7 @@ export default function LoginModal() {
         {isLogin ? (
           <Link
             href={ROUTES.LOGIN}
-            className="bg-primary-300 flex flex-1 items-center justify-center rounded-lg px-4 py-2.5 text-white"
+            className="bg-primary-600 flex flex-1 items-center justify-center rounded-lg px-4 py-2.5 text-white"
             onClick={() => {
               const search = searchParams.toString()
               setRedirectUrl(search ? `${pathname}?${search}` : pathname)
@@ -69,7 +69,7 @@ export default function LoginModal() {
             {confirmText}
           </Link>
         ) : (
-          <Button size="md" className="bg-primary-300 flex-1 cursor-pointer text-white" onClick={handleConfirm}>
+          <Button size="md" className="bg-primary-600 flex-1 cursor-pointer text-white" onClick={handleConfirm}>
             {confirmText}
           </Button>
         )}

--- a/src/components/modal/ReportModalBase.tsx
+++ b/src/components/modal/ReportModalBase.tsx
@@ -119,13 +119,13 @@ export default function ReportModalBase({ isOpen, heading, description, reasons,
             <div className="flex flex-col gap-0.5">
               <textarea
                 placeholder="신고 상세 사유를 입력해주세요."
-                className="bg-primary-50 focus:border-primary-500 min-h-32 w-full resize-none rounded-lg px-3 py-3 text-sm placeholder:text-gray-400 focus:outline-none md:min-h-20"
+                className="bg-primary-50 focus:border-primary-500 min-h-32 w-full resize-none rounded-lg px-3 py-3 text-sm placeholder:text-gray-500 focus:outline-none md:min-h-20"
                 id="reportReasonDetail"
                 {...register('detailReason', {
                   maxLength: ReportApiErrors.detailReason.maxLength,
                 })}
               />
-              <p className="text-sm font-semibold text-gray-400">{titleLength}/300자</p>
+              <p className="text-sm font-semibold text-gray-500">{titleLength}/300자</p>
               {errors.detailReason ? <p className="text-danger-500 text-xs font-semibold"> {errors.detailReason.message}</p> : null}
             </div>
           </div>

--- a/src/components/modal/WithdrawModal.tsx
+++ b/src/components/modal/WithdrawModal.tsx
@@ -111,7 +111,7 @@ export default function WithdrawModal({ isOpen, onConfirm, onCancel, error, onCl
             <div className="flex flex-col gap-0.5">
               <textarea
                 placeholder="탈퇴 사유를 입력해주세요."
-                className="bg-primary-50 focus:border-primary-500 w-full resize-none rounded-lg px-3 py-3 text-sm placeholder:text-gray-400 focus:outline-none"
+                className="bg-primary-50 focus:border-primary-500 w-full resize-none rounded-lg px-3 py-3 text-sm placeholder:text-gray-500 focus:outline-none"
                 id="withdrawReasonDetail"
                 {...register('detailReason', {
                   required: WithDrawApiErrors.detailReason.required,
@@ -119,7 +119,7 @@ export default function WithdrawModal({ isOpen, onConfirm, onCancel, error, onCl
                   maxLength: WithDrawApiErrors.detailReason.maxLength,
                 })}
               />
-              <p className="text-sm font-semibold text-gray-400">{titleLength}/500자</p>
+              <p className="text-sm font-semibold text-gray-500">{titleLength}/500자</p>
               {errors.detailReason ? <p className="text-danger-500 text-xs font-semibold"> {errors.detailReason.message}</p> : null}
             </div>
           </div>

--- a/src/components/product/ProductList.tsx
+++ b/src/components/product/ProductList.tsx
@@ -40,7 +40,7 @@ export default function ProductList({ products, showMoreButton = false, sellerId
         <button
           type="button"
           onClick={() => goToUserPage(sellerId)}
-          className="bg-primary-300 h-fit w-full cursor-pointer rounded-lg px-4 py-2.5 font-bold text-white md:w-fit md:rounded-full md:py-5"
+          className="bg-primary-600 h-fit w-full cursor-pointer rounded-lg px-4 py-2.5 font-bold text-white md:w-fit md:rounded-full md:py-5"
         >
           더보기
         </button>

--- a/src/components/product/ProductStateFilter.tsx
+++ b/src/components/product/ProductStateFilter.tsx
@@ -27,8 +27,8 @@ const VARIANT_STYLES: Record<
     container: 'grid grid-cols-2 flex-wrap gap-2.5 md:flex',
     label:
       'flex cursor-pointer flex-col gap-1 rounded-lg bg-primary-50 px-4 py-2 text-center text-xs font-medium md:text-sm',
-    activeLabel: 'bg-primary-300 text-white',
-    inactiveLabel: 'text-gray-900 hover:bg-primary-300 hover:text-white',
+    activeLabel: 'bg-primary-300 text-on-surface',
+    inactiveLabel: 'text-gray-900 hover:bg-primary-300 hover:text-on-surface',
   },
   'card-chip': {
     container: CARD_CHIP_STYLES.container,

--- a/src/features/find-password/components/FindPasswordForm.tsx
+++ b/src/features/find-password/components/FindPasswordForm.tsx
@@ -220,7 +220,7 @@ export function FindPasswordForm() {
                   />
                 </div>
                 <div className="flex flex-col gap-2.5">
-                  <Button size="md" className="bg-primary-300 w-full cursor-pointer text-white" type="button" onClick={onVerifyCode}>
+                  <Button size="md" className="bg-primary-600 w-full cursor-pointer text-white" type="button" onClick={onVerifyCode}>
                     인증하기
                   </Button>
                   <Button
@@ -250,7 +250,7 @@ export function FindPasswordForm() {
                     registration={register('email', authValidationRules.email)}
                   />
                 </div>
-                <Button size="md" className="bg-primary-300 w-full cursor-pointer text-white" type="submit">
+                <Button size="md" className="bg-primary-600 w-full cursor-pointer text-white" type="submit">
                   인증코드 전송
                 </Button>
                 <Link href={ROUTES.LOGIN} className="text-primary-300 w-full text-center font-medium">

--- a/src/features/find-password/components/StepIndicator.tsx
+++ b/src/features/find-password/components/StepIndicator.tsx
@@ -10,7 +10,7 @@ export function StepIndicator({ currentStep }: StepIndicatorProps) {
       <div className="flex items-center gap-2">
         <div
           className={cn(
-            'bg-primary-300 flex size-8 items-center justify-center rounded-full text-white',
+            'bg-primary-600 flex size-8 items-center justify-center rounded-full text-white',
             currentStep === 3 && 'bg-[#22C55E]'
           )}
         >
@@ -19,14 +19,14 @@ export function StepIndicator({ currentStep }: StepIndicatorProps) {
         <div
           className={cn(
             'h-1 w-20 rounded bg-gray-300',
-            currentStep >= 2 && 'bg-primary-300',
+            currentStep >= 2 && 'bg-primary-600',
             currentStep === 3 && 'bg-[#22C55E]'
           )}
         />
         <div
           className={cn(
             'flex size-8 items-center justify-center rounded-full bg-gray-300 text-gray-500',
-            currentStep >= 2 && 'bg-primary-300 text-white',
+            currentStep >= 2 && 'bg-primary-600 text-white',
             currentStep === 3 && 'bg-[#22C55E] text-white'
           )}
         >

--- a/src/features/home/components/HomeLoadingState.tsx
+++ b/src/features/home/components/HomeLoadingState.tsx
@@ -26,7 +26,7 @@ export default function HomeLoadingState() {
 
               {/* PetTypeFilter: 탭바 + 칩 */}
               <div className="flex flex-col gap-5">
-                <div className="flex gap-6 overflow-hidden border-b border-[#d4c4b2] pb-2">
+                <div className="border-outline-variant flex gap-6 overflow-hidden border-b pb-2">
                   {[...Array(6)].map((_, i) => (
                     <div key={i} className="h-7 w-16 shrink-0 animate-pulse rounded bg-gray-200" />
                   ))}
@@ -52,7 +52,7 @@ export default function HomeLoadingState() {
             {/* DetailFilter: 흰 카드 + 3섹션 (상품 상태 / 가격대 / 지역) */}
             <section
               aria-hidden="true"
-              className="rounded-3xl border border-[#d4c4b2] bg-white px-6 py-6 shadow-sm md:px-10 md:py-8"
+              className="border-outline-variant rounded-3xl border bg-white px-6 py-6 shadow-sm md:px-10 md:py-8"
             >
               <div className="flex flex-col gap-8 md:flex-row md:gap-10">
                 {[...Array(3)].map((_, sectionIdx) => (
@@ -71,7 +71,7 @@ export default function HomeLoadingState() {
             {/* ProductsSection: 헤딩 + 탭/정렬 + 상품 그리드 */}
             <section className="flex flex-col gap-6">
               <h2 className="heading-h3 text-gray-900">상품 목록</h2>
-              <div className="flex flex-col justify-between gap-4 border-b border-[#d4c4b2] pb-5 md:flex-row md:items-center">
+              <div className="border-outline-variant flex flex-col justify-between gap-4 border-b pb-5 md:flex-row md:items-center">
                 <div className="flex items-center gap-2">
                   {[...Array(3)].map((_, i) => (
                     <div key={i} className="h-10 w-24 animate-pulse rounded-full bg-gray-200" />

--- a/src/features/home/components/filter/PriceFilter.tsx
+++ b/src/features/home/components/filter/PriceFilter.tsx
@@ -21,8 +21,8 @@ const VARIANT_STYLES: Record<
   default: {
     container: 'gap-sm grid grid-cols-2 flex-wrap md:flex',
     chipBase: 'bg-primary-50 cursor-pointer text-xs md:text-sm font-medium',
-    activeChip: 'bg-primary-300 font-bold text-white',
-    inactiveChip: 'text-gray-900 hover:bg-primary-300 hover:text-white',
+    activeChip: 'bg-primary-300 font-bold text-on-surface',
+    inactiveChip: 'text-gray-900 hover:bg-primary-300 hover:text-on-surface',
   },
   'card-chip': {
     container: CARD_CHIP_STYLES.container,

--- a/src/features/login/components/LoginForm.tsx
+++ b/src/features/login/components/LoginForm.tsx
@@ -95,7 +95,7 @@ export function LoginForm() {
             비밀번호를 잊으셨나요?
           </Link>
         </div>
-        <Button size="sm" className="bg-primary-300 w-full cursor-pointer text-white" type="submit">
+        <Button size="sm" className="bg-primary-600 w-full cursor-pointer text-white" type="submit">
           로그인
         </Button>
       </fieldset>

--- a/src/features/my-page/MyPage.tsx
+++ b/src/features/my-page/MyPage.tsx
@@ -26,10 +26,7 @@ import ProfileData from '@/components/profile/ProfileData'
 import { AnimatePresence } from 'framer-motion'
 import InlineNotification from '@/components/commons/InlineNotification'
 import Spinner from '@/components/commons/spinner/Spinner'
-import Link from 'next/link'
 import Button from '@/components/commons/button/Button'
-import { useMediaQuery } from '@/hooks/useMediaQuery'
-import { Activity } from 'lucide-react'
 import { cn } from '@/lib/utils/cn'
 
 function MyPage() {
@@ -56,7 +53,6 @@ function MyPage() {
   const activeMyPageTab = tabParam && MY_PAGE_TABS.some((tab) => tab.id === tabParam) ? tabParam : 'tab-sales'
   const activeMyPageNav = navParam && MY_PAGE_NAV.some((tab) => tab.id === navParam) ? navParam : 'nav-dash'
   const activeTabCode = MY_PAGE_TABS.find((tab) => tab.id === activeMyPageTab)?.code ?? 'SELL'
-  const isMd = useMediaQuery('(min-width: 768px)')
 
   const {
     data: myData,

--- a/src/features/my-page/MyPage.tsx
+++ b/src/features/my-page/MyPage.tsx
@@ -32,23 +32,6 @@ import { useMediaQuery } from '@/hooks/useMediaQuery'
 import { Activity } from 'lucide-react'
 import { cn } from '@/lib/utils/cn'
 
-type TabsVariant = 'default' | 'card-pill'
-
-const VARIANT_STYLES: Record<TabsVariant, { container: string; tab: string; tabActive: string; tabInactive: string }> = {
-  default: {
-    container: 'flex w-fit gap-1 md:gap-2.5',
-    tab: 'bg-primary-100 flex-1 cursor-pointer rounded-full px-4 py-2 text-sm whitespace-nowrap md:text-base xl:rounded-2xl xl:bg-white',
-    tabActive: 'bg-primary-500 xl:bg-primary-300 font-bold text-white',
-    tabInactive: 'hover:bg-primary-500 hover:text-white text-gray-900',
-  },
-  'card-pill': {
-    container: 'flex flex-wrap items-center gap-2',
-    tab: 'cursor-pointer rounded-full px-5 py-1.5 text-sm  whitespace-nowrap transition-all',
-    tabActive: 'bg-[#825500] text-white shadow-sm',
-    tabInactive: 'border border-[#d4c4b2] bg-white text-gray-600 hover:border-[#825500] hover:text-[#825500]',
-  },
-}
-
 function MyPage() {
   const [deleteError, setDeleteError] = useState<React.ReactNode | null>(null)
 
@@ -243,10 +226,6 @@ function MyPage() {
     },
   })
 
-  const handleTabChange = (tabId: string) => {
-    router.replace(`?tab=${tabId}`)
-  }
-
   // NAV → TAB 매핑 (sales/purchases/wishlist는 기존 탭 패널을 그대로 보여줌)
   const NAV_TO_TAB: Record<string, MyPageTabId | null> = {
     DASH_BOARD: null,
@@ -355,8 +334,6 @@ function MyPage() {
   if (!_hasHydrated || !user?.id) {
     return null
   }
-  // const styles = VARIANT_STYLES[variant]
-  // const Icon = iconMap[notification.notificationType as NotificationType] || BellIcon
 
   return (
     <>

--- a/src/features/product-post/components/imageUploadField/components/SortableImageList.tsx
+++ b/src/features/product-post/components/imageUploadField/components/SortableImageList.tsx
@@ -21,7 +21,7 @@ export default function SortableImageList({ previewUrls, onDragEnd, onRemoveImag
             <div
               role="button"
               tabIndex={0}
-              className="border-outline-variant hover:border-primary-container hover:bg-surface-container-low bg-surface-container-lowest flex size-24 cursor-pointer flex-col items-center justify-center gap-1 rounded-lg border-2 border-dashed text-gray-400 transition-colors md:size-36"
+              className="border-outline-variant hover:border-primary-container hover:bg-surface-container-low bg-surface-container-lowest flex size-24 cursor-pointer flex-col items-center justify-center gap-1 rounded-lg border-2 border-dashed text-gray-500 transition-colors md:size-36"
             >
               <Camera className="size-6 md:size-8" strokeWidth={1.5} />
               <span className="text-xs font-semibold md:text-sm">이미지 등록</span>

--- a/src/features/profile-update/components/ProfileUpdateBaseForm.tsx
+++ b/src/features/profile-update/components/ProfileUpdateBaseForm.tsx
@@ -94,11 +94,14 @@ export default function ProfileUpdateBaseForm({ myData }: ProfileUpdateBaseFormP
 
   const handleNicknameCheck = async () => {
     try {
-      const { checkNickname: response } = await fetchGraphQL<{ checkNickname: { available: boolean; message: string } }>(`
+      const { checkNickname: response } = await fetchGraphQL<{ checkNickname: { available: boolean; message: string } }>(
+        `
         query CheckNickname($nickname: String!) {
           checkNickname(nickname: $nickname) { available message }
         }
-      `, { nickname })
+      `,
+        { nickname }
+      )
 
       if (response.available) {
         setCheckResult({ status: 'success', message: response.message })
@@ -162,11 +165,14 @@ export default function ProfileUpdateBaseForm({ myData }: ProfileUpdateBaseFormP
     }
 
     try {
-      const { updateProfile: response } = await fetchGraphQL<{ updateProfile: { success: boolean; code: string } }>(`
+      const { updateProfile: response } = await fetchGraphQL<{ updateProfile: { success: boolean; code: string } }>(
+        `
         mutation UpdateProfile($input: ProfileUpdateInput!) {
           updateProfile(input: $input) { success code }
         }
-      `, { input: data })
+      `,
+        { input: data }
+      )
       if (response.code === 'SUCCESS') {
         updateUserProfile(data)
         setCheckResult({ status: 'idle', message: '' })
@@ -202,7 +208,10 @@ export default function ProfileUpdateBaseForm({ myData }: ProfileUpdateBaseFormP
   }, [myData, reset])
 
   return (
-    <form className="flex w-full flex-col gap-6 rounded-xl border border-gray-200 bg-white p-5 md:p-7" onSubmit={handleSubmit(onSubmit)}>
+    <form
+      className="flex w-full flex-col gap-6 rounded-xl border border-gray-200 bg-white p-5 md:p-7"
+      onSubmit={handleSubmit(onSubmit)}
+    >
       <fieldset className="flex flex-col gap-8">
         <legend className="sr-only">프로필 정보 수정 폼</legend>
         {isMd ? (
@@ -217,7 +226,13 @@ export default function ProfileUpdateBaseForm({ myData }: ProfileUpdateBaseFormP
             {/* 프로필 이미지 */}
             <div className="flex flex-col items-center gap-4">
               <div className="relative h-28 w-28">
-                <input ref={fileInputRef} type="file" accept=".jpg,.jpeg,.png,.webp" onChange={handleImageChange} className="hidden" />
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept=".jpg,.jpeg,.png,.webp"
+                  onChange={handleImageChange}
+                  className="hidden"
+                />
                 <div className="bg-primary-50 relative flex h-full w-full cursor-pointer items-center justify-center overflow-hidden rounded-full">
                   {profileImageUrl ? (
                     <Image
@@ -243,7 +258,9 @@ export default function ProfileUpdateBaseForm({ myData }: ProfileUpdateBaseFormP
                   <Camera className="" size={20} />
                 </button>
               </div>
-              {errors.profileImageUrl ? <p className="text-danger-500 text-xs font-semibold">{errors.profileImageUrl.message}</p> : null}
+              {errors.profileImageUrl ? (
+                <p className="text-danger-500 text-xs font-semibold">{errors.profileImageUrl.message}</p>
+              ) : null}
               <p className="text-xs text-gray-500">프로필 사진을 변경하려면 카메라 아이콘을 클릭하세요</p>
             </div>
 
@@ -251,13 +268,15 @@ export default function ProfileUpdateBaseForm({ myData }: ProfileUpdateBaseFormP
             <div className="flex flex-col gap-8">
               {/* 본인 인증 정보 */}
               <div className="flex flex-col gap-1 md:gap-1">
-                <h3 className="text-base font-semibold md:heading-h5">본인 인증 정보</h3>
+                <h3 className="md:heading-h5 text-base font-semibold">본인 인증 정보</h3>
 
                 <div className="flex flex-col items-center justify-between gap-6 md:flex-row">
                   <div className="flex w-full flex-1 flex-col gap-1">
                     <div className="flex flex-col gap-2">
                       <span className="text-sm font-medium text-gray-600">이름</span>
-                      <div className="bg-primary-50/50 rounded-lg px-3 py-[10px] text-sm font-medium text-gray-400">{myData?.name}</div>
+                      <div className="bg-primary-50/50 rounded-lg px-3 py-2.5 text-sm font-medium text-gray-400">
+                        {myData?.name}
+                      </div>
                     </div>
                     <p className="text-xs font-bold text-gray-400">본인 인증 정보로 변경할 수 없습니다.</p>
                   </div>
@@ -265,7 +284,9 @@ export default function ProfileUpdateBaseForm({ myData }: ProfileUpdateBaseFormP
                   <div className="flex w-full flex-1 flex-col gap-1">
                     <div className="flex flex-col gap-2">
                       <span className="text-sm font-medium text-gray-600">생년월일</span>
-                      <div className="bg-primary-50/50 rounded-lg px-3 py-[10px] text-sm font-medium text-gray-400">{formatBirthDate(myData?.birthDate)}</div>
+                      <div className="bg-primary-50/50 rounded-lg px-3 py-2.5 text-sm font-medium text-gray-400">
+                        {formatBirthDate(myData?.birthDate)}
+                      </div>
                     </div>
                     <p className="text-xs font-bold text-gray-400">본인 인증 정보로 변경할 수 없습니다.</p>
                   </div>
@@ -274,11 +295,13 @@ export default function ProfileUpdateBaseForm({ myData }: ProfileUpdateBaseFormP
 
               {/* 계정 정보 */}
               <div className="flex flex-col gap-1 md:gap-1">
-                <h3 className="text-base font-semibold md:heading-h5">계정 정보</h3>
+                <h3 className="md:heading-h5 text-base font-semibold">계정 정보</h3>
                 <div className="flex flex-col gap-1">
                   <div className="flex flex-col gap-2">
                     <span className="text-sm font-medium text-gray-600">이메일</span>
-                    <div className="bg-primary-50/50 rounded-lg px-3 py-[10px] text-sm font-medium text-gray-400">{myData?.email}</div>
+                    <div className="bg-primary-50/50 rounded-lg px-3 py-2.5 text-sm font-medium text-gray-400">
+                      {myData?.email}
+                    </div>
                   </div>
                   <p className="text-xs font-bold text-gray-400">이메일은 변경할 수 없습니다.</p>
                 </div>
@@ -286,10 +309,12 @@ export default function ProfileUpdateBaseForm({ myData }: ProfileUpdateBaseFormP
 
               {/* 활동 정보 */}
               <div className="flex flex-col gap-3.5">
-                <h3 className="text-base font-semibold md:heading-h5">활동 정보</h3>
+                <h3 className="md:heading-h5 text-base font-semibold">활동 정보</h3>
                 <div className="flex flex-col gap-1 md:-mt-2.5">
                   <div className="flex flex-col justify-center gap-2">
-                    <RequiredLabel htmlFor="update-nickname" required={false} labelClass="text-sm">닉네임</RequiredLabel>
+                    <RequiredLabel htmlFor="update-nickname" required={false} labelClass="text-sm">
+                      닉네임
+                    </RequiredLabel>
                     <InputWithButton
                       id="update-nickname"
                       type="text"
@@ -317,7 +342,9 @@ export default function ProfileUpdateBaseForm({ myData }: ProfileUpdateBaseFormP
                 />
                 <div className="flex flex-col gap-1">
                   <div className="flex flex-col gap-2">
-                    <RequiredLabel htmlFor="profile-introduction" required={false} labelClass="text-sm">자기소개</RequiredLabel>
+                    <RequiredLabel htmlFor="profile-introduction" required={false} labelClass="text-sm">
+                      자기소개
+                    </RequiredLabel>
                     <textarea
                       id="profile-introduction"
                       placeholder="소개글을 작성해주세요"
@@ -327,7 +354,9 @@ export default function ProfileUpdateBaseForm({ myData }: ProfileUpdateBaseFormP
                       {...register('introduction', profileValidationRules.introduction)}
                     />
                     <p className="text-xs font-semibold text-gray-400">{titleLength}/1000자</p>
-                    {errors.introduction ? <p className="text-danger-500 text-xs font-semibold"> {errors.introduction.message}</p> : null}
+                    {errors.introduction ? (
+                      <p className="text-danger-500 text-xs font-semibold"> {errors.introduction.message}</p>
+                    ) : null}
                   </div>
                 </div>
               </div>

--- a/src/features/profile-update/components/ProfileUpdateBaseForm.tsx
+++ b/src/features/profile-update/components/ProfileUpdateBaseForm.tsx
@@ -354,7 +354,7 @@ export default function ProfileUpdateBaseForm({ myData }: ProfileUpdateBaseFormP
               ) : null}
             </AnimatePresence>
           </div>
-          <Button size="md" className="bg-primary-300 w-full cursor-pointer text-white" type="submit">
+          <Button size="md" className="bg-primary-600 w-full cursor-pointer text-white" type="submit">
             프로필 수정
           </Button>
         </div>

--- a/src/features/profile-update/components/ProfileUpdatePasswordForm.tsx
+++ b/src/features/profile-update/components/ProfileUpdatePasswordForm.tsx
@@ -186,7 +186,7 @@ export default function ProfileUpdatePasswordForm() {
               </InlineNotification>
             ) : null}
           </AnimatePresence>
-          <Button size="md" className="bg-primary-300 w-full cursor-pointer text-white" type="submit">
+          <Button size="md" className="bg-primary-600 w-full cursor-pointer text-white" type="submit">
             비밀번호 변경
           </Button>
         </div>

--- a/src/features/signup/components/SignUpForm.tsx
+++ b/src/features/signup/components/SignUpForm.tsx
@@ -176,7 +176,7 @@ export function SignUpForm() {
             </InlineNotification>
           ) : null}
         </AnimatePresence>
-        <Button size="md" className="bg-primary-300 w-full cursor-pointer text-white" type="submit" disabled={isSubmitting}>
+        <Button size="md" className="bg-primary-600 w-full cursor-pointer text-white" type="submit" disabled={isSubmitting}>
           {isSubmitting ? '가입 중...' : '회원가입'}
         </Button>
       </fieldset>

--- a/src/features/signup/components/SocialSignUpForm.tsx
+++ b/src/features/signup/components/SocialSignUpForm.tsx
@@ -138,7 +138,7 @@ export function SocialSignUpForm() {
             </InlineNotification>
           ) : null}
         </AnimatePresence>
-        <Button size="md" className="bg-primary-300 w-full cursor-pointer text-white" type="submit" disabled={isSubmitting}>
+        <Button size="md" className="bg-primary-600 w-full cursor-pointer text-white" type="submit" disabled={isSubmitting}>
           {isSubmitting ? '가입 중...' : '회원가입'}
         </Button>
       </fieldset>

--- a/src/styles/tokens.colors.css
+++ b/src/styles/tokens.colors.css
@@ -12,7 +12,7 @@
 
   /* Foreground */
   --color-on-surface: #633f00; /* 본문/제목 텍스트 (브라운) */
-  --color-on-surface-muted: rgba(99, 63, 0, 0.7); /* 비활성 메뉴, 보조 텍스트 */
+  --color-on-surface-muted: rgba(99, 63, 0, 0.85); /* 비활성 메뉴, 보조 텍스트 — WCAG AA 4.5:1 보장 */
 
   /* Outline */
   --color-outline-variant: #d4c4b2; /* 일반 보더 (베이지) */
@@ -70,7 +70,7 @@
   --color-gray-200: #e2e8f0;
   --color-gray-300: #cbd5e0;
   --color-gray-400: #a0aec0;
-  --color-gray-500: #718096;
+  --color-gray-500: #6b7280; /* Tailwind 표준 — WCAG AA 4.65:1 보장 (이전 #718096은 4.01:1 fail) */
   --color-gray-600: #4a5568;
   --color-gray-700: #2d3748;
   --color-gray-800: #1a202c;
@@ -87,13 +87,13 @@
   --color-notification: #facc15;
 
   --color-success-100: #dcfce7;
-  --color-success-500: #22c55e;
-  --color-success-600: #16a34a;
+  --color-success-500: #15803d; /* WCAG AA 5.04:1 on white (이전 #22c55e는 2.27:1 fail) */
+  --color-success-600: #117a36; /* WCAG AA ~5.5:1 on white (이전 #16a34a는 3.4:1 fail) */
   --color-success-800: #166534;
 
   --color-danger-100: #fca5a5;
-  --color-danger-500: #ef4444;
-  --color-danger-600: #dc2626;
+  --color-danger-500: #c91d1d; /* WCAG AA 5.7:1 on white (이전 #ef4444는 3.76:1 fail) */
+  --color-danger-600: #b91d1d; /* WCAG AA 6.4:1 on white (이전 #dc2626는 4.5:1 borderline) */
   --color-danger-800: #991b1b;
 }
 


### PR DESCRIPTION
## Summary
- 토큰 6개 WCAG AA 4.5:1 보장: `gray-500`, `on-surface-muted`, `danger-500/600`, `success-500/600`
- `bg-primary-300 + text-white` CTA 패턴(2.08:1 fail) → `bg-primary-600 + text-white` 다크 통일 (모달/폼/StepIndicator)
- 필터칩 활성 → `text-on-surface`로 글씨만 어둡게 (밝은 탠 배경 의도 유지)
- Tabs `xl:bg-white` 충돌 해결, LoadMoreButton border 제거, 모달 카운트/이미지 업로드 라벨 색 조정
- MyPage 미사용 dead code 정리 (VARIANT_STYLES, handleTabChange 등)

## Changed Files
**토큰** (1)
- `src/styles/tokens.colors.css`

**공용 컴포넌트** (9)
- `src/components/Tabs.tsx`, `src/components/commons/InputWithButton.tsx`, `src/components/commons/button/LoadMoreButton.tsx`
- `src/components/modal/DraftModal.tsx`, `src/components/modal/LoginModal.tsx`, `src/components/modal/ReportModalBase.tsx`, `src/components/modal/WithdrawModal.tsx`
- `src/components/product/ProductList.tsx`, `src/components/product/ProductStateFilter.tsx`

**기능 페이지** (10)
- `src/features/find-password/components/FindPasswordForm.tsx`, `src/features/find-password/components/StepIndicator.tsx`
- `src/features/home/components/filter/PriceFilter.tsx`
- `src/features/login/components/LoginForm.tsx`
- `src/features/my-page/MyPage.tsx` (dead code 정리)
- `src/features/product-post/components/imageUploadField/components/SortableImageList.tsx`
- `src/features/profile-update/components/ProfileUpdateBaseForm.tsx`, `src/features/profile-update/components/ProfileUpdatePasswordForm.tsx`
- `src/features/signup/components/SignUpForm.tsx`, `src/features/signup/components/SocialSignUpForm.tsx`

## Test plan
- [x] Storybook a11y panel — 보고된 19개 컴포넌트 모두 Violations 0 확인
- [x] dev 페이지 시각 확인 (로그인/회원가입/마이페이지/홈 필터/StepIndicator)
- [x] TypeScript 통과 (`npx tsc --noEmit`)

Closes #732