### PR TITLE
refactor: 헤더 알림 UI 정리 및 마이페이지 폰트/패딩 폴리싱

### DIFF
--- a/src/components/UnderlineTabs.tsx
+++ b/src/components/UnderlineTabs.tsx
@@ -46,7 +46,7 @@ export function UnderlineTabs({
               aria-controls={`panel-${tab.code}`}
               tabIndex={isActive ? 0 : -1}
               className={cn(
-                'cursor-pointer pb-3 text-base font-semibold transition-all md:pb-1',
+                'cursor-pointer pb-3 text-sm font-semibold transition-all md:pb-1',
                 isActive ? 'border-primary text-primary border-b-2' : 'text-on-surface-muted hover:text-primary'
               )}
             >

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -157,7 +157,7 @@ export default function Header() {
                   <Link
                     href={ROUTES.HOME}
                     className={cn(
-                      'pb-1 text-base font-medium transition-colors',
+                      'pb-1 text-sm font-semibold transition-colors',
                       isMarketActive ? 'border-primary text-primary border-b-2' : 'text-primary/70 hover:text-primary'
                     )}
                   >
@@ -166,7 +166,7 @@ export default function Header() {
                   <Link
                     href={ROUTES.COMMUNITY}
                     className={cn(
-                      'pb-1 text-base font-medium transition-colors',
+                      'pb-1 text-sm font-semibold transition-colors',
                       isCommunityActive ? 'border-primary text-primary border-b-2' : 'text-primary/70 hover:text-primary'
                     )}
                   >
@@ -175,7 +175,7 @@ export default function Header() {
                   <Link
                     href={ROUTES.MAP}
                     className={cn(
-                      'pb-1 text-base font-medium transition-colors',
+                      'pb-1 text-sm font-semibold transition-colors',
                       isMapActive ? 'border-primary text-primary border-b-2' : 'text-primary/70 hover:text-primary'
                     )}
                   >

--- a/src/components/header/components/UserControls.tsx
+++ b/src/components/header/components/UserControls.tsx
@@ -7,7 +7,7 @@ import { useUserStore } from '@/store/userStore'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { ROUTES } from '@/constants/routes'
-import { MessageCircleMore, Bell } from 'lucide-react'
+import { MessageCircle, Bell } from 'lucide-react'
 import IconButton from '@/components/commons/button/IconButton'
 import NotificationsDropdown from './notification-section/NotificationsDropdown'
 import { useQuery } from '@tanstack/react-query'
@@ -55,18 +55,21 @@ export default function UserControls({ isSideOpen, setIsSideOpen, hideMenuButton
       {hasHydrated && isLogin() ? (
         <div className="flex items-center gap-1">
           <Link href={ROUTES.CHAT} className="ml-1 hidden xl:block" aria-label="채팅">
-            <MessageCircleMore className="text-primary" strokeWidth={1.5} />
+            <MessageCircle className="text-primary" strokeWidth={1.5} size={20} />
           </Link>
-          <div className="relative mr-2.5" onClick={handleBellToggle}>
+          <div className="relative" onClick={handleBellToggle}>
             <IconButton aria-label="알림" size="lg" className="hover:bg-transparent">
-              <Bell size={24} className="stroke-primary" />
+              <Bell size={20} strokeWidth={1.5} className="text-primary" />
             </IconButton>
             {(unreadCountData?.unreadCount ?? 0) > 0 ? (
-              <span className="bg-danger-500 absolute top-0 -right-2 flex size-5 items-center justify-center rounded-full p-2 text-sm text-white">
-                {unreadCountData?.unreadCount}
-              </span>
+              <span
+                className="bg-danger-500 absolute top-1 right-1 size-2 rounded-full"
+                aria-label={`읽지 않은 알림 ${unreadCountData?.unreadCount}개`}
+              />
             ) : null}
-            {isNotificationOpen ? <NotificationsDropdown isNotificationOpen={isNotificationOpen} setIsNotificationOpen={setIsNotificationOpen} /> : null}
+            {isNotificationOpen ? (
+              <NotificationsDropdown isNotificationOpen={isNotificationOpen} setIsNotificationOpen={setIsNotificationOpen} />
+            ) : null}
           </div>
           <UserMenu
             isNotificationOpen={false}

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -1,12 +1,12 @@
 import {
   MessageSquarePlus,
   MessageSquareMore,
+  MessageSquareText,
   HeartCrack,
   Tag,
   ShieldAlert,
   Trash2,
   Reply,
-  MessageCircle,
   TriangleAlert,
   Check,
   Slash,
@@ -335,7 +335,7 @@ export const iconMap = {
   ADMIN_SANCTION: ShieldAlert,
   POST_DELETED: Trash2,
   COMMENT_REPLY: Reply,
-  POST_COMMENT: MessageCircle,
+  POST_COMMENT: MessageSquareText,
 } as const satisfies Record<string, LucideIcon>
 export type NotificationType = keyof typeof iconMap
 

--- a/src/features/my-page/MyPage.tsx
+++ b/src/features/my-page/MyPage.tsx
@@ -363,14 +363,14 @@ function MyPage() {
                     tabIndex={isActive ? 0 : -1}
                     onClick={() => handleNavChange(tab.id)}
                     className={cn(
-                      'flex cursor-pointer items-center gap-3 rounded-xl px-4 py-3 text-left transition-all',
+                      'flex cursor-pointer items-center gap-3 rounded-xl px-3 py-2 text-left font-medium transition-all',
                       isActive
-                        ? 'bg-primary-container text-on-primary-container font-medium'
+                        ? 'bg-primary-container text-on-primary-container font-semibold'
                         : 'text-on-surface-muted hover:bg-surface-container-low hover:text-on-surface'
                     )}
                   >
                     <Icon size={16} />
-                    <span className="text-sm md:text-base">{tab.label}</span>
+                    <span className="text-sm">{tab.label}</span>
                   </button>
                 )
               })}

--- a/src/features/my-page/components/MyDashboard.tsx
+++ b/src/features/my-page/components/MyDashboard.tsx
@@ -50,7 +50,7 @@ export default function MyDashboard({ myProducts, myRequests, myFavorites }: MyD
   return (
     <div className="flex flex-col gap-8">
       {/* 거래 내역 요약 */}
-      <section className="bg-surface-container-lowest border-outline-variant/40 rounded-2xl border p-6 md:p-8">
+      <section className="bg-surface-container-lowest border-outline-variant/40 rounded-2xl border p-6">
         <UnderlineTabs
           tabs={DASHBOARD_TABS_LIST}
           activeTab={activeTab}
@@ -60,7 +60,7 @@ export default function MyDashboard({ myProducts, myRequests, myFavorites }: MyD
           rightSlot={
             <Link
               href={`?nav=${currentConfig.nav}&tab=${currentConfig.tab}`}
-              className="text-primary flex items-center gap-1 text-sm font-bold hover:underline"
+              className="text-primary flex items-center gap-1 text-sm font-semibold hover:underline"
             >
               전체보기
               <ChevronRight size={16} />
@@ -86,11 +86,8 @@ export default function MyDashboard({ myProducts, myRequests, myFavorites }: MyD
       <section className="grid grid-cols-1 gap-8 lg:grid-cols-2">
         <div className="bg-surface-container-lowest border-outline-variant/40 rounded-2xl border p-6 md:p-8">
           <div className="mb-6 flex items-center justify-between">
-            <h2 className="text-on-surface text-lg font-bold">나의 커뮤니티 글</h2>
-            <Link
-              href="?nav=nav-activity"
-              className="text-primary flex items-center gap-1 text-sm font-bold hover:underline"
-            >
+            <h2 className="text-on-surface text-base font-bold">나의 커뮤니티 글</h2>
+            <Link href="?nav=nav-activity" className="text-primary flex items-center gap-1 text-sm font-bold hover:underline">
               전체보기
               <ChevronRight size={16} />
             </Link>
@@ -100,11 +97,8 @@ export default function MyDashboard({ myProducts, myRequests, myFavorites }: MyD
 
         <div className="bg-surface-container-lowest border-outline-variant/40 rounded-2xl border p-6 md:p-8">
           <div className="mb-6 flex items-center justify-between">
-            <h2 className="text-on-surface text-lg font-bold">최근 작성한 댓글</h2>
-            <Link
-              href="?nav=nav-activity"
-              className="text-primary flex items-center gap-1 text-sm font-bold hover:underline"
-            >
+            <h2 className="text-on-surface text-base font-bold">최근 작성한 댓글</h2>
+            <Link href="?nav=nav-activity" className="text-primary flex items-center gap-1 text-sm font-bold hover:underline">
               전체보기
               <ChevronRight size={16} />
             </Link>

--- a/src/features/my-page/components/MyList.tsx
+++ b/src/features/my-page/components/MyList.tsx
@@ -167,10 +167,10 @@ export default function MyList({
         </div>
 
         <div className="flex flex-1 items-stretch gap-3 md:gap-4">
-          <div className="flex flex-1 self-stretch flex-col justify-between gap-3">
+          <div className="flex flex-1 flex-col justify-between gap-3 self-stretch">
             <div className="flex w-full items-start justify-between">
-              <div className="flex w-full flex-col gap-1">
-                {isMd ? <h3 className="line-clamp-2 w-96 text-base leading-6.5">{title}</h3> : null}
+              <div className="flex w-full flex-col">
+                {isMd ? <h3 className="line-clamp-2 w-96 text-[15px] leading-6.5">{title}</h3> : null}
                 {!isMd ? (
                   <div className="relative flex w-full items-start justify-between gap-2">
                     <h3 className="line-clamp-2 w-full text-sm font-normal">{title}</h3>
@@ -234,7 +234,7 @@ export default function MyList({
                     ) : null}
                   </div>
                 ) : null}
-                <span className="text-md font-bold text-gray-900">{formatPrice(price)} 원</span>
+                <span className="text-base font-bold text-gray-900">{formatPrice(price)} 원</span>
               </div>
             </div>
             <div className="flex items-center gap-3">
@@ -256,12 +256,7 @@ export default function MyList({
               ) : null}
               <div className="flex gap-1">
                 {isMyProductTab && !isCompleted ? (
-                  <Button
-                    size="sm"
-                    variant="secondary"
-                    className="flex-1 cursor-pointer"
-                    onClick={handleProductUpdate}
-                  >
+                  <Button size="sm" variant="secondary" className="flex-1 cursor-pointer" onClick={handleProductUpdate}>
                     수정
                   </Button>
                 ) : null}

--- a/src/features/my-page/components/MyPagePanel.tsx
+++ b/src/features/my-page/components/MyPagePanel.tsx
@@ -172,7 +172,7 @@ export default function MyPagePanel({
           description={titleDescription}
           buttonLabel={config.buttonLabel}
           navigateTo={config.navigateTo}
-          buttonClassname="text-base"
+          buttonClassname="text-sm"
         />
       ) : (
         <MyPageTitle heading="차단한 사용자" description={`차단한 사용자 ${myBlockedTotal ?? 0}명`} />

--- a/src/features/my-page/components/MyPageTitle.tsx
+++ b/src/features/my-page/components/MyPageTitle.tsx
@@ -24,7 +24,7 @@ export default function MyPageTitle({ heading, count, description, buttonLabel, 
   return (
     <div className="flex justify-between">
       <div>
-        <h2 className="flex items-center gap-2 text-sm font-semibold md:text-base">{heading}</h2>
+        <h2 className="flex items-center gap-2 text-[15px] font-semibold">{heading}</h2>
         {description ? (
           <p className="text-sm text-gray-500">{count !== undefined ? `${description} ${count}` : description}</p>
         ) : null}


### PR DESCRIPTION
## Summary

### 헤더 알림 영역
- 알림 카운트 숫자 → 빨간 점(`size-2`)으로 단순화 (`aria-label`로 접근성 유지)
- Bell 아이콘 `stroke-primary` → `text-primary`로 패턴 통일 (다른 헤더 아이콘과 일관)
- MessageCircle / Bell 아이콘 `strokeWidth={1.5}` 적용 (미니멀 톤)

### 알림 드롭다운
- `POST_COMMENT` 알림 아이콘: `MessageCircle` → `MessageSquareText`로 변경
  (채팅 아이콘과 시각 구분 명확화)

### 마이페이지 시각 폴리싱
- UnderlineTabs: `text-base` → `text-sm`
- 사이드 메뉴: padding/폰트 톤 미세 조정 (`px-4 py-3` → `px-3 py-2`, font-medium)
- MyPageTitle: `text-[15px]` 정밀 조정
- MyPagePanel buttonClassname: `text-base` → `text-sm`
- 기타 마이페이지 컴포넌트 폰트/간격 톤 정리

## Test plan
- [ ] 헤더 알림에서 카운트가 점으로 표시되는지 확인 (`unreadCount > 0`)
- [ ] 헤더 알림 아이콘 hover/클릭 동작 확인
- [ ] NotificationsDropdown 안의 댓글 알림이 MessageSquareText 아이콘으로 표시되는지 확인
- [ ] 마이페이지 사이드 메뉴 / 타이틀 / 탭 폰트 톤 확인

closes #740