### PR TITLE
refactor: 마이페이지 회원정보 통합 및 시각/용어 일관성 정리

### DIFF
--- a/src/components/UnderlineTabs.stories.tsx
+++ b/src/components/UnderlineTabs.stories.tsx
@@ -43,7 +43,7 @@ export const WithRightSlot: Story = {
     tabs: [
       { id: 'sales', label: '판매 내역', code: 'sales' },
       { id: 'purchases', label: '구매 내역', code: 'purchases' },
-      { id: 'wishlist', label: '관심 목록', code: 'wishlist' },
+      { id: 'wishlist', label: '찜한 상품', code: 'wishlist' },
     ],
     activeTab: 'sales',
     onTabChange: () => {},

--- a/src/components/UnderlineTabs.tsx
+++ b/src/components/UnderlineTabs.tsx
@@ -31,7 +31,7 @@ export function UnderlineTabs({
   const filteredTabs = excludeTabId ? tabs.filter((tab) => tab.id !== excludeTabId) : tabs
 
   return (
-    <div className={cn('border-outline-variant/30 flex items-end justify-between border-b', className)}>
+    <div className={cn('border-outline-variant/30 flex items-center justify-between border-b', className)}>
       <div role="tablist" aria-label={ariaLabel} className="flex gap-6 md:gap-10">
         {filteredTabs.map((tab) => {
           const isActive = activeTab === tab.id

--- a/src/components/commons/button/Button.stories.tsx
+++ b/src/components/commons/button/Button.stories.tsx
@@ -35,7 +35,7 @@ export const WithIcon: Story = {
 }
 
 export const IconOnly: Story = {
-  args: { icon: Heart, 'aria-label': '좋아요' },
+  args: { icon: Heart, 'aria-label': '찜하기' },
 }
 
 export const Primary: Story = {

--- a/src/components/commons/button/IconButton.stories.tsx
+++ b/src/components/commons/button/IconButton.stories.tsx
@@ -35,7 +35,7 @@ export const Medium: Story = {
 export const Large: Story = {
   args: {
     size: 'lg',
-    'aria-label': '좋아요',
+    'aria-label': '찜하기',
     children: <Heart size={24} />,
   },
 }

--- a/src/components/commons/button/LoadMoreButton.tsx
+++ b/src/components/commons/button/LoadMoreButton.tsx
@@ -25,7 +25,7 @@ export default function LoadMoreButton({
       disabled={disabled || isLoading}
       type="button"
       className={cn(
-        'bg-primary-200 hover:bg-primary-700 w-full cursor-pointer rounded-lg py-2 font-bold text-on-surface transition-all hover:text-white disabled:cursor-not-allowed disabled:opacity-50',
+        'bg-primary-200 hover:bg-primary-700 w-full cursor-pointer rounded-lg py-2 text-sm font-bold text-on-surface transition-all hover:text-white disabled:cursor-not-allowed disabled:opacity-50',
         className
       )}
     >

--- a/src/components/product/ProductMetaItem.stories.tsx
+++ b/src/components/product/ProductMetaItem.stories.tsx
@@ -18,7 +18,7 @@ export const WithEyeIcon: Story = {
 }
 
 export const Favorites: Story = {
-  args: { icon: Heart, label: '좋아요 12' },
+  args: { icon: Heart, label: '찜 12' },
 }
 
 export const Location: Story = {

--- a/src/components/product/components/ProductInfo.tsx
+++ b/src/components/product/components/ProductInfo.tsx
@@ -40,7 +40,7 @@ export function ProductInfo({
     <div className="flex flex-3 flex-col gap-2 bg-white p-3 md:flex-none md:p-4">
       <ProductBadge items={badgeItems} />
       <ProductHeading title={title} price={price} />
-      {/* 메타 (레퍼런스 패턴): 은평구 · 좋아요 15  ........  3분 전 */}
+      {/* 메타 (레퍼런스 패턴): 은평구 · 찜 15  ........  3분 전 */}
       <div className="mt-auto flex w-full items-center gap-1 text-gray-500">
         {location ? (
           <>
@@ -48,7 +48,7 @@ export function ProductInfo({
             {hasFavoriteCount ? <span className={metaTextClass} aria-hidden="true">·</span> : null}
           </>
         ) : null}
-        {hasFavoriteCount ? <ProductMetaItem label={`좋아요 ${favoriteCount}`} textClassName={metaTextClass} /> : null}
+        {hasFavoriteCount ? <ProductMetaItem label={`찜 ${favoriteCount}`} textClassName={metaTextClass} /> : null}
         {hasCreatedAt ? (
           <ProductMetaItem label={getTimeAgo(createdAt)} className="ml-auto text-gray-500" textClassName={metaTextClass} />
         ) : null}

--- a/src/components/profile/ProfileData.tsx
+++ b/src/components/profile/ProfileData.tsx
@@ -2,14 +2,28 @@
 
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { MapPin, Calendar, Settings, Flag, Ban, LockOpen, ShieldAlert, Route } from 'lucide-react'
+import { Camera, Flag, Ban, LockOpen, ShieldAlert, EllipsisVertical } from 'lucide-react'
 import { getImageSrcSet, IMAGE_SIZES, toResizedWebpUrl } from '@/lib/utils/imageUrl'
-import { ProductMetaItem } from '@/components/product/ProductMetaItem'
-import { type Dispatch, type SetStateAction } from 'react'
-import { formatJoinDate } from '@/lib/utils/formatJoinDate'
+import { useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react'
 import { ROUTES } from '@/constants/routes'
 import { useMediaQuery } from '@/hooks/useMediaQuery'
 import { useUserStore } from '@/store/userStore'
+import IconButton from '@/components/commons/button/IconButton'
+import { useOutsideClick } from '@/hooks/useOutsideClick'
+import { Z_INDEX } from '@/constants/ui'
+import { cn } from '@/lib/utils/cn'
+import { uploadImage } from '@/lib/api/products'
+import { fetchGraphQL } from '@/lib/api/graphql'
+import imageCompression from 'browser-image-compression'
+import { useQueryClient } from '@tanstack/react-query'
+import InlineNotification from '@/components/commons/InlineNotification'
+import { AnimatePresence } from 'framer-motion'
+
+export interface ProfileSummaryCounts {
+  sales: number
+  purchases: number
+  wishlist: number
+}
 
 export interface MyPageData {
   id: number
@@ -34,59 +48,240 @@ interface ProfileDataProps {
   handleUserUnBlocked?: (id: number) => void
   isMyProfile?: boolean
   unblockUser?: () => void
+  summaryCounts?: ProfileSummaryCounts
+  enableImageUpload?: boolean
 }
 
+const SUMMARY_ITEMS: Array<{ key: keyof ProfileSummaryCounts; label: string }> = [
+  { key: 'sales', label: '판매내역' },
+  { key: 'purchases', label: '구매내역' },
+  { key: 'wishlist', label: '찜한 상품' },
+]
+
 export default function ProfileData({
-  setIsWithdrawModalOpen,
-  setIsReportModalOpen,
-  setIsBlockModalOpen,
   data,
   isMyProfile,
+  setIsReportModalOpen,
+  setIsBlockModalOpen,
   unblockUser,
+  summaryCounts,
+  enableImageUpload,
 }: ProfileDataProps) {
   const user = useUserStore((state) => state.user)
+  const updateUserProfile = useUserStore((state) => state.updateUserProfile)
+  const queryClient = useQueryClient()
   const isMd = useMediaQuery('(min-width: 768px)')
   const pathname = usePathname()
   const isProfileEditPage = pathname === '/profile-update'
-  const formattedJoinDate = data?.createdAt ? formatJoinDate(data.createdAt) : ''
 
-  const getProvider = (email: string | undefined) => {
-    if (email?.includes('gmail')) return 'google'
-    if (email?.includes('kakao')) return 'kakao'
-    return '이메일' // 일반 회원
+  const [isMoreMenuOpen, setIsMoreMenuOpen] = useState(false)
+  const moreMenuRef = useRef<HTMLDivElement>(null)
+  useOutsideClick(isMoreMenuOpen, [moreMenuRef], () => setIsMoreMenuOpen(false))
+
+  const menuItemClass =
+    'flex w-full cursor-pointer items-center gap-2 whitespace-nowrap px-4 py-2.5 text-sm text-on-surface hover:bg-surface-container-high transition-colors'
+
+  const introRef = useRef<HTMLParagraphElement>(null)
+  const [isIntroExpanded, setIsIntroExpanded] = useState(false)
+  const [isIntroClamped, setIsIntroClamped] = useState(false)
+  useEffect(() => {
+    if (!introRef.current || isIntroExpanded) return
+    setIsIntroClamped(introRef.current.scrollHeight > introRef.current.clientHeight + 1)
+  }, [data?.introduction, isIntroExpanded])
+
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [profileImageUrl, setProfileImageUrl] = useState(data?.profileImageUrl || '')
+  const [prevDataImageUrl, setPrevDataImageUrl] = useState(data?.profileImageUrl || '')
+  const [imgError, setImgError] = useState(false)
+  const [imageUpdateError, setImageUpdateError] = useState<React.ReactNode | null>(null)
+  const nextDataImageUrl = data?.profileImageUrl || ''
+  if (nextDataImageUrl !== prevDataImageUrl) {
+    setPrevDataImageUrl(nextDataImageUrl)
+    setProfileImageUrl(nextDataImageUrl)
+    setImgError(false)
   }
 
-  const provider = getProvider(user?.email)
+  const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file || !data) return
+
+    const allowedTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/webp']
+    if (!allowedTypes.includes(file.type)) {
+      setImageUpdateError(<p className="text-base font-semibold">지원하지 않는 파일 형식입니다.</p>)
+      e.target.value = ''
+      return
+    }
+    if (file.size > 5 * 1024 * 1024) {
+      setImageUpdateError(<p className="text-base font-semibold">파일 크기는 5MB를 초과할 수 없습니다.</p>)
+      e.target.value = ''
+      return
+    }
+
+    try {
+      const compressed = await imageCompression(file, {
+        maxSizeMB: 1,
+        maxWidthOrHeight: 800,
+        useWebWorker: true,
+        fileType: 'image/webp',
+      })
+      const uploaded = await uploadImage([compressed])
+      const nextUrl = uploaded.mainImageUrl
+
+      const { updateProfile: response } = await fetchGraphQL<{ updateProfile: { success: boolean; code: string } }>(
+        `mutation UpdateProfile($input: ProfileUpdateInput!) { updateProfile(input: $input) { success code } }`,
+        { input: { profileImageUrl: nextUrl } }
+      )
+
+      if (response.code === 'SUCCESS') {
+        setProfileImageUrl(nextUrl)
+        setImgError(false)
+        setImageUpdateError(null)
+        updateUserProfile({ profileImageUrl: nextUrl })
+        await queryClient.refetchQueries({ queryKey: ['mypage', user?.id] })
+      }
+    } catch {
+      setImageUpdateError(
+        <div className="flex flex-col gap-0.5">
+          <p className="text-base font-semibold">프로필 이미지 변경에 실패했습니다.</p>
+          <p>잠시 후 다시 시도해주세요.</p>
+        </div>
+      )
+    }
+    e.target.value = ''
+  }
 
   return (
     <aside
       aria-label="프로필"
-      className="bg-outline-variant/40 flex h-fit flex-col rounded-none border-b border-gray-200 px-5 py-5 md:max-w-72 md:min-w-72 md:rounded-xl md:border"
+      className="bg-surface/95 border-outline-variant/40 flex h-fit flex-col rounded-none border-b px-5 py-5 md:max-w-72 md:min-w-72 md:rounded-xl md:border"
     >
+      <AnimatePresence>
+        {imageUpdateError ? (
+          <InlineNotification type="error" onClose={() => setImageUpdateError(null)}>
+            {imageUpdateError}
+          </InlineNotification>
+        ) : null}
+      </AnimatePresence>
       <div className="text-text-primary sticky top-24 flex flex-col rounded-xl">
-        <div className="flex flex-col gap-3 md:gap-6">
+        <div className="relative flex flex-col gap-3 md:gap-6">
+          {!isMyProfile ? (
+            <div ref={moreMenuRef} className="absolute top-0 right-0 z-10">
+              <IconButton
+                size="sm"
+                onClick={() => setIsMoreMenuOpen((prev) => !prev)}
+                aria-label="유저 옵션 메뉴 열기"
+                aria-haspopup="menu"
+                aria-expanded={isMoreMenuOpen}
+              >
+                <EllipsisVertical size={16} className="text-gray-500" />
+              </IconButton>
+              {isMoreMenuOpen ? (
+                <div
+                  role="menu"
+                  className={cn(
+                    'border-outline-variant/60 absolute top-9 right-0 flex flex-col overflow-hidden rounded-lg border bg-white shadow-md',
+                    Z_INDEX.DROPDOWN
+                  )}
+                >
+                  {data?.isBlocked ? (
+                    <button
+                      type="button"
+                      role="menuitem"
+                      className={menuItemClass}
+                      onClick={() => {
+                        unblockUser?.()
+                        setIsMoreMenuOpen(false)
+                      }}
+                    >
+                      <LockOpen size={16} />
+                      <span>차단 해제</span>
+                    </button>
+                  ) : (
+                    <button
+                      type="button"
+                      role="menuitem"
+                      className={menuItemClass}
+                      onClick={() => {
+                        setIsBlockModalOpen?.(true)
+                        setIsMoreMenuOpen(false)
+                      }}
+                    >
+                      <Ban size={16} />
+                      <span>차단하기</span>
+                    </button>
+                  )}
+                  {data?.isReported ? (
+                    <div
+                      role="menuitem"
+                      aria-disabled="true"
+                      className="flex items-center gap-2 px-4 py-2.5 text-sm whitespace-nowrap text-gray-400"
+                    >
+                      <Flag size={16} />
+                      <span>신고완료</span>
+                    </div>
+                  ) : (
+                    <button
+                      type="button"
+                      role="menuitem"
+                      className={menuItemClass}
+                      onClick={() => {
+                        setIsReportModalOpen?.(true)
+                        setIsMoreMenuOpen(false)
+                      }}
+                    >
+                      <Flag size={16} />
+                      <span>신고하기</span>
+                    </button>
+                  )}
+                </div>
+              ) : null}
+            </div>
+          ) : null}
           <div className="flex flex-row items-center gap-3.5">
-            <div className="bg-primary-50 flex h-14 w-14 shrink-0 items-center justify-center overflow-hidden rounded-full">
-              {data?.profileImageUrl ? (
-                // eslint-disable-next-line @next/next/no-img-element
-                <img
-                  src={toResizedWebpUrl(data.profileImageUrl, 150)}
-                  srcSet={getImageSrcSet(data.profileImageUrl)}
-                  sizes={IMAGE_SIZES.tinyThumbnail}
-                  alt={data.nickname}
-                  loading="lazy"
-                  onError={(e) => {
-                    const img = e.currentTarget
-                    if (data.profileImageUrl && img.src !== data.profileImageUrl) {
-                      img.srcset = ''
-                      img.src = data.profileImageUrl
-                    }
-                  }}
-                  className="h-full w-full object-cover"
+            <div className="relative h-14 w-14 shrink-0">
+              {enableImageUpload ? (
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept=".jpg,.jpeg,.png,.webp"
+                  onChange={handleImageChange}
+                  className="hidden"
                 />
-              ) : (
-                <div className="heading-h4">{data?.nickname.charAt(0).toUpperCase()}</div>
-              )}
+              ) : null}
+              <div className="bg-primary-50 flex h-full w-full items-center justify-center overflow-hidden rounded-full">
+                {profileImageUrl ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={imgError ? profileImageUrl : toResizedWebpUrl(profileImageUrl, 150)}
+                    srcSet={getImageSrcSet(profileImageUrl)}
+                    sizes={IMAGE_SIZES.smallThumbnail}
+                    alt={data?.nickname || '프로필 이미지'}
+                    loading="lazy"
+                    onError={(e) => {
+                      const img = e.currentTarget
+                      if (profileImageUrl && img.src !== profileImageUrl) {
+                        img.srcset = ''
+                        img.src = profileImageUrl
+                        return
+                      }
+                      setImgError(true)
+                    }}
+                    className="h-full w-full object-cover"
+                  />
+                ) : (
+                  <div className="text-xl font-semibold">{data?.nickname.charAt(0).toUpperCase()}</div>
+                )}
+              </div>
+              {enableImageUpload ? (
+                <button
+                  type="button"
+                  className="bg-primary-100 hover:bg-primary-200 absolute -right-1 -bottom-1 flex size-7 cursor-pointer items-center justify-center rounded-full shadow-sm transition-colors"
+                  onClick={() => fileInputRef.current?.click()}
+                  aria-label="프로필 사진 변경"
+                >
+                  <Camera size={16} />
+                </button>
+              ) : null}
             </div>
 
             {isMd ? (
@@ -98,7 +293,7 @@ export default function ProfileData({
                     차단 유저
                   </span>
                 ) : null}
-                <p className="heading-h5 text-text-primary leading-none">{data?.nickname}</p>
+                <p className="text-text-primary text-base leading-none font-semibold">{data?.nickname}</p>
                 <p className="text-text-primary text-sm leading-none">{`${data?.addressSido} ${data?.addressGugun}`}</p>
               </div>
             ) : (
@@ -116,102 +311,47 @@ export default function ProfileData({
                 <p className="text-sm font-normal text-gray-500">
                   {data?.addressSido} {data?.addressGugun}
                 </p>
-                <p className="text-sm font-normal text-gray-500">{formattedJoinDate} 가입</p>
               </div>
             )}
           </div>
-          <p className="w-full text-sm font-normal text-gray-500">{data?.introduction || '소개글을 작성해주세요'}</p>
-          {/* 데스크탑 내 정보 */}
-          {/* {isMyProfile ? (
-            <>
-              <div className="flex flex-col gap-3.5">
-                {isMd ? (
-                  <div className="flex flex-col gap-2.5">
-                    <ProductMetaItem
-                      icon={MapPin}
-                      iconSize={17}
-                      strokeWidth={1}
-                      label={`${data?.addressSido} ${data?.addressGugun}`}
-                      className="gap-2"
-                      textClassName="text-sm font-normal"
-                    />
-                    <ProductMetaItem
-                      icon={Calendar}
-                      iconSize={17}
-                      strokeWidth={1}
-                      label={`가입일: ${formattedJoinDate}`}
-                      className="gap-2"
-                      textClassName="text-sm font-normal"
-                    />
-                    <ProductMetaItem
-                      icon={Route}
-                      iconSize={17}
-                      strokeWidth={1}
-                      label={`가입 경로: ${provider}`}
-                      className="gap-2"
-                      textClassName="text-sm font-normal"
-                    />
-                  </div>
-                ) : null}
-                {!isProfileEditPage ? (
-                  <Link
-                    href={ROUTES.PROFILE_UPDATE}
-                    className="bg-primary shadow-primary/20 flex items-center justify-center gap-2.5 rounded-lg px-3 py-2 text-white shadow-lg transition-all hover:-translate-y-0.5 hover:shadow-xl"
-                  >
-                    <Settings size={19} />
-                    <span className="text-sm font-semibold">내 정보 수정</span>
-                  </Link>
-                ) : null}
-              </div>
+          <div className="flex w-full flex-col gap-1">
+            <p
+              ref={introRef}
+              className={cn(
+                'w-full text-sm font-normal break-words whitespace-pre-wrap text-gray-500',
+                !isIntroExpanded && 'line-clamp-3'
+              )}
+            >
+              {data?.introduction || '소개글을 작성해주세요'}
+            </p>
+            {data?.introduction && (isIntroExpanded || isIntroClamped) ? (
               <button
                 type="button"
-                className="border-outline-variant/60 text-on-surface-muted w-full cursor-pointer pb-0 text-right text-xs hover:underline md:border-t md:pt-6 md:text-left"
-                onClick={() => setIsWithdrawModalOpen?.(true)}
+                onClick={() => setIsIntroExpanded((prev) => !prev)}
+                className="cursor-pointer self-start text-xs text-gray-400 hover:underline"
+                aria-expanded={isIntroExpanded}
               >
-                회원탈퇴
+                {isIntroExpanded ? '접기' : '더보기'}
               </button>
-            </>
-          ) : null} */}
-
-          {/* 다른 유저 프로필 */}
-          {!isMyProfile ? (
-            <div className="flex items-center justify-between gap-[15px]">
-              {data?.isBlocked ? (
-                <button
-                  type="button"
-                  onClick={() => unblockUser?.()}
-                  className="flex w-full cursor-pointer items-center justify-center gap-2 rounded-lg bg-gray-100/50 px-3 py-2 text-sm font-semibold text-black hover:bg-gray-100 md:bg-transparent md:py-1.5 md:text-gray-500 md:hover:bg-gray-100"
-                >
-                  <LockOpen size={16} />
-                  차단 해제
-                </button>
-              ) : (
-                <button
-                  type="button"
-                  className="flex w-full cursor-pointer items-center justify-center gap-2 rounded-lg bg-gray-100/50 px-3 py-2 text-sm font-semibold text-black hover:bg-gray-100 md:bg-transparent md:py-1.5 md:text-gray-500 md:hover:bg-gray-100"
-                  onClick={() => setIsBlockModalOpen?.(true)}
-                >
-                  <Ban size={16} />
-                  차단하기
-                </button>
-              )}
-
-              {data?.isReported ? (
-                <div className="flex w-full items-center justify-center gap-2 rounded-lg bg-gray-100/50 px-3 py-2 text-sm text-gray-500 md:py-1.5">
-                  <Flag size={16} />
-                  <span>신고완료</span>
+            ) : null}
+          </div>
+          {isMyProfile && summaryCounts ? (
+            <div className="border-outline-variant/40 grid grid-cols-3 gap-2 border-t pt-4">
+              {SUMMARY_ITEMS.map((item) => (
+                <div key={item.key} className="flex flex-col items-center gap-1">
+                  <span className="text-on-surface-variant text-[13px]">{item.label}</span>
+                  <strong className="text-on-surface text-base font-bold">{summaryCounts[item.key]}</strong>
                 </div>
-              ) : (
-                <button
-                  type="button"
-                  className="flex w-full cursor-pointer items-center justify-center gap-2 rounded-lg bg-gray-100/50 px-3 py-2 text-sm font-semibold text-black hover:bg-gray-100 md:bg-transparent md:py-1.5 md:text-gray-500 md:hover:bg-gray-100"
-                  onClick={() => setIsReportModalOpen?.(true)}
-                >
-                  <Flag size={16} />
-                  신고하기
-                </button>
-              )}
+              ))}
             </div>
+          ) : null}
+          {isMyProfile && !isProfileEditPage ? (
+            <Link
+              href={ROUTES.PROFILE_UPDATE}
+              className="bg-primary-100 text-on-surface-variant hover:bg-primary-200 inline-flex items-center justify-center rounded-full px-4 py-2 text-sm font-bold transition-colors"
+            >
+              프로필 수정
+            </Link>
           ) : null}
         </div>
       </div>

--- a/src/features/my-page/MyPage.tsx
+++ b/src/features/my-page/MyPage.tsx
@@ -337,8 +337,18 @@ function MyPage() {
         <h1 className="sr-only">마이페이지</h1>
         <div className="mx-auto flex max-w-7xl flex-col gap-3.5 md:flex-row md:gap-8">
           <div className="flex flex-col gap-3">
-            <ProfileData setIsWithdrawModalOpen={setIsWithdrawModalOpen} data={myData!} isMyProfile />
-            <div role="tablist" aria-label="마이페이지 메뉴" className="flex flex-col gap-2">
+            <ProfileData
+              setIsWithdrawModalOpen={setIsWithdrawModalOpen}
+              data={myData!}
+              isMyProfile
+              enableImageUpload
+              summaryCounts={{
+                sales: myProductsData?.pages[0]?.total ?? 0,
+                purchases: myRequestData?.pages[0]?.total ?? 0,
+                wishlist: myFavoriteData?.pages[0]?.total ?? 0,
+              }}
+            />
+            <div role="tablist" aria-label="마이페이지 메뉴" className="flex flex-col gap-1">
               {MY_PAGE_NAV.map((tab) => {
                 const isActive = activeMyPageNav === tab.id
                 const Icon = myPageIconMap[tab.code]
@@ -355,12 +365,12 @@ function MyPage() {
                     className={cn(
                       'flex cursor-pointer items-center gap-3 rounded-xl px-4 py-3 text-left transition-all',
                       isActive
-                        ? 'bg-primary-container text-on-primary-container'
+                        ? 'bg-primary-container text-on-primary-container font-medium'
                         : 'text-on-surface-muted hover:bg-surface-container-low hover:text-on-surface'
                     )}
                   >
                     <Icon size={16} />
-                    <span className="text-sm md:text-base md:font-semibold">{tab.label}</span>
+                    <span className="text-sm md:text-base">{tab.label}</span>
                   </button>
                 )
               })}
@@ -391,7 +401,6 @@ function MyPage() {
 
             {activeMyPageNav === 'nav-dash' ? (
               <MyDashboard
-                profile={myData}
                 myProducts={myProductsData?.pages.flatMap((page) => page.content)}
                 myRequests={myRequestData?.pages.flatMap((page) => page.content)}
                 myFavorites={myFavoriteData?.pages.flatMap((page) => page.content)}

--- a/src/features/my-page/components/MyDashboard.tsx
+++ b/src/features/my-page/components/MyDashboard.tsx
@@ -1,25 +1,13 @@
 'use client'
 
-import { useRef, useState } from 'react'
+import { useState } from 'react'
 import Link from 'next/link'
-import { Camera, ChevronRight } from 'lucide-react'
+import { ChevronRight } from 'lucide-react'
 import ProductCard from '@/components/product/ProductCard'
 import { UnderlineTabs } from '@/components/UnderlineTabs'
-import { cn } from '@/lib/utils/cn'
 import type { Product } from '@/types'
-import type { MyPageData } from '@/components/profile/ProfileData'
-import { ROUTES } from '@/constants/routes'
-import { getImageSrcSet, IMAGE_SIZES, toResizedWebpUrl } from '@/lib/utils/imageUrl'
-import { uploadImage } from '@/lib/api/products'
-import imageCompression from 'browser-image-compression'
-import { fetchGraphQL } from '@/lib/api/graphql'
-import { useQueryClient } from '@tanstack/react-query'
-import { useUserStore } from '@/store/userStore'
-import InlineNotification from '@/components/commons/InlineNotification'
-import { AnimatePresence } from 'framer-motion'
 
 interface MyDashboardProps {
-  profile?: MyPageData
   myProducts?: Product[]
   myRequests?: Product[]
   myFavorites?: Product[]
@@ -36,7 +24,7 @@ interface TabConfig {
 const TAB_CONFIG: Record<DashboardTab, TabConfig> = {
   sales: { label: '판매 내역', nav: 'nav-sales', tab: 'tab-sales' },
   purchases: { label: '구매 내역', nav: 'nav-purchases', tab: 'tab-purchases' },
-  wishlist: { label: '관심 목록', nav: 'nav-wishlist', tab: 'tab-wishlist' },
+  wishlist: { label: '찜한 상품', nav: 'nav-wishlist', tab: 'tab-wishlist' },
 }
 
 const TAB_ORDER: DashboardTab[] = ['sales', 'purchases', 'wishlist']
@@ -47,21 +35,8 @@ const DASHBOARD_TABS_LIST: { id: DashboardTab; label: string; code: DashboardTab
   code: id,
 }))
 
-const SUMMARY_ITEMS = [
-  { key: 'sales', label: '판매 내역' },
-  { key: 'purchases', label: '구매 내역' },
-  { key: 'wishlist', label: '관심 목록' },
-] as const
-
-export default function MyDashboard({ profile, myProducts, myRequests, myFavorites }: MyDashboardProps) {
+export default function MyDashboard({ myProducts, myRequests, myFavorites }: MyDashboardProps) {
   const [activeTab, setActiveTab] = useState<DashboardTab>('sales')
-  const [imgError, setImgError] = useState(false)
-  const [profileImageUrl, setProfileImageUrl] = useState(profile?.profileImageUrl || '')
-  const [imageUpdateError, setImageUpdateError] = useState<React.ReactNode | null>(null)
-  const fileInputRef = useRef<HTMLInputElement>(null)
-  const queryClient = useQueryClient()
-  const user = useUserStore((state) => state.user)
-  const updateUserProfile = useUserStore((state) => state.updateUserProfile)
 
   const dataMap: Record<DashboardTab, Product[] | undefined> = {
     sales: myProducts,
@@ -71,158 +46,11 @@ export default function MyDashboard({ profile, myProducts, myRequests, myFavorit
 
   const currentData = dataMap[activeTab]?.slice(0, 4) ?? []
   const currentConfig = TAB_CONFIG[activeTab]
-  const summaryCounts = {
-    sales: myProducts?.length ?? 0,
-    purchases: myRequests?.length ?? 0,
-    wishlist: myFavorites?.length ?? 0,
-  }
-
-  const compressImage = async (file: File) => {
-    return await imageCompression(file, {
-      maxSizeMB: 1,
-      maxWidthOrHeight: 800,
-      useWebWorker: true,
-      fileType: 'image/webp',
-    })
-  }
-
-  const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0]
-    if (!file || !profile) return
-
-    const allowedTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/webp']
-    if (!allowedTypes.includes(file.type)) {
-      setImageUpdateError(<p className="text-base font-semibold">지원하지 않는 파일 형식입니다.</p>)
-      e.target.value = ''
-      return
-    }
-
-    if (file.size > 5 * 1024 * 1024) {
-      setImageUpdateError(<p className="text-base font-semibold">파일 크기는 5MB를 초과할 수 없습니다.</p>)
-      e.target.value = ''
-      return
-    }
-
-    try {
-      const compressedFile = await compressImage(file)
-      const uploadedUrl = await uploadImage([compressedFile])
-      const nextProfileImageUrl = uploadedUrl.mainImageUrl
-
-      const { updateProfile: response } = await fetchGraphQL<{ updateProfile: { success: boolean; code: string } }>(
-        `
-        mutation UpdateProfile($input: ProfileUpdateInput!) {
-          updateProfile(input: $input) { success code }
-        }
-      `,
-        { input: { profileImageUrl: nextProfileImageUrl } }
-      )
-
-      if (response.code === 'SUCCESS') {
-        setProfileImageUrl(nextProfileImageUrl)
-        setImgError(false)
-        setImageUpdateError(null)
-        updateUserProfile({ profileImageUrl: nextProfileImageUrl })
-        await queryClient.refetchQueries({ queryKey: ['mypage', user?.id] })
-      }
-    } catch {
-      setImageUpdateError(
-        <div className="flex flex-col gap-0.5">
-          <p className="text-base font-semibold">프로필 이미지 변경에 실패했습니다.</p>
-          <p>잠시 후 다시 시도해주세요.</p>
-        </div>
-      )
-    }
-
-    e.target.value = ''
-  }
 
   return (
     <div className="flex flex-col gap-8">
-      <section className="bg-surface-container-lowest border-outline-variant/50 rounded-3xl border p-6 shadow-sm">
-        <AnimatePresence>
-          {imageUpdateError ? (
-            <InlineNotification type="error" onClose={() => setImageUpdateError(null)}>
-              {imageUpdateError}
-            </InlineNotification>
-          ) : null}
-        </AnimatePresence>
-        <div className="flex flex-col gap-6">
-          <div className="flex items-start gap-5 md:gap-8">
-            <div className="relative h-20 w-20 shrink-0">
-              <input
-                ref={fileInputRef}
-                type="file"
-                accept=".jpg,.jpeg,.png,.webp"
-                onChange={handleImageChange}
-                className="hidden"
-              />
-              <div className="bg-chip-surface relative flex h-full w-full items-center justify-center overflow-hidden rounded-full border-2 border-[#825500]">
-                {profileImageUrl ? (
-                  // eslint-disable-next-line @next/next/no-img-element
-                  <img
-                    src={imgError ? profileImageUrl : toResizedWebpUrl(profileImageUrl, 150)}
-                    srcSet={getImageSrcSet(profileImageUrl)}
-                    sizes={IMAGE_SIZES.smallThumbnail}
-                    alt={profile?.nickname || '프로필 이미지'}
-                    loading="lazy"
-                    onError={(e) => {
-                      const img = e.currentTarget
-                      if (profileImageUrl && img.src !== profileImageUrl) {
-                        img.srcset = ''
-                        img.src = profileImageUrl
-                        return
-                      }
-                      setImgError(true)
-                    }}
-                    className="h-full w-full object-cover"
-                  />
-                ) : (
-                  <div className="flex h-full w-full items-center justify-center text-2xl font-semibold text-[#825500]">
-                    {profile?.nickname?.charAt(0).toUpperCase()}
-                  </div>
-                )}
-              </div>
-              <button
-                type="button"
-                className="bg-primary-100 absolute right-0 bottom-1 flex size-8 cursor-pointer items-center justify-center rounded-full"
-                onClick={() => fileInputRef.current?.click()}
-                aria-label="프로필 사진 변경"
-              >
-                <Camera size={20} />
-              </button>
-            </div>
-
-            <div className="flex min-w-0 flex-col gap-3">
-              <div className="flex items-center gap-3">
-                <h2 className="text-on-surface text-xl font-semibold">{profile?.nickname}</h2>
-                <Link
-                  href={ROUTES.PROFILE_UPDATE}
-                  className="bg-primary-100 text-on-surface-variant hover:bg-primary-200 inline-flex w-fit items-center justify-center rounded-full px-5 py-2 text-sm font-bold transition-colors"
-                >
-                  프로필 수정
-                </Link>
-              </div>
-              <div className="flex">
-                {SUMMARY_ITEMS.map((item, index) => (
-                  <div
-                    key={item.key}
-                    className={cn(
-                      'flex flex-col items-center gap-2',
-                      index < SUMMARY_ITEMS.length - 1 ? 'border-outline-variant/50 border-r pr-4 md:pr-6' : ''
-                    )}
-                  >
-                    <span className="text-on-surface-variant text-sm font-medium">{item.label}</span>
-                    <strong className="text-on-surface text-3xl font-bold">{summaryCounts[item.key]}</strong>
-                  </div>
-                ))}
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
       {/* 거래 내역 요약 */}
-      <section className="bg-surface-container-lowest border-outline-variant/20 rounded-2xl border p-6 shadow-sm md:p-8">
+      <section className="bg-surface-container-lowest border-outline-variant/40 rounded-2xl border p-6 md:p-8">
         <UnderlineTabs
           tabs={DASHBOARD_TABS_LIST}
           activeTab={activeTab}
@@ -256,21 +84,29 @@ export default function MyDashboard({ profile, myProducts, myRequests, myFavorit
 
       {/* 활동 요약 */}
       <section className="grid grid-cols-1 gap-8 lg:grid-cols-2">
-        <div className="bg-surface-container-lowest border-outline-variant/20 rounded-2xl border p-6 shadow-sm md:p-8">
+        <div className="bg-surface-container-lowest border-outline-variant/40 rounded-2xl border p-6 md:p-8">
           <div className="mb-6 flex items-center justify-between">
             <h2 className="text-on-surface text-lg font-bold">나의 커뮤니티 글</h2>
-            <Link href="?nav=nav-activity" className="text-primary text-sm font-bold hover:underline">
+            <Link
+              href="?nav=nav-activity"
+              className="text-primary flex items-center gap-1 text-sm font-bold hover:underline"
+            >
               전체보기
+              <ChevronRight size={16} />
             </Link>
           </div>
           <p className="text-on-surface-muted py-8 text-center text-sm">작성한 커뮤니티 글이 없습니다.</p>
         </div>
 
-        <div className="bg-surface-container-lowest border-outline-variant/20 rounded-2xl border p-6 shadow-sm md:p-8">
+        <div className="bg-surface-container-lowest border-outline-variant/40 rounded-2xl border p-6 md:p-8">
           <div className="mb-6 flex items-center justify-between">
             <h2 className="text-on-surface text-lg font-bold">최근 작성한 댓글</h2>
-            <Link href="?nav=nav-activity" className="text-primary text-sm font-bold hover:underline">
+            <Link
+              href="?nav=nav-activity"
+              className="text-primary flex items-center gap-1 text-sm font-bold hover:underline"
+            >
               전체보기
+              <ChevronRight size={16} />
             </Link>
           </div>
           <p className="text-on-surface-muted py-8 text-center text-sm">작성한 댓글이 없습니다.</p>

--- a/src/features/my-page/components/MyList.tsx
+++ b/src/features/my-page/components/MyList.tsx
@@ -92,13 +92,6 @@ export default function MyList({
     },
   })
 
-  const { mutate: cancelFavorite } = useMutation({
-    mutationFn: () => api.post(`/products/${id}/favorite`),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['myFavorite'] })
-    },
-  })
-
   const handleProductType = (value: string) => {
     const koToEn = STATUS_EN_TO_KO.find((status) => status.name === value)?.value
     setCurrentTradeStatus(koToEn as TransactionStatus)
@@ -129,18 +122,12 @@ export default function MyList({
   const isReserved = currentTradeStatus === 'RESERVED'
   const isSalesTab = activeTab === 'tab-sales'
   const isPurchasesTab = activeTab === 'tab-purchases'
-  const isWishlistTab = activeTab === 'tab-wishlist'
   const isMyProductTab = isSalesTab || isPurchasesTab
 
   // 메인 페이지 ProductThumbnail 패턴: 이미지 위 오버레이 + 라운드 흰 배지
   const overlayLabel = isCompleted ? (isPurchasesTab ? '구매완료' : '판매완료') : isReserved ? '예약중' : null
   const overlayBg = isCompleted ? 'bg-black/60' : 'bg-black/40'
 
-  const handleCancelFavorite = (e: React.MouseEvent) => {
-    e.preventDefault()
-    e.stopPropagation()
-    cancelFavorite()
-  }
   const handleMoreToggle = (e: React.MouseEvent) => {
     e.preventDefault()
     e.stopPropagation()
@@ -154,7 +141,7 @@ export default function MyList({
     <li id={id.toString()} className="relative w-full hover:z-10">
       <Link
         href={ROUTES.DETAIL_ID(id, title)}
-        className="bg-surface-container-lowest border-outline-variant/40 group flex w-full items-stretch gap-3 rounded-xl border p-3 transition-shadow hover:shadow-lg md:gap-4 md:p-4"
+        className="group flex w-full items-stretch gap-3 rounded-xl border border-black/5 bg-white p-3 shadow-sm transition-all duration-500 hover:-translate-y-1 hover:shadow-xl md:gap-4 md:p-4"
       >
         <div className="relative aspect-square w-24 shrink-0 overflow-hidden rounded-lg md:w-32">
           <Image
@@ -234,18 +221,14 @@ export default function MyList({
                           </Button>
                         ) : null}
 
-                        {/* 삭제 또는 찜 취소 */}
+                        {/* 삭제 */}
                         <Button
                           size="sm"
                           className="text-danger-500 hover:bg-surface-container-high w-fit cursor-pointer gap-3 rounded-none transition-all"
-                          onClick={
-                            isWishlistTab
-                              ? handleCancelFavorite
-                              : (e: React.MouseEvent) => handleConfirmModal(e, id, title, price, mainImageUrl)
-                          }
+                          onClick={(e: React.MouseEvent) => handleConfirmModal(e, id, title, price, mainImageUrl)}
                         >
                           <Trash2 size={16} />
-                          <span>{isWishlistTab ? '찜 취소' : '삭제'}</span>
+                          <span>삭제</span>
                         </Button>
                       </div>
                     ) : null}
@@ -285,13 +268,9 @@ export default function MyList({
                 <Button
                   size="sm"
                   className="border-outline-variant/60 text-on-surface hover:bg-surface-container-high flex-1 cursor-pointer border transition-all"
-                  onClick={
-                    isWishlistTab
-                      ? handleCancelFavorite
-                      : (e: React.MouseEvent) => handleConfirmModal(e, id, title, price, mainImageUrl)
-                  }
+                  onClick={(e: React.MouseEvent) => handleConfirmModal(e, id, title, price, mainImageUrl)}
                 >
-                  {isWishlistTab ? '찜 취소' : '삭제'}
+                  삭제
                 </Button>
               </div>
             </div>

--- a/src/features/my-page/components/MyPagePanel.tsx
+++ b/src/features/my-page/components/MyPagePanel.tsx
@@ -7,12 +7,14 @@ import type { MyPageTabId, TransactionStatus } from '@/constants/constants'
 import type { BlockedUser, Product } from '@/types'
 import MyPageTitle from './MyPageTitle'
 import MyList from './MyList'
+import ProductCard from '@/components/product/ProductCard'
 import Button from '@/components/commons/button/Button'
 import LoadMoreButton from '@/components/commons/button/LoadMoreButton'
 import EmptyState from '@/components/EmptyState'
 import { Package, Heart, type LucideIcon } from 'lucide-react'
 import Link from 'next/link'
 import { cn } from '@/lib/utils/cn'
+import { getTimeAgo } from '@/lib/utils/getTimeAgo'
 
 interface MyPagePanelProps {
   activeTabCode: string
@@ -161,7 +163,7 @@ export default function MyPagePanel({
       role="tabpanel"
       id={`panel-${activeTabCode}`}
       aria-labelledby={activeMyPageTab}
-      className={cn('flex flex-col rounded-xl border-gray-200 px-5 py-7 md:border md:p-5', hasContent && 'gap-6')}
+      className={cn('border-outline-variant/40 flex flex-col rounded-xl px-5 py-5 md:border md:p-5', hasContent && 'gap-4')}
     >
       {config ? (
         <MyPageTitle
@@ -180,19 +182,29 @@ export default function MyPagePanel({
         {activeMyPageTab !== 'tab-blocked' ? (
           productData?.content?.length ? (
             <>
-              <div
-                className={cn(
-                  '-m-2 p-2',
-                  productCount > 1 && 'scrollbar-hide max-h-[60vh] overflow-y-auto',
-                  productCount <= 1 && 'overflow-visible'
-                )}
-              >
-                <ul className="flex flex-col items-stretch justify-start divide-y divide-gray-200 md:gap-2.5 md:divide-y-0">
+              {activeMyPageTab === 'tab-wishlist' ? (
+                <ul className="grid grid-cols-2 gap-4 lg:grid-cols-4">
                   {productData.content.map((product) => (
-                    <MyList key={product.id} {...product} activeTab={activeMyPageTab} handleConfirmModal={handleConfirmModal} />
+                    <li key={product.id}>
+                      <ProductCard data={product} vertical />
+                    </li>
                   ))}
                 </ul>
-              </div>
+              ) : (
+                <div
+                  className={cn(
+                    '-m-2 p-2',
+                    productCount > 1 && 'scrollbar-hide max-h-[60vh] overflow-y-auto',
+                    productCount <= 1 && 'overflow-visible'
+                  )}
+                >
+                  <ul className="flex flex-col items-stretch justify-start divide-y divide-gray-200 md:gap-2.5 md:divide-y-0">
+                    {productData.content.map((product) => (
+                      <MyList key={product.id} {...product} activeTab={activeMyPageTab} handleConfirmModal={handleConfirmModal} />
+                    ))}
+                  </ul>
+                </div>
+              )}
               {hasNextPage ? <LoadMoreButton onClick={() => fetchNextPage()} isLoading={isFetchingNextPage} /> : null}
             </>
           ) : config ? (
@@ -200,19 +212,27 @@ export default function MyPagePanel({
           ) : null
         ) : myBlockedData?.length ? (
           <>
-            <ul className="scrollbar-hide flex max-h-[60vh] flex-col items-center justify-start gap-2.5 overflow-y-auto">
+            <ul className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
               {myBlockedData.map((user) => (
                 <li
                   key={user.blockedUserId}
-                  className="border-outline-variant/60 flex w-full items-center justify-between gap-6 rounded-lg border p-3.5"
+                  className="border-outline-variant/40 flex flex-col items-center gap-3 rounded-2xl border bg-white p-4"
                 >
-                  <Link href={`/user-profile/${user.blockedUserId}`} className="flex items-center gap-4">
-                    <div className="relative aspect-square w-12 shrink-0 overflow-hidden rounded-full">
+                  <Link href={`/user-profile/${user.blockedUserId}`} className="flex w-full flex-col items-center gap-2">
+                    <div className="relative aspect-square w-14 shrink-0 overflow-hidden rounded-full">
                       <BlockedUserAvatar profileImageUrl={user.profileImageUrl} nickname={user.nickname} />
                     </div>
-                    <span className="font-medium">{user.nickname}</span>
+                    <div className="flex flex-col items-center text-center">
+                      <span className="line-clamp-1 font-semibold">{user.nickname}</span>
+                      <span className="text-xs text-gray-500">{getTimeAgo(user.blockedAt)} 차단</span>
+                    </div>
                   </Link>
-                  <Button size="sm" variant="secondary" className="cursor-pointer" onClick={() => unblockUser?.(user.blockedUserId)}>
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    className="hover:bg-surface-container-low hover:text-on-surface w-full cursor-pointer"
+                    onClick={() => unblockUser?.(user.blockedUserId)}
+                  >
                     차단 해제
                   </Button>
                 </li>

--- a/src/features/profile-update/components/ProfileUpdateBaseForm.tsx
+++ b/src/features/profile-update/components/ProfileUpdateBaseForm.tsx
@@ -353,7 +353,7 @@ export default function ProfileUpdateBaseForm({ myData }: ProfileUpdateBaseFormP
                       )}
                       {...register('introduction', profileValidationRules.introduction)}
                     />
-                    <p className="text-xs font-semibold text-gray-400">{titleLength}/1000자</p>
+                    <p className="text-xs font-semibold text-gray-400">{titleLength}/200자</p>
                     {errors.introduction ? (
                       <p className="text-danger-500 text-xs font-semibold"> {errors.introduction.message}</p>
                     ) : null}

--- a/src/hooks/useFavorite.ts
+++ b/src/hooks/useFavorite.ts
@@ -19,18 +19,23 @@ export function useFavorite({ productId, initialIsFavorite }: UseFavoriteOptions
     setIsFavorite(initialIsFavorite)
   }, [initialIsFavorite])
 
-  const { mutate: toggleFavorite, isPending } = useMutation({
-    mutationFn: () => fetchGraphQL(`
+  const { mutate: runFavoriteRequest, isPending } = useMutation({
+    mutationFn: () =>
+      fetchGraphQL(
+        `
       mutation ToggleFavorite($productId: Int!) {
         toggleFavorite(productId: $productId) { success }
       }
-    `, { productId }),
+    `,
+        { productId }
+      ),
     onMutate: () => {
       setIsFavorite((prev) => !prev)
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['product', productId] })
       queryClient.invalidateQueries({ queryKey: ['products'] })
+      queryClient.invalidateQueries({ queryKey: ['myFavorite'] })
     },
     onError: () => {
       setIsFavorite(initialIsFavorite)
@@ -50,7 +55,7 @@ export function useFavorite({ productId, initialIsFavorite }: UseFavoriteOptions
       return
     }
 
-    toggleFavorite()
+    runFavoriteRequest()
   }
 
   return { isFavorite, isPending, handleToggleFavorite }

--- a/src/lib/utils/validation/authValidationRules.ts
+++ b/src/lib/utils/validation/authValidationRules.ts
@@ -52,8 +52,8 @@ export const profileValidationRules = {
       message: '2자 이상이어야 합니다.',
     },
     maxLength: {
-      value: 1000,
-      message: '자기소개는 1000자 이하이어야 합니다.',
+      value: 200,
+      message: '자기소개는 200자 이하이어야 합니다.',
     },
   } satisfies RegisterOptions<ProfileUpdateBaseFormValues, 'introduction'>,
 

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -39,6 +39,7 @@ export interface BlockedUser {
   blockedUserId: number
   nickname: string
   profileImageUrl: string
+  blockedAt: string
 }
 
 export interface MyBlockedUsersResponse {


### PR DESCRIPTION
## Summary
- `ProfileData`에 활동 카운트 / 프로필 사진 업로드 / 프로필 수정 링크 통합
- 차단/신고를 케밥 메뉴로 묶음 (다른 유저 페이지)
- 소개글 line-clamp + 더보기 토글, 200자 제한
- 모바일 가입일 제거 (디바이스 비대칭 해소)
- 찜한 상품을 `ProductCard` 그리드로 표시
- 차단 유저 그리드 카드 + `blockedAt` 표시
- 시각 일관성 통일 (shadow 제거, border-outline-variant/40, 전체보기 화살표 통일)
- "좋아요"/"관심목록" → "찜" 계열로 용어 통일
- LoadMoreButton 14px
- `useFavorite` hook의 `myFavorite` invalidate 추가 (찜 취소 즉시 갱신)

## Test plan
- [ ] 마이페이지 사이드바에 활동 카운트 / 프로필 사진 업로드 / 프로필 수정 링크 표시 확인
- [ ] 다른 유저 페이지에서 케밥 메뉴 → 차단/신고 옵션 동작 확인
- [ ] 소개글이 3줄 초과 시 "더보기/접기" 토글 동작 확인
- [ ] 찜한 상품 그리드 표시 + 하트 토글로 즉시 사라짐 확인
- [ ] 차단 유저 그리드 카드에 "N일 전 차단" 표시 확인 (백엔드 응답 반영 필요)
- [ ] 모든 "찜" 텍스트가 일관되게 표시되는지 확인

closes #736