### PR TITLE
refactor: 헤더 메뉴 및 마이페이지 타이틀 폰트 톤 조정

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -157,8 +157,8 @@ export default function Header() {
                   <Link
                     href={ROUTES.HOME}
                     className={cn(
-                      'pb-1 text-sm font-bold transition-colors',
-                      isMarketActive ? 'border-b-2 border-primary text-primary' : 'text-primary/70 hover:text-primary'
+                      'pb-1 text-base font-medium transition-colors',
+                      isMarketActive ? 'border-primary text-primary border-b-2' : 'text-primary/70 hover:text-primary'
                     )}
                   >
                     중고거래
@@ -166,8 +166,8 @@ export default function Header() {
                   <Link
                     href={ROUTES.COMMUNITY}
                     className={cn(
-                      'pb-1 text-sm font-bold transition-colors',
-                      isCommunityActive ? 'border-b-2 border-primary text-primary' : 'text-primary/70 hover:text-primary'
+                      'pb-1 text-base font-medium transition-colors',
+                      isCommunityActive ? 'border-primary text-primary border-b-2' : 'text-primary/70 hover:text-primary'
                     )}
                   >
                     질문·정보
@@ -175,8 +175,8 @@ export default function Header() {
                   <Link
                     href={ROUTES.MAP}
                     className={cn(
-                      'pb-1 text-sm font-bold transition-colors',
-                      isMapActive ? 'border-b-2 border-primary text-primary' : 'text-primary/70 hover:text-primary'
+                      'pb-1 text-base font-medium transition-colors',
+                      isMapActive ? 'border-primary text-primary border-b-2' : 'text-primary/70 hover:text-primary'
                     )}
                   >
                     펫지도

--- a/src/features/my-page/components/MyPageTitle.tsx
+++ b/src/features/my-page/components/MyPageTitle.tsx
@@ -24,8 +24,10 @@ export default function MyPageTitle({ heading, count, description, buttonLabel, 
   return (
     <div className="flex justify-between">
       <div>
-        <h2 className="flex items-center gap-2 text-sm font-bold md:text-base">{heading}</h2>
-        {description ? <p className="text-sm text-gray-500">{count !== undefined ? `${description} ${count}` : description}</p> : null}
+        <h2 className="flex items-center gap-2 text-sm font-semibold md:text-base">{heading}</h2>
+        {description ? (
+          <p className="text-sm text-gray-500">{count !== undefined ? `${description} ${count}` : description}</p>
+        ) : null}
       </div>
       {buttonLabel ? (
         <Button


### PR DESCRIPTION
## Summary
- 헤더 네비게이션 메뉴(중고거래/질문·정보/펫지도): `text-sm font-bold` → `text-base font-medium`
- 마이페이지 타이틀: `font-bold` → `font-semibold`
- JSX 포매팅 정리

## Test plan
- [ ] 헤더 메뉴 텍스트 톤 확인
- [ ] 마이페이지 타이틀 톤 확인

closes #738