### PR TITLE
refactor: 로그인/회원가입 페이지 디자인 리뉴얼

### DIFF
--- a/src/components/commons/InputWithButton.tsx
+++ b/src/components/commons/InputWithButton.tsx
@@ -2,6 +2,7 @@
 
 import InputField from './InputField'
 import Button from './button/Button'
+import { cn } from '@/lib/utils/cn'
 import type { FieldError, UseFormRegisterReturn } from 'react-hook-form'
 
 interface InputWithButtonProps {
@@ -19,6 +20,7 @@ interface InputWithButtonProps {
   buttonSize?: 'xs' | 'sm' | 'md' | 'lg'
   borderColor?: string
   inputClass?: string
+  autoFocus?: boolean
 }
 
 export default function InputWithButton({
@@ -29,13 +31,14 @@ export default function InputWithButton({
   checkResult,
   registration,
   buttonText,
-  buttonClassName = 'bg-primary-100 text-primary cursor-pointer font-semibold',
+  buttonClassName,
   buttonDisabled,
   onButtonClick,
   size = 'text-sm',
   buttonSize = 'md',
   borderColor = 'border-gray-400',
   inputClass,
+  autoFocus,
 }: InputWithButtonProps) {
   return (
     <div className="flex items-start gap-4">
@@ -49,10 +52,20 @@ export default function InputWithButton({
         error={error}
         checkResult={checkResult}
         className="flex-1"
-        inputClass={inputClass}
+        inputClass={cn('py-2 md:py-2.5', inputClass)}
         registration={registration}
+        autoFocus={autoFocus}
       />
-      <Button size={buttonSize} className={buttonClassName} type="button" onClick={onButtonClick} disabled={buttonDisabled}>
+      <Button
+        size={buttonSize}
+        className={cn(
+          'bg-primary-100 text-primary hover:bg-primary-200 cursor-pointer font-semibold shrink-0 h-10 md:h-11 transition-colors disabled:bg-gray-100 disabled:text-gray-400 disabled:hover:bg-gray-100 disabled:pointer-events-none',
+          buttonClassName,
+        )}
+        type="button"
+        onClick={onButtonClick}
+        disabled={buttonDisabled}
+      >
         {buttonText}
       </Button>
     </div>

--- a/src/components/commons/select/SelectDropdown.tsx
+++ b/src/components/commons/select/SelectDropdown.tsx
@@ -27,7 +27,7 @@ function Select({ isOpen, disabled, onClick, id, buttonClassName, selectedLabel,
       onClick={onClick}
       id={id}
       className={cn(
-        'relative flex w-full items-center cursor-pointer rounded-lg border border-gray-400 px-3 py-3 pr-10 text-sm disabled:cursor-not-allowed disabled:border-gray-200 disabled:bg-gray-100/30 disabled:text-gray-300',
+        'relative flex w-full items-center cursor-pointer rounded-lg border border-gray-400 bg-white px-3 py-3 pr-10 text-sm disabled:cursor-not-allowed disabled:border-gray-200 disabled:bg-gray-100/30 disabled:text-gray-300',
         buttonClassName,
       )}
     >

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -49,6 +49,9 @@ const HIDE_SEARCHBAR_ALWAYS_PATHS: string[] = [
 // 메뉴 버튼 숨김 경로
 const HIDE_MENU_BUTTON_PATHS: string[] = [ROUTES.LOGIN, ROUTES.SIGNUP]
 
+// 미니멀 헤더 경로 (로고만 표시)
+const MINIMAL_HEADER_PATHS: string[] = [ROUTES.LOGIN, ROUTES.SIGNUP, ROUTES.FIND_PASSWORD]
+
 // SearchBar 숨김 패턴 - 모바일만 (동적 경로)
 const HIDE_SEARCHBAR_MOBILE_PATTERNS = [/^\/user-profile\/\d+$/]
 
@@ -85,6 +88,7 @@ export default function Header() {
     HIDE_SEARCHBAR_ALWAYS_PATHS.includes(pathname) || HIDE_SEARCHBAR_ALWAYS_PATTERNS.some((pattern) => pattern.test(pathname))
   const hideSearchBar = hideSearchBarMobile || hideSearchBarAlways
   const hideMenuButton = HIDE_MENU_BUTTON_PATHS.includes(pathname)
+  const isMinimalHeader = MINIMAL_HEADER_PATHS.includes(pathname)
 
   const isHome = pathname === ROUTES.HOME
   const isMarketActive = pathname === '/' || pathname.startsWith('/market')
@@ -152,7 +156,7 @@ export default function Header() {
             {/* 왼쪽: 로고 + 데스크탑 메뉴 */}
             <div className="flex shrink-0 items-center gap-8 xl:gap-12">
               <Logo />
-              {isXl ? (
+              {isXl && !isMinimalHeader ? (
                 <nav className="flex items-center gap-8" aria-label="주 메뉴">
                   <Link
                     href={ROUTES.HOME}
@@ -201,15 +205,17 @@ export default function Header() {
               <div className="flex-1" aria-hidden="true" />
             )}
 
-            {/* 오른쪽: 검색 토글(모바일) + 사용자 컨트롤 */}
-            <div className="flex shrink-0 items-center gap-1 xl:gap-4">
-              {!hideSearchBar && !isXl ? (
-                <IconButton aria-label="검색" onClick={() => setIsSearchOpen((prev) => !prev)}>
-                  <Search className="text-primary" />
-                </IconButton>
-              ) : null}
-              <UserControls isSideOpen={isSideOpen} setIsSideOpen={setIsSideOpen} hideMenuButton={hideMenuButton} />
-            </div>
+            {/* 오른쪽: 검색 토글(모바일) + 사용자 컨트롤 — 미니멀 헤더에서는 숨김 */}
+            {!isMinimalHeader ? (
+              <div className="flex shrink-0 items-center gap-1 xl:gap-4">
+                {!hideSearchBar && !isXl ? (
+                  <IconButton aria-label="검색" onClick={() => setIsSearchOpen((prev) => !prev)}>
+                    <Search className="text-primary" />
+                  </IconButton>
+                ) : null}
+                <UserControls isSideOpen={isSideOpen} setIsSideOpen={setIsSideOpen} hideMenuButton={hideMenuButton} />
+              </div>
+            ) : null}
           </div>
 
           {/* 모바일 검색바 - 아코디언 */}

--- a/src/features/login/Login.tsx
+++ b/src/features/login/Login.tsx
@@ -3,25 +3,31 @@ import { ROUTES } from '@/constants/routes'
 import { TitleSection } from './components/TitleSection'
 import { SocialLoginButtons } from './components/SocialLoginButtons'
 import { LoginForm } from './components/LoginForm'
+import Logo from '@/components/Logo'
 
 function Login() {
   return (
-    <div className="flex h-screen flex-col items-center justify-center bg-[#F3F4F6]">
-      <div className="flex h-full min-w-full flex-col items-center gap-10 bg-white px-8 py-10 md:h-auto md:min-w-100 md:rounded-[20px]">
-        <TitleSection title="로그인" />
-        <LoginForm />
-        <div className="flex w-full flex-col gap-3">
-          <div className="flex w-full items-center gap-4">
-            <div role="separator" className="h-px flex-1 bg-black/10" />
-            <span className="text-xs text-gray-500">소셜 계정으로 로그인</span>
-            <div role="separator" className="h-px flex-1 bg-black/10" />
-          </div>
-          <SocialLoginButtons />
-          <div className="mt-3 flex w-full justify-center gap-1">
-            <span className="text-sm">아직 계정이 없으신가요?</span>
-            <Link href={ROUTES.SIGNUP} className="text-primary-300 text-sm font-bold">
-              회원가입하기
-            </Link>
+    <div className="flex min-h-screen flex-col items-center justify-start bg-[#F3F4F6] py-20">
+      <div className="flex min-w-full flex-col items-center gap-2 md:min-w-132.5">
+        <Logo />
+        <div className="flex flex-col items-center gap-9">
+          <TitleSection title="우리 아이를 위한 믿음직한 선택" desc="로그인하고 반려동물 이웃과의 특별한 일상을 시작해보세요" />
+          <div className="bg-surface border-outline-variant/10 flex h-full min-w-full flex-col items-center gap-9 border px-10 py-7 shadow-2xl md:h-auto md:min-w-100 md:rounded-3xl">
+            <LoginForm />
+            <div className="flex w-full flex-col gap-3">
+              <div className="flex w-full items-center gap-4">
+                <div role="separator" className="h-px flex-1 bg-black/10" />
+                <span className="text-xs text-gray-500">소셜 계정으로 로그인</span>
+                <div role="separator" className="h-px flex-1 bg-black/10" />
+              </div>
+              <SocialLoginButtons />
+              <div className="mt-3 flex w-full justify-center gap-1">
+                <span className="text-sm">아직 계정이 없으신가요?</span>
+                <Link href={ROUTES.SIGNUP} className="text-primary-300 text-sm font-bold">
+                  회원가입하기
+                </Link>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/src/features/login/components/LoginForm.tsx
+++ b/src/features/login/components/LoginForm.tsx
@@ -11,6 +11,7 @@ import { authValidationRules } from '@/lib/utils/validation/authValidationRules'
 import { useUserStore } from '@/store/userStore'
 import axios from 'axios'
 import { useEffect } from 'react'
+import { TitleSection } from './TitleSection'
 
 interface LoginFormValues {
   email: string
@@ -68,7 +69,8 @@ export function LoginForm() {
   }, [email, password, clearErrors])
 
   return (
-    <form className="w-full" onSubmit={handleSubmit(onSubmit)}>
+    <form className="flex w-full flex-col gap-10" onSubmit={handleSubmit(onSubmit)}>
+      <TitleSection title="로그인" desc="계정에 로그인하여 더 많은 기능을 이용해보세요" size="sm" />
       <fieldset className="flex flex-col gap-2">
         <legend className="sr-only">로그인폼</legend>
         <div className="flex flex-col gap-4">

--- a/src/features/login/components/TitleSection.tsx
+++ b/src/features/login/components/TitleSection.tsx
@@ -1,3 +1,4 @@
+import Logo from '@/components/Logo'
 import Link from 'next/link'
 
 interface TitleSectionProps {
@@ -5,18 +6,24 @@ interface TitleSectionProps {
   desc?: string
   link?: string
   linkPath?: string
+  size?: 'sm' | 'md'
 }
 
-export function TitleSection({ title, desc, link, linkPath }: TitleSectionProps) {
+export function TitleSection({ title, desc, link, linkPath, size = 'md' }: TitleSectionProps) {
+  const titleClass = size === 'sm' ? 'heading-h4' : 'heading-h3'
+  const descClass = 'text-sm text-on-surface-muted'
+
   return (
-    <div className="flex flex-col items-center gap-1">
-      <h1 className="heading-h4">{title}</h1>
-      {desc ? <span className="text-sm">{desc}</span> : null}
-      {link && linkPath ? (
-        <Link href={linkPath} className="text-primary-300 text-sm font-bold">
-          {link}
-        </Link>
-      ) : null}
+    <div className="flex flex-col items-center gap-2">
+      <div className="flex flex-col items-center gap-1">
+        <h1 className={titleClass}>{title}</h1>
+        {desc ? <span className={descClass}>{desc}</span> : null}
+        {link && linkPath ? (
+          <Link href={linkPath} className="text-primary-300 text-sm font-bold">
+            {link}
+          </Link>
+        ) : null}
+      </div>
     </div>
   )
 }

--- a/src/features/profile-update/components/ProfileUpdateBaseForm.tsx
+++ b/src/features/profile-update/components/ProfileUpdateBaseForm.tsx
@@ -323,7 +323,7 @@ export default function ProfileUpdateBaseForm({ myData }: ProfileUpdateBaseFormP
                       buttonText="중복체크"
                       size="text-sm"
                       buttonSize="md"
-                      buttonClassName="bg-primary-200 text-sm text-white cursor-pointer font-semibold py-[10px]"
+                      buttonClassName="bg-primary-200 text-sm text-white cursor-pointer font-semibold py-[10px] !h-auto"
                       inputClass="md:py-[10px]"
                       checkResult={checkResult}
                       onButtonClick={handleNicknameCheck}

--- a/src/features/signup/Signup.tsx
+++ b/src/features/signup/Signup.tsx
@@ -1,13 +1,22 @@
 import { TitleSection } from '../login/components/TitleSection'
 import { ROUTES } from '@/constants/routes'
 import { SignUpForm } from './components/SignUpForm'
+import Logo from '@/components/Logo'
 
 export default function Signup() {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-baseline bg-white py-10 md:justify-center md:bg-[#F3F4F6]">
-      <div className="flex min-w-full flex-col items-center gap-9 rounded-[20px] bg-white px-5 md:min-w-132.5 md:py-10">
-        <TitleSection title="회원가입" desc="이미 계정이 있으신가요?" link="로그인하기" linkPath={ROUTES.LOGIN} />
-        <SignUpForm />
+    <div className="flex min-h-screen flex-col items-center justify-baseline bg-[#F3F4F6] py-20 md:justify-center">
+      <div className="flex min-w-full flex-col items-center gap-2 md:min-w-132.5">
+        <Logo />
+        <div className="flex flex-col items-center gap-9">
+          <TitleSection
+            title="커들마켓에 오신것을 환영합니다!"
+            desc="반려동물과 이웃을 잇는 따뜻한 커뮤니티"
+            // link="로그인하기"
+            // linkPath={ROUTES.LOGIN}
+          />
+          <SignUpForm />
+        </div>
       </div>
     </div>
   )

--- a/src/features/signup/components/BirthDateField.tsx
+++ b/src/features/signup/components/BirthDateField.tsx
@@ -20,7 +20,8 @@ const validateBirthDate = (value: string): string | true => {
 
   const age = today.getFullYear() - birthDate.getFullYear()
   const isBeforeBirthday =
-    today.getMonth() < birthDate.getMonth() || (today.getMonth() === birthDate.getMonth() && today.getDate() < birthDate.getDate())
+    today.getMonth() < birthDate.getMonth() ||
+    (today.getMonth() === birthDate.getMonth() && today.getDate() < birthDate.getDate())
   const actualAge = isBeforeBirthday ? age - 1 : age
 
   if (!value || value === '--') return '생년월일을 입력해주세요'
@@ -41,8 +42,10 @@ export function BirthDateField<T extends FieldValues>({ control }: BirthDateFiel
   }
 
   return (
-    <div className="flex flex-col gap-2.5">
-      <RequiredLabel htmlFor="signup-birthdate">생년월일</RequiredLabel>
+    <div className="flex flex-col">
+      <RequiredLabel htmlFor="signup-birthdate" labelClass="text-sm">
+        생년월일
+      </RequiredLabel>
       <Controller
         name={'birthDate' as Path<T>}
         control={control}
@@ -76,7 +79,7 @@ export function BirthDateField<T extends FieldValues>({ control }: BirthDateFiel
                     updateDate(newValue, month, day)
                   }}
                   onBlur={handleBlur}
-                  className="focus:border-primary-500 w-full rounded-lg border border-gray-400 px-3 py-2 text-sm placeholder:text-gray-400 focus:outline-none md:py-3"
+                  className="focus:border-primary-500 w-full rounded-lg border border-gray-400 bg-white px-3 py-2 text-sm placeholder:text-gray-400 focus:outline-none md:py-3"
                 />
                 <input
                   type="text"
@@ -89,7 +92,7 @@ export function BirthDateField<T extends FieldValues>({ control }: BirthDateFiel
                     updateDate(year, newValue, day)
                   }}
                   onBlur={handleBlur}
-                  className="focus:border-primary-500 w-full rounded-lg border border-gray-400 px-3 py-2 text-sm placeholder:text-gray-400 focus:outline-none md:py-3"
+                  className="focus:border-primary-500 w-full rounded-lg border border-gray-400 bg-white px-3 py-2 text-sm placeholder:text-gray-400 focus:outline-none md:py-3"
                 />
                 <input
                   type="text"
@@ -102,7 +105,7 @@ export function BirthDateField<T extends FieldValues>({ control }: BirthDateFiel
                     updateDate(year, month, newValue)
                   }}
                   onBlur={handleBlur}
-                  className="focus:border-primary-500 w-full rounded-lg border border-gray-400 px-3 py-2 text-sm placeholder:text-gray-400 focus:outline-none md:py-3"
+                  className="focus:border-primary-500 w-full rounded-lg border border-gray-400 bg-white px-3 py-2 text-sm placeholder:text-gray-400 focus:outline-none md:py-3"
                 />
               </div>
               {fieldState.error ? <p className="text-danger-500 text-xs font-semibold">{fieldState.error.message}</p> : null}

--- a/src/features/signup/components/EmailValidCode.tsx
+++ b/src/features/signup/components/EmailValidCode.tsx
@@ -18,7 +18,14 @@ interface EmailValidCodeProps {
   clearErrors: UseFormClearErrors<SignUpFormValues>
 }
 
-export function EmailValidCode({ register, errors, control, setIsEmailVerified, setIsEmailCodeVerified, clearErrors }: EmailValidCodeProps) {
+export function EmailValidCode({
+  register,
+  errors,
+  control,
+  setIsEmailVerified,
+  setIsEmailCodeVerified,
+  clearErrors,
+}: EmailValidCodeProps) {
   const [emailCheckResult, setEmailCheckResult] = useState<{
     status: 'idle' | 'success' | 'error'
     message: string
@@ -34,57 +41,50 @@ export function EmailValidCode({ register, errors, control, setIsEmailVerified, 
   const email = useWatch({ control, name: 'email' })
   const emailCode = useWatch({ control, name: 'emailCode' })
 
-  const handleEmailCheck = async () => {
+  const handleEmailVerify = async () => {
+    if (!email || email.trim() === '') {
+      setEmailCheckResult({ status: 'error', message: '이메일을 입력해주세요.' })
+      setIsEmailVerified(false)
+      return
+    }
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+    if (!emailRegex.test(email)) {
+      setEmailCheckResult({ status: 'error', message: '올바른 이메일 형식을 입력해주세요.' })
+      setIsEmailVerified(false)
+      return
+    }
     setIsEmailChecking(true)
     try {
-      const response = await checkEmail(email)
-
-      if (response.data) {
-        setEmailCheckResult({
-          status: 'success',
-          message: response.message,
-        })
-        setIsEmailVerified(true)
-        clearErrors('email')
-      } else {
+      const checkResponse = await checkEmail(email)
+      if (!checkResponse.data) {
         setEmailCheckResult({
           status: 'error',
-          message: response.message,
+          message: checkResponse.message || '이미 가입된 이메일이에요. 로그인하시거나 다른 이메일을 사용해주세요.',
         })
         setIsEmailVerified(false)
+        return
+      }
+      setIsEmailVerified(true)
+      clearErrors('email')
+      try {
+        await sendEmailValidCode(email)
+        setEmailCheckResult({
+          status: 'success',
+          message: '✓ 인증코드를 발송했어요. 이메일을 확인해주세요.',
+        })
+      } catch (error) {
+        if (isAxiosError(error)) {
+          setEmailCheckResult({
+            status: 'error',
+            message: error.response?.data?.message || '인증코드 발송에 실패했어요. 잠시 후 다시 시도해주세요.',
+          })
+        } else {
+          setEmailCheckResult({ status: 'error', message: '네트워크 오류가 발생했어요.' })
+        }
       }
     } catch {
-      setEmailCheckResult({
-        status: 'error',
-        message: '이메일 확인 중 오류가 발생했습니다.',
-      })
+      setEmailCheckResult({ status: 'error', message: '이메일 확인 중 오류가 발생했어요.' })
       setIsEmailVerified(false)
-    } finally {
-      setIsEmailChecking(false)
-    }
-  }
-
-  const handleSendValidCode = async () => {
-    setIsEmailChecking(true)
-    try {
-      await sendEmailValidCode(email)
-      setEmailCheckResult({
-        status: 'success',
-        message: '인증 번호를 발송했습니다.',
-      })
-    } catch (error) {
-      console.error('인증코드 발송 실패:', error)
-      if (isAxiosError(error)) {
-        setEmailCheckResult({
-          status: 'error',
-          message: error.response?.data?.message || '인증코드 발송에 실패했습니다.',
-        })
-      } else {
-        setEmailCheckResult({
-          status: 'error',
-          message: '네트워크 오류가 발생했습니다.',
-        })
-      }
     } finally {
       setIsEmailChecking(false)
     }
@@ -119,33 +119,57 @@ export function EmailValidCode({ register, errors, control, setIsEmailVerified, 
     }
   }
 
+  const isCodeSent = emailCheckResult.status === 'success'
+  const isCodeVerified = codeCheckResult.status === 'success'
+
+  const emailHelperText = isCodeVerified
+    ? '✓ 이메일 인증이 완료되었어요.'
+    : isCodeSent
+      ? '메일이 도착하지 않으면 스팸함을 확인하거나 재발송해주세요.'
+      : '사용 가능 여부를 확인한 뒤 인증코드를 보내드려요.'
+  const codeHelperText = isCodeVerified
+    ? '✓ 이메일 인증이 완료되었어요.'
+    : isCodeSent
+      ? '이메일로 받은 인증코드를 입력해주세요.'
+      : '이메일 인증 후 인증코드가 발송돼요.'
+
   return (
-    <div className="flex flex-col gap-2.5">
-      <RequiredLabel htmlFor="signup-email">이메일</RequiredLabel>
+    <div className="flex flex-col">
+      <RequiredLabel htmlFor="signup-email" labelClass="text-sm">
+        이메일
+      </RequiredLabel>
       <div className="flex flex-col gap-4">
-        <InputWithButton
-          id="signup-email"
-          type="email"
-          placeholder="example@gmail.com"
-          error={errors.email}
-          checkResult={emailCheckResult}
-          registration={register('email', authValidationRules.email)}
-          buttonText={isEmailChecking ? (emailCheckResult.status === 'success' ? '전송 중...' : '체크 중...') : emailCheckResult.status === 'success' ? '인증코드 전송' : '중복체크'}
-          onButtonClick={emailCheckResult.status === 'success' ? handleSendValidCode : handleEmailCheck}
-          buttonDisabled={isEmailChecking}
-        />
-        <InputWithButton
-          id="signup-email-code"
-          type="text"
-          placeholder="전송된 코드를 입력해주세요"
-          error={errors.emailCode}
-          checkResult={codeCheckResult}
-          registration={register('emailCode', authValidationRules.emailCode)}
-          buttonText={isCodeChecking ? '확인 중...' : '인증코드 확인'}
-          buttonClassName="cursor-pointer bg-gray-100 font-semibold text-gray-900"
-          onButtonClick={handleCheckValidCode}
-          buttonDisabled={isCodeChecking}
-        />
+        <div className="flex flex-col gap-1.5">
+          <InputWithButton
+            id="signup-email"
+            type="email"
+            placeholder="example@gmail.com"
+            error={errors.email}
+            checkResult={emailCheckResult}
+            registration={register('email', authValidationRules.email)}
+            buttonText={isEmailChecking ? '확인 중...' : isCodeSent ? '재발송' : '이메일 인증'}
+            buttonClassName="bg-primary-100 text-primary cursor-pointer font-semibold text-sm"
+            onButtonClick={handleEmailVerify}
+            buttonDisabled={isEmailChecking || isCodeVerified}
+            autoFocus
+          />
+          <p className="text-xs text-gray-500">{emailHelperText}</p>
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <InputWithButton
+            id="signup-email-code"
+            type="text"
+            placeholder="전송된 코드를 입력해주세요"
+            error={errors.emailCode}
+            checkResult={codeCheckResult}
+            registration={register('emailCode', authValidationRules.emailCode)}
+            buttonText={isCodeChecking ? '확인 중...' : '인증코드 확인'}
+            buttonClassName="cursor-pointer bg-gray-100 font-semibold text-gray-900 text-sm"
+            onButtonClick={handleCheckValidCode}
+            buttonDisabled={isCodeChecking || !isCodeSent || isCodeVerified}
+          />
+          <p className="text-xs text-gray-500">{codeHelperText}</p>
+        </div>
       </div>
     </div>
   )

--- a/src/features/signup/components/NameField.tsx
+++ b/src/features/signup/components/NameField.tsx
@@ -11,8 +11,10 @@ interface NameFieldProps {
 
 export function NameField({ register, errors }: NameFieldProps) {
   return (
-    <div className="flex flex-col gap-2.5">
-      <RequiredLabel htmlFor="signup-name">이름</RequiredLabel>
+    <div className="flex flex-col">
+      <RequiredLabel htmlFor="signup-name" labelClass="text-sm">
+        이름
+      </RequiredLabel>
       <InputField
         id="signup-name"
         type="text"
@@ -23,7 +25,6 @@ export function NameField({ register, errors }: NameFieldProps) {
         className="flex flex-col gap-2.5"
         error={errors.name}
         registration={register('name', signupValidationRules.name)}
-        autoFocus
       />
     </div>
   )

--- a/src/features/signup/components/NicknameField.tsx
+++ b/src/features/signup/components/NicknameField.tsx
@@ -84,8 +84,10 @@ export function NicknameField<T extends FieldValues>({
   }, [nickname, setIsNicknameVerified, setCheckResult])
 
   return (
-    <div className="flex flex-col gap-2.5">
-      <RequiredLabel htmlFor="signup-nickname">닉네임</RequiredLabel>
+    <div className="flex flex-col">
+      <RequiredLabel htmlFor="signup-nickname" labelClass="text-sm">
+        닉네임
+      </RequiredLabel>
       <InputWithButton
         id="signup-nickname"
         type="text"
@@ -96,6 +98,7 @@ export function NicknameField<T extends FieldValues>({
         buttonText={isChecking ? '체크 중...' : '중복체크'}
         onButtonClick={handleNicknameCheck}
         buttonDisabled={isChecking}
+        buttonClassName="text-sm"
       />
     </div>
   )

--- a/src/features/signup/components/PasswordField.tsx
+++ b/src/features/signup/components/PasswordField.tsx
@@ -3,7 +3,14 @@
 import InputField from '@/components/commons/InputField'
 import RequiredLabel from '@/components/commons/RequiredLabel'
 import type { SignUpFormValues } from './SignUpForm'
-import { type UseFormRegister, type FieldErrors, type Control, type UseFormSetError, type UseFormClearErrors, useWatch } from 'react-hook-form'
+import {
+  type UseFormRegister,
+  type FieldErrors,
+  type Control,
+  type UseFormSetError,
+  type UseFormClearErrors,
+  useWatch,
+} from 'react-hook-form'
 import { authValidationRules } from '@/lib/utils/validation/authValidationRules'
 import { signupValidationRules } from '../validationRules'
 import { useMemo, useEffect } from 'react'
@@ -41,9 +48,11 @@ export function PasswordField({ register, errors, control, setError, clearErrors
   }, [password, passwordConfirm, setError, clearErrors])
 
   return (
-    <div className="flex flex-col gap-2.5">
-      <RequiredLabel htmlFor="signup-password">비밀번호</RequiredLabel>
-      <div className="flex flex-col gap-4">
+    <div className="flex flex-col">
+      <RequiredLabel htmlFor="signup-password" labelClass="text-sm">
+        비밀번호
+      </RequiredLabel>
+      <div className="flex flex-col gap-1">
         <InputField
           id="signup-password"
           type="password"

--- a/src/features/signup/components/SignUpForm.tsx
+++ b/src/features/signup/components/SignUpForm.tsx
@@ -18,6 +18,9 @@ import { AnimatePresence } from 'framer-motion'
 import InlineNotification from '@/components/commons/InlineNotification'
 import { isAxiosError } from 'axios'
 import type { ToastType } from '@/types/toast'
+import { TitleSection } from '@/features/login/components/TitleSection'
+import Link from 'next/link'
+import { ROUTES } from '@/constants/routes'
 
 export interface SignUpFormValues {
   email: string
@@ -80,15 +83,7 @@ export function SignUpForm() {
       hasError = true
     }
 
-    if (!isEmailVerified) {
-      setError('email', {
-        type: 'manual',
-        message: '이메일 중복 확인을 완료해주세요.',
-      })
-      hasError = true
-    }
-
-    if (!isEmailCodeVerified) {
+    if (!isEmailVerified || !isEmailCodeVerified) {
       setError('emailCode', {
         type: 'manual',
         message: '이메일 인증을 완료해주세요.',
@@ -143,10 +138,23 @@ export function SignUpForm() {
   }
 
   return (
-    <form className="w-full" onSubmit={handleSubmit(onSubmit)}>
+    <form
+      className="bg-surface border-outline-variant/10 flex w-full flex-col gap-14 rounded-3xl border px-10 shadow-2xl md:py-7"
+      onSubmit={handleSubmit(onSubmit)}
+    >
+      <TitleSection title="회원가입" desc="몇 가지 정보만 입력하면 바로 시작할 수 있어요" size="sm" />
       <fieldset className="flex flex-col gap-9">
         <legend className="sr-only">회원가입폼</legend>
         <div className="flex flex-col gap-6">
+          <EmailValidCode
+            register={register}
+            errors={errors}
+            control={control}
+            setIsEmailVerified={setIsEmailVerified}
+            setIsEmailCodeVerified={setIsEmailCodeVerified}
+            clearErrors={clearErrors}
+          />
+          <PasswordField register={register} errors={errors} control={control} setError={setError} clearErrors={clearErrors} />
           <NameField register={register} errors={errors} />
           <NicknameField
             register={register}
@@ -157,17 +165,15 @@ export function SignUpForm() {
             checkResult={checkResult}
             setCheckResult={setCheckResult}
           />
-          <AddressField<SignUpFormValues> control={control} setValue={setValue} primaryName="addressSido" secondaryName="addressGugun" />
           <BirthDateField control={control} />
-          <EmailValidCode
-            register={register}
-            errors={errors}
+          <AddressField<SignUpFormValues>
             control={control}
-            setIsEmailVerified={setIsEmailVerified}
-            setIsEmailCodeVerified={setIsEmailCodeVerified}
-            clearErrors={clearErrors}
+            setValue={setValue}
+            primaryName="addressSido"
+            secondaryName="addressGugun"
+            labelClass="text-sm"
+            layoutClass="gap-0"
           />
-          <PasswordField register={register} errors={errors} control={control} setError={setError} clearErrors={clearErrors} />
         </div>
         <AnimatePresence>
           {signupNotification ? (
@@ -176,9 +182,20 @@ export function SignUpForm() {
             </InlineNotification>
           ) : null}
         </AnimatePresence>
-        <Button size="md" className="bg-primary-600 w-full cursor-pointer text-white" type="submit" disabled={isSubmitting}>
+        <Button
+          size="md"
+          className="bg-primary-600 hover:bg-primary-700 w-full cursor-pointer text-white transition-colors"
+          type="submit"
+          disabled={isSubmitting}
+        >
           {isSubmitting ? '가입 중...' : '회원가입'}
         </Button>
+        <p className="text-center text-sm text-gray-500">
+          이미 계정이 있으신가요?{' '}
+          <Link href={ROUTES.LOGIN} className="text-primary font-semibold hover:underline">
+            로그인하기
+          </Link>
+        </p>
       </fieldset>
     </form>
   )


### PR DESCRIPTION
## Summary

### 페이지 레이아웃 — 로그인/회원가입 공통
- 상단에 `Logo` 노출 + 카드형 컨테이너 (`shadow-2xl`, `rounded-3xl`)
- `TitleSection`을 두 단계로 분리: 외부 큰 캐치프레이즈 + 카드 내부 `sm` 사이즈 소제목
- 회원가입 카피: "커들마켓에 오신것을 환영합니다! / 반려동물과 이웃을 잇는 따뜻한 커뮤니티"
- 로그인 카피: 외부 "우리 아이를 위한 믿음직한 선택", 카드 내부 `sm` "로그인"
- 회원가입은 일반 가입 전용 — 소셜 가입 영역 제거, 하단에 "이미 계정이 있으신가요? 로그인하기" 링크

### 회원가입 폼
- 필드 순서 재배치: 이메일 → 비밀번호 → 이름 → 닉네임 → 생년월일 → 주소
- 이메일 인증 흐름 통합: `이메일 인증` 1회 클릭으로 중복 확인 + 코드 발송 자동 연쇄
- 빈 값/형식 검증 추가, 버튼 텍스트 `이메일 인증` / `재발송`
- 상태별 helper text 분기 (초기 / 코드 발송 후 / 인증 완료), 인증 완료 시 input/버튼 disabled
- autoFocus를 `NameField` → `EmailValidCode`(이메일 입력)로 이동
- 회원가입 버튼 hover (`hover:bg-primary-700 transition-colors`)

### 공통 컴포넌트
- `InputWithButton`: input/button 높이 일치 (`py-2 md:py-2.5` / `h-10 md:h-11`), `autoFocus` prop, `buttonClassName` cn merge, hover/disabled 톤 정리
- `SelectDropdown`: `bg-white` 적용
- `TitleSection`: `size?: 'sm' | 'md'` prop 추가, desc 톤 통일
- `BirthDateField`: input `bg-white`로 통일

### 헤더
- `MINIMAL_HEADER_PATHS` 상수 추가 (`/login`, `/signup`, `/find-password`)
- 인증 페이지에서 데스크탑 nav + 우측 `UserControls` 숨김 (로고만 표시)

### 기타
- `ProfileUpdateBaseForm`: `InputWithButton` 강제 height 풀기 위한 `!h-auto` 오버라이드

## Test plan
- [ ] `/login` 페이지: 외부 큰 캐치프레이즈 + 카드 내부 작은 소제목 노출 확인
- [ ] `/signup` 페이지: 외부 큰 캐치프레이즈 + 회원가입 폼 카드 노출 확인
- [ ] `/login`, `/signup`, `/find-password` 에서 헤더가 로고만 노출되는지 확인
- [ ] 회원가입 필드 순서 (이메일 → 비밀번호 → 이름 → 닉네임 → 생년월일 → 주소) 확인
- [ ] 페이지 진입 시 이메일 입력에 autoFocus가 들어가는지 확인
- [ ] 이메일 입력 후 `이메일 인증` 한 번 클릭으로 중복 확인 + 코드 발송 자동 연쇄 동작 확인
- [ ] 이메일 빈 값/잘못된 형식일 때 인증이 차단되는지 확인
- [ ] 코드 발송 후 버튼이 `재발송`으로 바뀌고 helper text가 적절히 분기되는지 확인
- [ ] 인증 코드 검증 성공 시 input/버튼이 disabled 되는지 확인
- [ ] `/signup` 하단 "이미 계정이 있으신가요? 로그인하기" 링크 노출 확인 (소셜 가입 영역 없음)
- [ ] 생년월일 select, 거주지 select가 흰색 배경으로 통일됐는지 확인
- [ ] 프로필 수정 페이지에서 `InputWithButton` 높이가 정상인지 확인 (regression check)

closes #744