### PR TITLE
refactor: 프로필 수정 페이지 사이드바 재구성 및 회원탈퇴 진입점 복구

### DIFF
--- a/src/components/profile/ProfileData.tsx
+++ b/src/components/profile/ProfileData.tsx
@@ -51,6 +51,17 @@ interface ProfileDataProps {
   unblockUser?: () => void
   summaryCounts?: ProfileSummaryCounts
   enableImageUpload?: boolean
+  showJoinDate?: boolean
+}
+
+function formatJoinDate(iso?: string) {
+  if (!iso) return ''
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return ''
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}.${month}.${day}`
 }
 
 const SUMMARY_ITEMS: Array<{ key: keyof ProfileSummaryCounts; label: string }> = [
@@ -67,6 +78,7 @@ export default function ProfileData({
   unblockUser,
   summaryCounts,
   enableImageUpload,
+  showJoinDate,
 }: ProfileDataProps) {
   const user = useUserStore((state) => state.user)
   const updateUserProfile = useUserStore((state) => state.updateUserProfile)
@@ -336,6 +348,12 @@ export default function ProfileData({
               </button>
             ) : null}
           </div>
+          {showJoinDate ? (
+            <div className="border-outline-variant/40 flex items-center justify-between border-t pt-4 text-sm">
+              <span className="text-on-surface-muted text-[13px]">가입일</span>
+              <span className="text-on-surface-muted text-[13px]">{formatJoinDate(data?.createdAt)}</span>
+            </div>
+          ) : null}
           {isMyProfile && summaryCounts ? (
             <div className="border-outline-variant/40 grid grid-cols-3 gap-2 border-t pt-4">
               {SUMMARY_ITEMS.map((item) => (

--- a/src/components/profile/ProfileData.tsx
+++ b/src/components/profile/ProfileData.tsx
@@ -38,9 +38,13 @@ export interface MyPageData {
   createdAt: string
   isBlocked?: boolean
   isReported?: boolean
+  provider?: 'LOCAL' | 'GOOGLE' | 'KAKAO'
 }
 
+type ProfileDataVariant = 'mypage' | 'profile-edit' | 'user-profile'
+
 interface ProfileDataProps {
+  variant?: ProfileDataVariant
   data?: MyPageData
   setIsWithdrawModalOpen?: Dispatch<SetStateAction<boolean>>
   setIsReportModalOpen?: Dispatch<SetStateAction<boolean>>
@@ -52,6 +56,16 @@ interface ProfileDataProps {
   enableImageUpload?: boolean
 }
 
+function formatJoinDate(iso?: string) {
+  if (!iso) return ''
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return ''
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}.${month}.${day}`
+}
+
 const SUMMARY_ITEMS: Array<{ key: keyof ProfileSummaryCounts; label: string }> = [
   { key: 'sales', label: '판매내역' },
   { key: 'purchases', label: '구매내역' },
@@ -59,6 +73,7 @@ const SUMMARY_ITEMS: Array<{ key: keyof ProfileSummaryCounts; label: string }> =
 ]
 
 export default function ProfileData({
+  variant = 'mypage',
   data,
   isMyProfile,
   setIsReportModalOpen,
@@ -67,6 +82,7 @@ export default function ProfileData({
   summaryCounts,
   enableImageUpload,
 }: ProfileDataProps) {
+  const isProfileEditVariant = variant === 'profile-edit'
   const user = useUserStore((state) => state.user)
   const updateUserProfile = useUserStore((state) => state.updateUserProfile)
   const queryClient = useQueryClient()
@@ -294,7 +310,11 @@ export default function ProfileData({
                   </span>
                 ) : null}
                 <p className="text-text-primary text-base leading-none font-semibold">{data?.nickname}</p>
-                <p className="text-text-primary text-sm leading-none">{`${data?.addressSido} ${data?.addressGugun}`}</p>
+                {isProfileEditVariant ? (
+                  <p className="text-on-surface-muted text-sm leading-none break-all">{data?.email}</p>
+                ) : (
+                  <p className="text-text-primary text-sm leading-none">{`${data?.addressSido} ${data?.addressGugun}`}</p>
+                )}
               </div>
             ) : (
               // 모바일 내 정보
@@ -314,27 +334,36 @@ export default function ProfileData({
               </div>
             )}
           </div>
-          <div className="flex w-full flex-col gap-1">
-            <p
-              ref={introRef}
-              className={cn(
-                'w-full text-sm font-normal break-words whitespace-pre-wrap text-gray-500',
-                !isIntroExpanded && 'line-clamp-3'
-              )}
-            >
-              {data?.introduction || '소개글을 작성해주세요'}
-            </p>
-            {data?.introduction && (isIntroExpanded || isIntroClamped) ? (
-              <button
-                type="button"
-                onClick={() => setIsIntroExpanded((prev) => !prev)}
-                className="cursor-pointer self-start text-xs text-gray-400 hover:underline"
-                aria-expanded={isIntroExpanded}
+          {isProfileEditVariant ? (
+            <div className="border-outline-variant/40 flex flex-col gap-2 border-t pt-4">
+              <div className="flex items-center justify-between text-sm">
+                <span className="text-on-surface-muted">가입일</span>
+                <span className="text-text-primary font-medium">{formatJoinDate(data?.createdAt)}</span>
+              </div>
+            </div>
+          ) : (
+            <div className="flex w-full flex-col gap-1">
+              <p
+                ref={introRef}
+                className={cn(
+                  'w-full text-sm font-normal break-words whitespace-pre-wrap text-gray-500',
+                  !isIntroExpanded && 'line-clamp-3'
+                )}
               >
-                {isIntroExpanded ? '접기' : '더보기'}
-              </button>
-            ) : null}
-          </div>
+                {data?.introduction || '소개글을 작성해주세요'}
+              </p>
+              {data?.introduction && (isIntroExpanded || isIntroClamped) ? (
+                <button
+                  type="button"
+                  onClick={() => setIsIntroExpanded((prev) => !prev)}
+                  className="cursor-pointer self-start text-xs text-gray-400 hover:underline"
+                  aria-expanded={isIntroExpanded}
+                >
+                  {isIntroExpanded ? '접기' : '더보기'}
+                </button>
+              ) : null}
+            </div>
+          )}
           {isMyProfile && summaryCounts ? (
             <div className="border-outline-variant/40 grid grid-cols-3 gap-2 border-t pt-4">
               {SUMMARY_ITEMS.map((item) => (

--- a/src/components/profile/ProfileData.tsx
+++ b/src/components/profile/ProfileData.tsx
@@ -41,10 +41,7 @@ export interface MyPageData {
   provider?: 'LOCAL' | 'GOOGLE' | 'KAKAO'
 }
 
-type ProfileDataVariant = 'mypage' | 'profile-edit' | 'user-profile'
-
 interface ProfileDataProps {
-  variant?: ProfileDataVariant
   data?: MyPageData
   setIsWithdrawModalOpen?: Dispatch<SetStateAction<boolean>>
   setIsReportModalOpen?: Dispatch<SetStateAction<boolean>>
@@ -56,16 +53,6 @@ interface ProfileDataProps {
   enableImageUpload?: boolean
 }
 
-function formatJoinDate(iso?: string) {
-  if (!iso) return ''
-  const date = new Date(iso)
-  if (Number.isNaN(date.getTime())) return ''
-  const year = date.getFullYear()
-  const month = String(date.getMonth() + 1).padStart(2, '0')
-  const day = String(date.getDate()).padStart(2, '0')
-  return `${year}.${month}.${day}`
-}
-
 const SUMMARY_ITEMS: Array<{ key: keyof ProfileSummaryCounts; label: string }> = [
   { key: 'sales', label: '판매내역' },
   { key: 'purchases', label: '구매내역' },
@@ -73,7 +60,6 @@ const SUMMARY_ITEMS: Array<{ key: keyof ProfileSummaryCounts; label: string }> =
 ]
 
 export default function ProfileData({
-  variant = 'mypage',
   data,
   isMyProfile,
   setIsReportModalOpen,
@@ -82,7 +68,6 @@ export default function ProfileData({
   summaryCounts,
   enableImageUpload,
 }: ProfileDataProps) {
-  const isProfileEditVariant = variant === 'profile-edit'
   const user = useUserStore((state) => state.user)
   const updateUserProfile = useUserStore((state) => state.updateUserProfile)
   const queryClient = useQueryClient()
@@ -310,11 +295,7 @@ export default function ProfileData({
                   </span>
                 ) : null}
                 <p className="text-text-primary text-base leading-none font-semibold">{data?.nickname}</p>
-                {isProfileEditVariant ? (
-                  <p className="text-on-surface-muted text-sm leading-none break-all">{data?.email}</p>
-                ) : (
-                  <p className="text-text-primary text-sm leading-none">{`${data?.addressSido} ${data?.addressGugun}`}</p>
-                )}
+                <p className="text-text-primary text-sm leading-none">{`${data?.addressSido} ${data?.addressGugun}`}</p>
               </div>
             ) : (
               // 모바일 내 정보
@@ -334,36 +315,27 @@ export default function ProfileData({
               </div>
             )}
           </div>
-          {isProfileEditVariant ? (
-            <div className="border-outline-variant/40 flex flex-col gap-2 border-t pt-4">
-              <div className="flex items-center justify-between text-sm">
-                <span className="text-on-surface-muted">가입일</span>
-                <span className="text-text-primary font-medium">{formatJoinDate(data?.createdAt)}</span>
-              </div>
-            </div>
-          ) : (
-            <div className="flex w-full flex-col gap-1">
-              <p
-                ref={introRef}
-                className={cn(
-                  'w-full text-sm font-normal break-words whitespace-pre-wrap text-gray-500',
-                  !isIntroExpanded && 'line-clamp-3'
-                )}
+          <div className="flex w-full flex-col gap-1">
+            <p
+              ref={introRef}
+              className={cn(
+                'w-full text-sm font-normal break-words whitespace-pre-wrap text-gray-500',
+                !isIntroExpanded && 'line-clamp-3'
+              )}
+            >
+              {data?.introduction || '소개글을 작성해주세요'}
+            </p>
+            {data?.introduction && (isIntroExpanded || isIntroClamped) ? (
+              <button
+                type="button"
+                onClick={() => setIsIntroExpanded((prev) => !prev)}
+                className="cursor-pointer self-start text-xs text-gray-400 hover:underline"
+                aria-expanded={isIntroExpanded}
               >
-                {data?.introduction || '소개글을 작성해주세요'}
-              </p>
-              {data?.introduction && (isIntroExpanded || isIntroClamped) ? (
-                <button
-                  type="button"
-                  onClick={() => setIsIntroExpanded((prev) => !prev)}
-                  className="cursor-pointer self-start text-xs text-gray-400 hover:underline"
-                  aria-expanded={isIntroExpanded}
-                >
-                  {isIntroExpanded ? '접기' : '더보기'}
-                </button>
-              ) : null}
-            </div>
-          )}
+                {isIntroExpanded ? '접기' : '더보기'}
+              </button>
+            ) : null}
+          </div>
           {isMyProfile && summaryCounts ? (
             <div className="border-outline-variant/40 grid grid-cols-3 gap-2 border-t pt-4">
               {SUMMARY_ITEMS.map((item) => (

--- a/src/features/profile-update/ProfileUpdate.tsx
+++ b/src/features/profile-update/ProfileUpdate.tsx
@@ -20,9 +20,6 @@ function ProfileUpdate() {
   const [withdrawError, setWithdrawError] = useState<React.ReactNode | null>(null)
   const { user, _hasHydrated, clearAll, updateUserProfile, setRedirectUrl } = useUserStore()
 
-  const socialDomains = ['gmail', 'kakao']
-  const isSocialLogin = socialDomains.some((domain) => user?.email?.includes(domain))
-
   const isMd = useMediaQuery('(min-width: 768px)')
   const {
     data: myData,
@@ -33,7 +30,7 @@ function ProfileUpdate() {
     queryFn: async () => {
       const data = await fetchGraphQL<{ myProfile: any }>(`
         query MyProfile {
-          myProfile { id email name nickname birthDate profileImageUrl introduction addressSido addressGugun createdAt rating }
+          myProfile { id email name nickname birthDate profileImageUrl introduction addressSido addressGugun createdAt rating provider }
         }
       `)
       return data.myProfile
@@ -41,13 +38,18 @@ function ProfileUpdate() {
     enabled: !!user,
   })
 
+  const isSocialLogin = !!myData?.provider && myData.provider !== 'LOCAL'
+
   const handleWithdraw = async (data: WithDrawFormValues) => {
     try {
-      await fetchGraphQL(`
+      await fetchGraphQL(
+        `
         mutation Withdraw($reason: String!, $detailReason: String!) {
           withdraw(reason: $reason, detailReason: $detailReason) { success }
         }
-      `, { reason: data.reason, detailReason: data.detailReason })
+      `,
+        { reason: data.reason, detailReason: data.detailReason }
+      )
       clearAll()
       router.push(ROUTES.HOME)
     } catch {
@@ -72,6 +74,7 @@ function ProfileUpdate() {
         addressSido: myData.addressSido,
         addressGugun: myData.addressGugun,
         createdAt: myData.createdAt,
+        provider: myData.provider,
       })
     }
   }, [myData, updateUserProfile])
@@ -110,9 +113,9 @@ function ProfileUpdate() {
       <div className="pb-4xl bg-[#F3F4F6] pt-0 md:pt-8">
         <h1 className="sr-only">프로필 수정</h1>
         <div className="mx-auto flex max-w-7xl flex-col gap-0 md:flex-row md:gap-8 md:p-0">
-          {isMd ? <ProfileData setIsWithdrawModalOpen={setIsWithdrawModalOpen} data={myData!} isMyProfile /> : null}
+          {isMd ? <ProfileData variant="profile-edit" data={myData!} isMyProfile /> : null}
           <div className="flex w-full flex-col gap-8 p-5 md:p-0">
-            <ProfileUpdateBaseForm myData={myData!} />
+            <ProfileUpdateBaseForm myData={myData!} onWithdrawClick={() => setIsWithdrawModalOpen(true)} />
             {!isSocialLogin ? <ProfileUpdatePasswordForm /> : null}
           </div>
         </div>

--- a/src/features/profile-update/ProfileUpdate.tsx
+++ b/src/features/profile-update/ProfileUpdate.tsx
@@ -113,7 +113,7 @@ function ProfileUpdate() {
       <div className="pb-4xl bg-[#F3F4F6] pt-0 md:pt-8">
         <h1 className="sr-only">프로필 수정</h1>
         <div className="mx-auto flex max-w-7xl flex-col gap-0 md:flex-row md:gap-8 md:p-0">
-          {isMd ? <ProfileData variant="profile-edit" data={myData!} isMyProfile /> : null}
+          {isMd ? <ProfileData data={myData!} isMyProfile /> : null}
           <div className="flex w-full flex-col gap-8 p-5 md:p-0">
             <ProfileUpdateBaseForm myData={myData!} onWithdrawClick={() => setIsWithdrawModalOpen(true)} />
             {!isSocialLogin ? <ProfileUpdatePasswordForm /> : null}

--- a/src/features/profile-update/ProfileUpdate.tsx
+++ b/src/features/profile-update/ProfileUpdate.tsx
@@ -113,7 +113,7 @@ function ProfileUpdate() {
       <div className="pb-4xl bg-[#F3F4F6] pt-0 md:pt-8">
         <h1 className="sr-only">프로필 수정</h1>
         <div className="mx-auto flex max-w-7xl flex-col gap-0 md:flex-row md:gap-8 md:p-0">
-          {isMd ? <ProfileData data={myData!} isMyProfile /> : null}
+          {isMd ? <ProfileData data={myData!} isMyProfile showJoinDate /> : null}
           <div className="flex w-full flex-col gap-8 p-5 md:p-0">
             <ProfileUpdateBaseForm myData={myData!} onWithdrawClick={() => setIsWithdrawModalOpen(true)} />
             {!isSocialLogin ? <ProfileUpdatePasswordForm /> : null}

--- a/src/features/profile-update/components/ProfileUpdateBaseForm.tsx
+++ b/src/features/profile-update/components/ProfileUpdateBaseForm.tsx
@@ -17,7 +17,6 @@ import { useState, useEffect, useRef } from 'react'
 import { useUserStore } from '@/store/userStore'
 import { uploadImage } from '@/lib/api/products'
 import { useQueryClient } from '@tanstack/react-query'
-import { useMediaQuery } from '@/hooks/useMediaQuery'
 import { Camera } from 'lucide-react'
 import { AnimatePresence } from 'framer-motion'
 import InlineNotification from '@/components/commons/InlineNotification'
@@ -39,8 +38,9 @@ const IMAGE_UPLOAD_ERRORS = {
 
 interface ProfileUpdateBaseFormProps {
   myData?: MyPageData
+  onWithdrawClick: () => void
 }
-export default function ProfileUpdateBaseForm({ myData }: ProfileUpdateBaseFormProps) {
+export default function ProfileUpdateBaseForm({ myData, onWithdrawClick }: ProfileUpdateBaseFormProps) {
   const {
     control,
     handleSubmit,
@@ -65,7 +65,6 @@ export default function ProfileUpdateBaseForm({ myData }: ProfileUpdateBaseFormP
 
   const queryClient = useQueryClient()
   const fileInputRef = useRef<HTMLInputElement>(null)
-  const isMd = useMediaQuery('(min-width: 768px)')
 
   const [updateError, setUpdateError] = useState<React.ReactNode | null>(null)
   const [updateSuccess, setUpdateSuccess] = useState<React.ReactNode | null>(null)
@@ -214,12 +213,10 @@ export default function ProfileUpdateBaseForm({ myData }: ProfileUpdateBaseFormP
     >
       <fieldset className="flex flex-col gap-8">
         <legend className="sr-only">프로필 정보 수정 폼</legend>
-        {isMd ? (
-          <div className="flex flex-col gap-2">
-            <h2 className="text-[20px] font-bold">기본 정보</h2>
-            <p className="text-sm text-gray-500">프로필 이미지, 닉네임, 거주지를 수정할 수 있습니다</p>
-          </div>
-        ) : null}
+        <div className="flex flex-col gap-2">
+          <h2 className="text-[20px] font-bold">기본 정보</h2>
+          <p className="text-sm text-gray-500">프로필 이미지, 닉네임, 거주지를 수정할 수 있습니다</p>
+        </div>
 
         <div className="flex flex-col gap-6">
           <div className="flex flex-col gap-10">
@@ -251,11 +248,11 @@ export default function ProfileUpdateBaseForm({ myData }: ProfileUpdateBaseFormP
                 </div>
                 <button
                   type="button"
-                  className="bg-primary-100 absolute right-0 bottom-2 flex size-8 cursor-pointer items-center justify-center rounded-full"
+                  className="bg-primary-100 hover:bg-primary-200 absolute right-0 bottom-2 flex size-8 cursor-pointer items-center justify-center rounded-full transition-colors"
                   onClick={() => fileInputRef.current?.click()}
                   aria-label="프로필 사진 변경"
                 >
-                  <Camera className="" size={20} />
+                  <Camera size={20} />
                 </button>
               </div>
               {errors.profileImageUrl ? (
@@ -293,9 +290,9 @@ export default function ProfileUpdateBaseForm({ myData }: ProfileUpdateBaseFormP
                 </div>
               </div>
 
-              {/* 계정 정보 */}
-              <div className="flex flex-col gap-1 md:gap-1">
-                <h3 className="md:heading-h5 text-base font-semibold">계정 정보</h3>
+              {/* 계정 정보 (데스크탑에서는 사이드바에 표시) */}
+              <div className="flex flex-col gap-1 md:hidden">
+                <h3 className="text-base font-semibold">계정 정보</h3>
                 <div className="flex flex-col gap-1">
                   <div className="flex flex-col gap-2">
                     <span className="text-sm font-medium text-gray-600">이메일</span>
@@ -387,6 +384,14 @@ export default function ProfileUpdateBaseForm({ myData }: ProfileUpdateBaseFormP
             프로필 수정
           </Button>
         </div>
+        <Button
+          size="md"
+          type="button"
+          onClick={onWithdrawClick}
+          className="w-auto cursor-pointer bg-transparent text-xs text-gray-400 md:ml-auto"
+        >
+          회원탈퇴
+        </Button>
       </fieldset>
     </form>
   )

--- a/src/features/profile-update/components/ProfileUpdateBaseForm.tsx
+++ b/src/features/profile-update/components/ProfileUpdateBaseForm.tsx
@@ -208,13 +208,13 @@ export default function ProfileUpdateBaseForm({ myData, onWithdrawClick }: Profi
 
   return (
     <form
-      className="flex w-full flex-col gap-6 rounded-xl border border-gray-200 bg-white p-5 md:p-7"
+      className="flex w-full flex-col gap-6 rounded-xl border border-gray-200 bg-white p-5 md:p-6"
       onSubmit={handleSubmit(onSubmit)}
     >
       <fieldset className="flex flex-col gap-8">
         <legend className="sr-only">프로필 정보 수정 폼</legend>
-        <div className="flex flex-col gap-2">
-          <h2 className="text-[20px] font-bold">기본 정보</h2>
+        <div className="flex flex-col">
+          <h2 className="text-[17.5px] font-semibold">기본 정보</h2>
           <p className="text-sm text-gray-500">프로필 이미지, 닉네임, 거주지를 수정할 수 있습니다</p>
         </div>
 
@@ -265,11 +265,11 @@ export default function ProfileUpdateBaseForm({ myData, onWithdrawClick }: Profi
             <div className="flex flex-col gap-8">
               {/* 본인 인증 정보 */}
               <div className="flex flex-col gap-1 md:gap-1">
-                <h3 className="md:heading-h5 text-base font-semibold">본인 인증 정보</h3>
+                {/* <h3 className="md:heading-h5 text-base font-semibold">본인 인증 정보</h3> */}
 
                 <div className="flex flex-col items-center justify-between gap-6 md:flex-row">
                   <div className="flex w-full flex-1 flex-col gap-1">
-                    <div className="flex flex-col gap-2">
+                    <div className="flex flex-col gap-1">
                       <span className="text-sm font-medium text-gray-600">이름</span>
                       <div className="bg-primary-50/50 rounded-lg px-3 py-2.5 text-sm font-medium text-gray-400">
                         {myData?.name}
@@ -279,7 +279,7 @@ export default function ProfileUpdateBaseForm({ myData, onWithdrawClick }: Profi
                   </div>
 
                   <div className="flex w-full flex-1 flex-col gap-1">
-                    <div className="flex flex-col gap-2">
+                    <div className="flex flex-col gap-1">
                       <span className="text-sm font-medium text-gray-600">생년월일</span>
                       <div className="bg-primary-50/50 rounded-lg px-3 py-2.5 text-sm font-medium text-gray-400">
                         {formatBirthDate(myData?.birthDate)}
@@ -306,9 +306,9 @@ export default function ProfileUpdateBaseForm({ myData, onWithdrawClick }: Profi
 
               {/* 활동 정보 */}
               <div className="flex flex-col gap-3.5">
-                <h3 className="md:heading-h5 text-base font-semibold">활동 정보</h3>
+                {/* <h3 className="md:heading-h5 text-base font-semibold">활동 정보</h3> */}
                 <div className="flex flex-col gap-1 md:-mt-2.5">
-                  <div className="flex flex-col justify-center gap-2">
+                  <div className="flex flex-col justify-center gap-1">
                     <RequiredLabel htmlFor="update-nickname" required={false} labelClass="text-sm">
                       닉네임
                     </RequiredLabel>
@@ -333,12 +333,12 @@ export default function ProfileUpdateBaseForm({ myData, onWithdrawClick }: Profi
                   primaryName="addressSido"
                   secondaryName="addressGugun"
                   required={false}
-                  layoutClass="gap-2"
+                  layoutClass="gap-1"
                   labelClass="text-sm"
                   buttonClassName="py-[10px]"
                 />
                 <div className="flex flex-col gap-1">
-                  <div className="flex flex-col gap-2">
+                  <div className="gap- flex flex-col">
                     <RequiredLabel htmlFor="profile-introduction" required={false} labelClass="text-sm">
                       자기소개
                     </RequiredLabel>
@@ -346,7 +346,7 @@ export default function ProfileUpdateBaseForm({ myData, onWithdrawClick }: Profi
                       id="profile-introduction"
                       placeholder="소개글을 작성해주세요"
                       className={cn(
-                        'focus:border-primary-500 min-h-[7vh] w-full resize-none rounded-lg border border-gray-400 bg-white px-3 py-3 text-sm placeholder:text-gray-400 focus:outline-none'
+                        'focus:border-primary-500 min-h-[7vh] w-full resize-none rounded-lg border border-gray-400 bg-white px-3 py-3 text-sm placeholder:text-sm placeholder:text-gray-400 focus:outline-none'
                       )}
                       {...register('introduction', profileValidationRules.introduction)}
                     />
@@ -380,7 +380,11 @@ export default function ProfileUpdateBaseForm({ myData, onWithdrawClick }: Profi
               ) : null}
             </AnimatePresence>
           </div>
-          <Button size="md" className="bg-primary-600 w-full cursor-pointer text-white" type="submit">
+          <Button
+            size="md"
+            className="bg-primary-600 hover:bg-primary-700 w-full cursor-pointer text-white transition-colors"
+            type="submit"
+          >
             프로필 수정
           </Button>
         </div>

--- a/src/features/profile-update/components/ProfileUpdatePasswordForm.tsx
+++ b/src/features/profile-update/components/ProfileUpdatePasswordForm.tsx
@@ -64,11 +64,14 @@ export default function ProfileUpdatePasswordForm() {
     }
 
     try {
-      await fetchGraphQL(`
+      await fetchGraphQL(
+        `
         mutation ChangePassword($currentPassword: String!, $newPassword: String!, $confirmPassword: String!) {
           changePassword(currentPassword: $currentPassword, newPassword: $newPassword, confirmPassword: $confirmPassword) { success }
         }
-      `, { ...requestData })
+      `,
+        { ...requestData }
+      )
       reset()
       setPwUpdateSuccess(
         <div className="flex flex-col gap-0.5">
@@ -100,19 +103,21 @@ export default function ProfileUpdatePasswordForm() {
   }, [password, passwordConfirm, setError, clearErrors])
 
   return (
-    <form className="flex w-full flex-col gap-6 rounded-xl border border-gray-200 bg-white p-7" onSubmit={handleSubmit(onSubmit)}>
-      <fieldset className="flex flex-col gap-8">
+    <form className="flex w-full flex-col gap-6 rounded-xl border border-gray-200 bg-white p-6" onSubmit={handleSubmit(onSubmit)}>
+      <fieldset className="flex flex-col gap-6">
         <legend className="sr-only">비밀번호 변경 폼</legend>
-        <div className="flex flex-col gap-2">
-          <h2 className="heading-h3">비밀번호 변경</h2>
-          <p className="text-gray-500">보안을 위해 주기적으로 비밀번호를 변경해주세요</p>
+        <div className="flex flex-col">
+          <h2 className="text-[17.5px] font-semibold">비밀번호 변경</h2>
+          <p className="text-sm text-gray-500">보안을 위해 주기적으로 비밀번호를 변경해주세요</p>
         </div>
 
-        <div className="flex flex-col gap-6">
-          <div className="flex flex-col gap-8">
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-5">
             <div className="flex flex-1 flex-col gap-1">
-              <div className="flex flex-col gap-2">
-                <label htmlFor="current-password" className="font-medium text-gray-600">현재 비밀번호</label>
+              <div className="flex flex-col gap-1">
+                <label htmlFor="current-password" className="text-sm font-medium text-gray-600">
+                  현재 비밀번호
+                </label>
                 <InputField
                   id="current-password"
                   type="password"
@@ -127,8 +132,10 @@ export default function ProfileUpdatePasswordForm() {
             </div>
 
             <div className="flex flex-1 flex-col gap-1">
-              <div className="flex flex-col gap-2">
-                <label htmlFor="new-password" className="font-medium text-gray-600">새 비밀번호</label>
+              <div className="flex flex-col gap-1">
+                <label htmlFor="new-password" className="text-sm font-medium text-gray-600">
+                  새 비밀번호
+                </label>
                 <InputField
                   id="new-password"
                   type="password"
@@ -143,8 +150,10 @@ export default function ProfileUpdatePasswordForm() {
             </div>
 
             <div className="flex flex-1 flex-col gap-1">
-              <div className="flex flex-col gap-2">
-                <label htmlFor="confirm-password" className="font-medium text-gray-600">새 비밀번호 확인</label>
+              <div className="flex flex-col gap-1">
+                <label htmlFor="confirm-password" className="text-sm font-medium text-gray-600">
+                  새 비밀번호 확인
+                </label>
                 <InputField
                   id="confirm-password"
                   type="password"
@@ -186,7 +195,11 @@ export default function ProfileUpdatePasswordForm() {
               </InlineNotification>
             ) : null}
           </AnimatePresence>
-          <Button size="md" className="bg-primary-600 w-full cursor-pointer text-white" type="submit">
+          <Button
+            size="md"
+            className="bg-primary-600 hover:bg-primary-700 w-full cursor-pointer text-white transition-colors"
+            type="submit"
+          >
             비밀번호 변경
           </Button>
         </div>

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -91,6 +91,7 @@ export const typeDefs = gql`
     addressGugun: String
     createdAt: String!
     rating: Float
+    provider: String
   }
 
   type BlockedUser {

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -12,6 +12,7 @@ export interface User {
   introduction?: string
   createdAt?: string
   userRole?: 'USER' | 'ADMIN'
+  provider?: 'LOCAL' | 'GOOGLE' | 'KAKAO'
 }
 
 // ========== 마이페이지 관련 타입 ==========


### PR DESCRIPTION
## Summary

### 좌측 사이드바 (`ProfileData`)
- 표시 정보·크기를 마이페이지/유저페이지와 **완전 동일**하게 유지 (공유 컴포넌트 `md:max-w-72 md:min-w-72`)
- 프로필 이미지 변경 기능은 사이드바에 노출하지 않음 (`enableImageUpload` 미전달)

### `ProfileUpdateBaseForm` — 회원탈퇴 진입점 + 폼 카드 정리
- 폼 카드 안 마지막에 ghost 스타일 "회원탈퇴" 버튼 추가 (`onWithdrawClick` 콜백 prop)
- 폼 카드 상단 "기본 정보" 헤더의 `isMd` 분기 제거 — 모바일·데스크탑 모두 노출 (비밀번호 변경 카드 헤더와 일관성)
- 폼 카드 안 큰 프로필 이미지 영역은 모바일·데스크탑 모두 노출 (이미지 변경은 폼 카드 내부에서만)
- 미사용이 된 `isMd` / `useMediaQuery` import 정리

### `isSocialLogin` 판정 정확화
- 기존 부정확한 도메인 substring 검사(`email.includes('gmail'|'kakao')`) 제거 → `myData.provider !== 'LOCAL'` 기반 정확한 판정으로 교체
- `myProfile` GraphQL 쿼리에 `provider` 필드 추가
- `updateUserProfile`에 `provider` 매핑 추가

### GraphQL / 타입
- `src/graphql/schema.ts` `MyProfile`에 `provider: String` 추가
- `src/types/user.ts` `User`에 `provider?: 'LOCAL' | 'GOOGLE' | 'KAKAO'` 추가
- `src/components/profile/ProfileData.tsx` `MyPageData`에 동일 필드 추가

## ⚠️ 백엔드 의존 (별도 처리)
본 PR이 정상 동작하려면 `cmarket_api` 백엔드에서 `/profile/me` 응답에 `provider` 필드 노출이 함께 머지되어야 합니다. 변경 파일:
- `MyPageDto.java` — `AuthProvider provider` 필드 추가
- `ProfileServiceImpl.java` — `.provider(user.getProvider())` 매핑
- `UserProfileResponse.java` — `AuthProvider provider` 필드 + `fromMyPageDto` 매핑

백엔드 머지 전까지는 `provider`가 `undefined`라 `isSocialLogin === false`로 동작 → 모든 유저에게 비밀번호 변경 카드가 일시 노출됩니다.

## 회원탈퇴 진입점 일관성
- 본 PR 이전엔 회원탈퇴 진입점이 코드베이스 전체에 부재 (`MyPage`/`UserPage`에서도 `setIsWithdrawModalOpen` prop이 dead). 본 PR로 프로필 수정 페이지가 **유일한 진입점**이 됨
- `MyPage`/`UserPage`의 dead prop 정리는 별도 후속 작업으로 분리

## Test plan
- [ ] `/profile-update` 데스크탑: 좌측 사이드바가 마이페이지와 동일한 모습 (이미지 + 닉네임 + 주소 + 자기소개) — 단, 카메라 버튼 없음
- [ ] `/profile-update` 데스크탑: 폼 카드 상단에 "기본 정보 / 프로필 이미지, 닉네임, 거주지를 수정할 수 있습니다" 헤더 노출
- [ ] `/profile-update` 모바일: 사이드바 없이 폼 카드 안 헤더/프로필 이미지/모든 정보 표시
- [ ] 폼 카드 안에서 프로필 이미지 변경 가능 (모바일·데스크탑 모두)
- [ ] 폼 마지막에 ghost 스타일 "회원탈퇴" 버튼 노출, 클릭 시 `WithdrawModal` 열림
- [ ] (백엔드 머지 후) 일반(LOCAL) 회원: 비밀번호 변경 카드 노출
- [ ] (백엔드 머지 후) OAuth(GOOGLE/KAKAO) 회원: 비밀번호 변경 카드 숨김
- [ ] 마이페이지/유저페이지의 `ProfileData`가 기존 동작 그대로 유지

closes #748