### PR TITLE
refactor: 모바일 반응형 디테일 폴리싱 및 viewport/z-index 정비

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,8 @@ import ClientComponents from '@/components/ClientComponents'
 import './globals.css'
 
 export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
   interactiveWidget: 'resizes-content',
 }
 

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -10,10 +10,11 @@ interface EmptyStateProps {
 export default function EmptyState({ icon: Icon, title, description, className = '' }: EmptyStateProps) {
   return (
     <div
-      className={`flex flex-col items-center justify-center gap-6 rounded-lg border-2 border-dashed border-gray-300 bg-white px-7 py-16 ${className}`}
+      className={`flex flex-col items-center justify-center gap-4 rounded-lg border-2 border-dashed border-gray-300 bg-white px-5 py-10 md:gap-6 md:px-7 md:py-16 ${className}`}
     >
-      <div className="bg-primary-50 flex h-25 w-25 items-center justify-center rounded-full">
-        <Icon size={50} strokeWidth={1} className="text-primary-300" />
+      <div className="bg-primary-50 flex h-16 w-16 items-center justify-center rounded-full md:h-25 md:w-25">
+        <Icon size={32} strokeWidth={1} className="text-primary-300 md:hidden" />
+        <Icon size={50} strokeWidth={1} className="text-primary-300 hidden md:block" />
       </div>
       <div className="flex flex-col items-center gap-1 md:gap-2">
         <p className="text-base font-semibold md:heading-h5">{title}</p>

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -34,7 +34,7 @@ const VARIANT_STYLES: Record<TabsVariant, { container: string; tab: string; tabA
   },
   'card-pill': {
     container: 'flex flex-wrap items-center gap-2',
-    tab: 'cursor-pointer rounded-full border px-5 py-1.5 text-sm whitespace-nowrap transition-all',
+    tab: 'cursor-pointer rounded-full border px-5 py-1.5 text-sm whitespace-nowrap transition-all max-md:px-4 max-md:py-1 max-md:font-normal',
     tabActive: 'border-[#825500] bg-[#825500] text-white shadow-sm',
     tabInactive: 'border-[#d4c4b2] bg-white text-gray-600 hover:border-[#825500] hover:text-[#825500]',
   },

--- a/src/components/product/ProductCard.tsx
+++ b/src/components/product/ProductCard.tsx
@@ -68,7 +68,7 @@ function ProductCard({ data, 'data-index': dataIndex, vertical = false, hideProd
 
   return (
     <article
-      className="group relative overflow-hidden rounded-3xl border border-black/5 bg-white shadow-sm transition-all duration-500 hover:-translate-y-1 hover:shadow-xl"
+      className="group relative overflow-hidden rounded-xl border border-black/5 bg-white shadow-sm transition-all duration-500 md:rounded-3xl md:hover:-translate-y-1 md:hover:shadow-xl"
       data-index={dataIndex}
     >
       <Link
@@ -77,10 +77,7 @@ function ProductCard({ data, 'data-index': dataIndex, vertical = false, hideProd
         aria-label={`${title}, ${price}원, ${productStatusName}, ${petTypeName}, ${productTradeName}`}
       />
       <div
-        className={cn(
-          'relative z-1 flex cursor-pointer',
-          vertical ? 'flex-col-reverse' : 'flex-row-reverse md:flex-col-reverse'
-        )}
+        className={cn('relative z-1 flex cursor-pointer', vertical ? 'flex-col-reverse' : 'flex-row-reverse md:flex-col-reverse')}
         onClick={handleContentClick}
       >
         <ProductInfo

--- a/src/components/product/ProductStateFilter.tsx
+++ b/src/components/product/ProductStateFilter.tsx
@@ -88,7 +88,7 @@ export function ProductStateFilter({
   const styles = VARIANT_STYLES[variant]
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col gap-2 max-md:gap-0">
       {useUrlSync ? (
         <h4 id="condition-filter-heading" className={headingClassName ?? 'heading-h5'}>
           상품 상태

--- a/src/components/product/components/ProductHeading.tsx
+++ b/src/components/product/components/ProductHeading.tsx
@@ -8,8 +8,8 @@ interface ProductHeadingProps {
 export function ProductHeading({ title, price }: ProductHeadingProps) {
   return (
     <div className="flex flex-col">
-      <h3 className="line-clamp-1 text-[13px] text-gray-900">{title}</h3>
-      <span className="text-md max-w-[90%] overflow-hidden font-bold text-gray-900">
+      <h3 className="line-clamp-1 text-sm text-gray-900 md:text-[13px]">{title}</h3>
+      <span className="max-w-[90%] overflow-hidden font-bold text-gray-900 md:text-base">
         <span>{formatPrice(price)}</span>원
       </span>
     </div>

--- a/src/components/product/components/ProductInfo.tsx
+++ b/src/components/product/components/ProductInfo.tsx
@@ -32,20 +32,24 @@ export function ProductInfo({
     ...(productStatusName ? [{ label: productStatusName, tone: 'outline' as const }] : []),
   ]
 
-  const metaTextClass = 'text-xs font-medium'
+  const metaTextClass = 'text-xs font-normal md:font-medium'
   const hasFavoriteCount = typeof favoriteCount === 'number'
   const hasCreatedAt = Boolean(createdAt)
 
   return (
-    <div className="flex flex-3 flex-col gap-2 bg-white p-3 md:flex-none md:p-4">
+    <div className="flex flex-3 flex-col gap-2 bg-white px-2 py-1.5 md:flex-none md:p-4">
       <ProductBadge items={badgeItems} />
       <ProductHeading title={title} price={price} />
       {/* 메타 (레퍼런스 패턴): 은평구 · 찜 15  ........  3분 전 */}
-      <div className="mt-auto flex w-full items-center gap-1 text-gray-500">
+      <div className="mt-auto flex w-full items-center gap-0.5 text-gray-500 md:gap-1">
         {location ? (
           <>
             <ProductMetaItem label={location} textClassName={metaTextClass} />
-            {hasFavoriteCount ? <span className={metaTextClass} aria-hidden="true">·</span> : null}
+            {hasFavoriteCount ? (
+              <span className={metaTextClass} aria-hidden="true">
+                ·
+              </span>
+            ) : null}
           </>
         ) : null}
         {hasFavoriteCount ? <ProductMetaItem label={`찜 ${favoriteCount}`} textClassName={metaTextClass} /> : null}

--- a/src/components/product/components/ProductThumbnail.tsx
+++ b/src/components/product/components/ProductThumbnail.tsx
@@ -85,7 +85,7 @@ export function ProductThumbnail({
         onError={() => {
           if (imgErrorStep < 2) setImgErrorStep((prev) => prev + 1)
         }}
-        className="absolute top-0 left-0 h-full w-full object-cover transition-transform duration-700 group-hover:scale-110"
+        className="absolute top-0 left-0 h-full w-full object-cover transition-transform duration-700 md:group-hover:scale-110"
       />
 
       {/* 거래상태 중앙 큰 오버레이 (모바일/데스크탑 동일) */}
@@ -103,14 +103,17 @@ export function ProductThumbnail({
         size="sm"
         icon={Heart}
         iconProps={{
-          size: 16,
+          size: 20,
           strokeWidth: 2,
-          className: cn(isFavorite ? 'fill-[#fc8181] stroke-[#fc8181]' : 'fill-none stroke-gray-600'),
+          className: cn(
+            'drop-shadow-md',
+            isFavorite ? 'fill-[#fc8181] stroke-[#fc8181]' : 'fill-none stroke-white'
+          ),
           'aria-hidden': true,
         }}
         onClick={handleHeartClick}
         aria-label={isFavorite ? '찜 해제' : '찜하기'}
-        className="pointer-events-auto absolute top-2 right-2 z-20 h-8 w-8 cursor-pointer rounded-full bg-white/90 p-0 shadow-sm backdrop-blur-md transition-all hover:bg-white md:top-3 md:right-3 md:h-7 md:w-7"
+        className="pointer-events-auto absolute top-0.5 right-0.5 z-20 h-8 w-8 cursor-pointer bg-transparent p-0 md:h-7 md:w-7"
       />
     </div>
   )

--- a/src/components/product/filterChipStyles.ts
+++ b/src/components/product/filterChipStyles.ts
@@ -9,7 +9,7 @@
  */
 export const CARD_CHIP_STYLES = {
   container: 'flex flex-wrap gap-2',
-  chip: 'inline-flex items-center cursor-pointer rounded-lg border px-3 py-2 text-xs font-medium whitespace-nowrap transition-all',
+  chip: 'inline-flex items-center cursor-pointer rounded-lg border px-3 py-2 text-xs font-medium whitespace-nowrap transition-all max-md:px-2.5 max-md:py-1.5',
   chipActive: 'border-[#825500] bg-[#825500] text-white',
   chipInactive:
     'border-[#d4c4b2] bg-[#f6f3f2] text-gray-700 hover:border-[#825500] hover:text-[#825500]',

--- a/src/features/home/Home.tsx
+++ b/src/features/home/Home.tsx
@@ -203,7 +203,7 @@ function Home() {
         <div className="flex min-h-100 items-center justify-center bg-white">
           <div className="flex flex-col items-center gap-4">
             <p>상품을 불러올 수 없습니다</p>
-            <Button variant="link" onClick={() => refetch()} className="font-bold text-[#825500] hover:text-primary">
+            <Button variant="link" onClick={() => refetch()} className="hover:text-primary font-bold text-[#825500]">
               다시 시도
             </Button>
           </div>
@@ -216,7 +216,7 @@ function Home() {
     <>
       <HomeHero />
       <div className="bg-white">
-        <div className="mx-auto max-w-[1280px] px-6 pt-12 pb-24 md:px-8 md:pt-18">
+        <div className="mx-auto max-w-[1280px] px-4 pt-12 pb-24 md:px-8 md:pt-18">
           <h1 className="sr-only">커들마켓</h1>
           <div className="flex flex-col gap-6">
             {/* Pet category & filters section */}
@@ -247,7 +247,7 @@ function Home() {
             </section>
 
             {/* Product list section */}
-            <section aria-label="상품 목록" className="flex flex-col gap-6">
+            <section aria-label="상품 목록" className="flex flex-col gap-6 pt-2 md:pt-0">
               {/* <h2 className="heading-h4 text-gray-900">상품 목록</h2> */}
               {isLoading && allProducts.length === 0 ? (
                 <HomeSkeleton />

--- a/src/features/home/components/HomeHero.tsx
+++ b/src/features/home/components/HomeHero.tsx
@@ -25,9 +25,9 @@ export default function HomeHero() {
         <img
           alt="반려동물과 함께하는 따뜻한 마켓"
           src="/images/hero.webp"
-          className="pointer-events-none absolute bottom-0 left-4 z-10 h-97.5 w-auto translate-y-[29.5%] md:h-90 xl:left-3.5"
+          className="pointer-events-none absolute bottom-0 left-4 z-10 h-48 w-auto translate-y-[30%] md:h-90 md:translate-y-[29.5%] xl:left-3.5"
         />
-        <div className="absolute top-[15%] z-20 flex h-full flex-col px-4 pt-8 text-primary md:justify-center md:pt-0 md:pl-[52%] xl:pl-[40%]">
+        <div className="text-primary absolute top-[15%] z-20 flex h-full w-full flex-col px-4 pt-8 md:justify-center md:pt-0 md:pl-[52%] xl:pl-[40%]">
           <h1 className="text-xl leading-tight font-bold md:text-3xl xl:text-4xl">
             우리 동네 반려인들과 함께하는
             <br />
@@ -41,7 +41,7 @@ export default function HomeHero() {
           <button
             type="button"
             onClick={focusHeaderSearch}
-            className="mt-5 inline-flex w-fit cursor-pointer items-center gap-2 rounded-full bg-[#825500] px-5 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-primary md:text-base"
+            className="hover:bg-primary mt-5 inline-flex w-fit cursor-pointer items-center gap-2 rounded-full bg-[#825500] px-5 py-2 text-sm font-medium text-white shadow-sm transition-colors md:text-base"
           >
             <Search className="h-4 w-4" />
             검색하러 가기

--- a/src/features/home/components/filter/CategoryFilter.tsx
+++ b/src/features/home/components/filter/CategoryFilter.tsx
@@ -26,9 +26,9 @@ export function CategoryFilter({ selectedCategory }: CategoryFilterProps) {
   }
 
   return (
-    <div className="flex flex-col gap-4 md:pt-2">
+    <div className="flex flex-col gap-4 pt-3 md:pt-2">
       <div
-        className="scrollbar-hide -mx-2 flex items-start gap-5 overflow-x-auto px-2 pb-2"
+        className="scrollbar-hide -mx-2 flex items-start gap-3 overflow-x-auto px-2 pb-2 md:gap-5"
         role="group"
         aria-label="상품 카테고리"
       >
@@ -41,12 +41,18 @@ export function CategoryFilter({ selectedCategory }: CategoryFilterProps) {
               size="sm"
               onClick={(e) => handleSelect(e, category.code)}
               aria-pressed={isActive}
-              className="group flex min-w-20 shrink-0 flex-col items-center rounded-none bg-transparent p-0 transition-all hover:bg-transparent"
+              className="group flex shrink-0 flex-col items-center gap-1 rounded-none bg-transparent p-0 transition-all hover:bg-transparent md:min-w-20 md:gap-0"
             >
-              <span className="flex h-20 w-20 items-center justify-center transition-all group-hover:-translate-y-1">
-                <Image src={category.iconImage} alt="" width={64} height={64} className="h-16 w-16 object-contain" />
+              <span className="bg-primary-50 flex h-16 w-16 items-center justify-center overflow-hidden rounded-full transition-all group-hover:-translate-y-1 md:h-20 md:w-20 md:overflow-visible md:rounded-none md:bg-transparent">
+                <Image
+                  src={category.iconImage}
+                  alt=""
+                  width={80}
+                  height={80}
+                  className="h-20 w-20 object-cover md:h-16 md:w-16 md:object-contain"
+                />
               </span>
-              <span className="text-sm font-bold whitespace-nowrap text-gray-600 transition-colors group-hover:text-[#825500]">
+              <span className="text-xs whitespace-nowrap text-gray-600 transition-colors group-hover:text-[#825500] md:text-sm md:font-bold">
                 {category.name}
               </span>
             </Button>

--- a/src/features/home/components/filter/DetailFilter.tsx
+++ b/src/features/home/components/filter/DetailFilter.tsx
@@ -29,7 +29,7 @@ export const DetailFilter = memo(function DetailFilterSection({
   filterReset,
 }: DetailFilterProps) {
   return (
-    <div className="flex flex-col gap-3">
+    <div className="flex flex-col gap-3 max-md:border-outline-variant max-md:rounded-3xl max-md:border max-md:bg-white max-md:px-4 max-md:py-3 max-md:shadow-sm">
       <DetailFilterButton
         isOpen={isOpen}
         onToggle={() => onToggle(!isOpen)}
@@ -42,7 +42,7 @@ export const DetailFilter = memo(function DetailFilterSection({
           id={FILTER_CONTENT_ID}
           role="group"
           aria-label="세부 필터 옵션"
-          className="border-outline-variant relative rounded-3xl border bg-white px-6 py-6 shadow-sm md:px-6 md:py-5"
+          className="relative md:border-outline-variant md:rounded-3xl md:border md:bg-white md:px-6 md:py-5 md:shadow-sm"
         >
           {/* 데스크탑 필터 초기화 (카드 우상단 액션) */}
           <Button
@@ -56,7 +56,7 @@ export const DetailFilter = memo(function DetailFilterSection({
             필터 초기화
           </Button>
 
-          <div className="flex flex-col gap-8 md:flex-row md:items-start md:justify-between md:gap-10">
+          <div className="flex flex-col gap-5 md:flex-row md:items-start md:justify-between md:gap-10">
             <ProductStateFilter
               variant="card-chip"
               useUrlSync

--- a/src/features/home/components/filter/LocationFilter.tsx
+++ b/src/features/home/components/filter/LocationFilter.tsx
@@ -72,12 +72,12 @@ export function LocationFilter({ headingClassName, variant = 'default' }: Locati
   const styles = VARIANT_STYLES[variant]
 
   return (
-    <div className="flex flex-1 flex-col gap-2">
+    <div className="flex flex-1 flex-col gap-2 max-md:gap-0">
       <h4 id="location-filter-heading" className={headingClassName ?? 'heading-h4'}>
         지역
       </h4>
       <div
-        className="flex flex-col gap-2.5 md:flex-row"
+        className="flex flex-row gap-2.5"
         role="group"
         aria-labelledby="location-filter-heading"
       >
@@ -107,7 +107,7 @@ export function LocationFilter({ headingClassName, variant = 'default' }: Locati
               value: gugun,
               label: gugun,
             }))}
-            placeholder={selectedSido ? '시/군/구 선택' : '시/도를 먼저 선택해주세요'}
+            placeholder={selectedSido ? '시/군/구 선택' : '시/도 먼저 선택'}
             disabled={!selectedSido}
             buttonClassName={styles.gugunButton}
           />

--- a/src/features/home/components/filter/PetTypeFilter.tsx
+++ b/src/features/home/components/filter/PetTypeFilter.tsx
@@ -92,7 +92,7 @@ export function PetTypeFilter({ activeTab, selectedDetailPet, onTabChange }: Pet
             type="button"
             size="sm"
             onClick={() => setShowAll(true)}
-            className="cursor-pointer rounded-full bg-gray-100 px-5 py-2.5 text-gray-600 hover:bg-gray-200 md:hidden"
+            className="cursor-pointer rounded-full bg-gray-100 px-3 py-1 text-xs text-gray-600 hover:bg-gray-200 md:hidden"
           >
             더보기 ({filteredPetDetails.length - INITIAL_DISPLAY_COUNT}개)
           </Button>

--- a/src/features/home/components/filter/PriceFilter.tsx
+++ b/src/features/home/components/filter/PriceFilter.tsx
@@ -59,7 +59,7 @@ export function PriceFilter({ headingClassName, selectedPriceRange, variant = 'd
   const styles = VARIANT_STYLES[variant]
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col gap-2 max-md:gap-0">
       <h4 id="price-filter-heading" className={headingClassName ?? 'heading-h4'}>
         가격대
       </h4>

--- a/src/features/home/components/product-section/ProductsSection.tsx
+++ b/src/features/home/components/product-section/ProductsSection.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useMemo } from 'react'
 import ProductList from '@/components/product/ProductList'
-import SelectDropdown from '@/components/commons/select/SelectDropdown'
 import Tabs from '@/components/Tabs'
 import { PRODUCT_TYPE_TABS, SORT_TYPE, type ProductTypeTabId } from '@/constants/constants'
 import type { Product } from '@/types/product'
@@ -17,7 +16,7 @@ interface ProductListHeaderProps {
 
 function ProductListHeader({ totalElements }: ProductListHeaderProps) {
   return (
-    <p className="text-sm text-gray-500" aria-live="polite">
+    <p className="text-xs text-gray-500 md:text-sm" aria-live="polite">
       {`전체 ${totalElements}개`}
     </p>
   )
@@ -70,9 +69,9 @@ export function ProductsSection({
   }, [products, onlyOnSale])
 
   return (
-    <section role="tabpanel" id={`panel-${activeTabCode}`} aria-labelledby={activeTab} className="flex flex-col gap-2">
+    <section role="tabpanel" id={`panel-${activeTabCode}`} aria-labelledby={activeTab} className="flex flex-col gap-4 md:gap-2">
       {/* 탭 + 토글 + 정렬 */}
-      <div className="border-outline-variant flex flex-col justify-between gap-4 border-b pb-2 md:flex-row md:items-center md:pt-15">
+      <div className="border-outline-variant flex flex-col justify-between gap-7 border-b pb-2 md:flex-row md:items-center md:gap-4 md:pt-15">
         <Tabs
           tabs={PRODUCT_TYPE_TABS}
           activeTab={activeTab}
@@ -81,7 +80,7 @@ export function ProductsSection({
           variant="card-pill"
         />
 
-        <div className="flex flex-wrap items-center gap-4 md:gap-3">
+        <div className="flex flex-wrap items-center justify-between gap-2 md:justify-end">
           <label className="group flex cursor-pointer items-center gap-2.5">
             <span className="relative inline-block">
               <input
@@ -91,26 +90,15 @@ export function ProductsSection({
                 className="peer sr-only"
               />
               <span className="block h-4 w-7 rounded-full bg-gray-200 transition-colors peer-checked:bg-[#825500]"></span>
-              <span className="absolute top-0.5 left-0.5 h-3 w-3 rounded-full bg-white transition-transform peer-checked:translate-x-5"></span>
+              <span className="absolute top-0.5 left-0.5 h-3 w-3 rounded-full bg-white transition-transform peer-checked:translate-x-3"></span>
             </span>
-            <span className="text-sm font-bold text-gray-600 group-hover:text-[#825500]">판매중만 보기</span>
+            <span className="text-sm text-gray-600 md:font-bold">판매중</span>
           </label>
 
           <div className="bg-outline-variant/60 hidden h-4 w-px md:block" />
 
-          {/* 모바일: SelectDropdown — 공간 효율 + 프로젝트 컨벤션 일치 */}
-          <div className="w-32 md:hidden">
-            <SelectDropdown
-              value={selectedSort}
-              onChange={handleSortChange}
-              options={SORT_TYPE.map((sort) => ({ value: sort.label, label: sort.label }))}
-              placeholder="최신순"
-              buttonClassName="border-0 bg-[#f6efe2] text-gray-900 px-3 py-2 text-sm"
-            />
-          </div>
-
-          {/* 데스크탑: 인라인 옵션 리스트 */}
-          <div className="hidden items-center gap-2 md:flex">
+          {/* 정렬 인라인 옵션 리스트 */}
+          <div className="flex items-center gap-2">
             {SORT_TYPE.map((sort, idx) => {
               const isActive = selectedSort === sort.label
               return (
@@ -121,8 +109,8 @@ export function ProductsSection({
                     size="sm"
                     onClick={() => handleSortChange(sort.label)}
                     className={cn(
-                      'cursor-pointer p-0 text-sm whitespace-nowrap hover:no-underline',
-                      isActive ? 'font-bold text-[#825500]' : 'font-medium text-gray-500 hover:text-[#825500]'
+                      'cursor-pointer p-0 text-[13px] font-normal whitespace-nowrap hover:no-underline md:text-sm',
+                      isActive ? 'text-[#825500] md:font-bold' : 'text-gray-500 hover:text-[#825500] md:font-medium'
                     )}
                   >
                     {sort.label}
@@ -135,7 +123,7 @@ export function ProductsSection({
         </div>
       </div>
 
-      <ProductListHeader totalElements={onlyOnSale ? visibleProducts.length : totalElements} />
+      {/* <ProductListHeader totalElements={onlyOnSale ? visibleProducts.length : totalElements} /> */}
 
       {visibleProducts.length > 0 ? (
         <ProductList products={visibleProducts} />

--- a/src/features/home/components/tab/ProductPetTypeTabs.tsx
+++ b/src/features/home/components/tab/ProductPetTypeTabs.tsx
@@ -52,7 +52,7 @@ export function ProductPetTypeTabs({ activeTab, onTabChange }: ProductPetTypeTab
               size="sm"
               onClick={() => onTabChange(tab.id)}
               className={cn(
-                '-mb-px cursor-pointer rounded-none border-b-2 px-3 py-3 whitespace-nowrap md:px-3',
+                '-mb-px cursor-pointer rounded-none border-b-2 px-3 pt-3 pb-1 whitespace-nowrap md:px-3 md:pb-3',
                 isActive
                   ? 'border-[#825500] font-bold text-[#825500]'
                   : 'border-transparent font-medium text-gray-500 hover:text-[#825500]'

--- a/src/features/product-detail/components/MainImage.tsx
+++ b/src/features/product-detail/components/MainImage.tsx
@@ -147,7 +147,7 @@ export default function MainImage({ mainImageUrl, subImageUrls, title, tradeStat
 
       {/* 거래상태 중앙 큰 오버레이 (메인 카드 ProductThumbnail과 동일 패턴) */}
       {isOverlayShown ? (
-        <div className={cn('pointer-events-none absolute inset-0 z-30 flex items-center justify-center', overlayBg)}>
+        <div className={cn('pointer-events-none absolute inset-0 z-10 flex items-center justify-center', overlayBg)}>
           <span className={cn('rounded-full bg-white/95 font-bold text-gray-900 shadow-md', badgeSizeClass)}>
             {displayTradeStatus}
           </span>

--- a/src/features/product-detail/components/ProductDescription.tsx
+++ b/src/features/product-detail/components/ProductDescription.tsx
@@ -3,7 +3,10 @@ interface ProductDescriptionProps {
 }
 export default function ProductDescription({ description }: ProductDescriptionProps) {
   return (
-    <section aria-label="상품 설명" className="h-64 overflow-y-auto rounded-lg border border-gray-200 bg-white p-3.5 text-sm whitespace-pre-line text-gray-900 md:min-h-[22vh]">
+    <section
+      aria-label="상품 설명"
+      className="min-h-20 overflow-y-auto rounded-lg border border-gray-200 bg-white p-3.5 text-sm whitespace-pre-line text-gray-900 md:min-h-[22vh]"
+    >
       {description}
     </section>
   )

--- a/src/features/product-detail/components/ProductDetailMobileMeta.tsx
+++ b/src/features/product-detail/components/ProductDetailMobileMeta.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { Eye, Heart, Flag } from 'lucide-react'
+import { Eye, Heart } from 'lucide-react'
 import { ProductMetaItem } from '@/components/product/ProductMetaItem'
 import dynamic from 'next/dynamic'
 const ProductReportModal = dynamic(() => import('@/components/modal/ProductReportModal'))
@@ -20,16 +20,27 @@ export default function ProductDetailMobileMeta({ productId, productTitle, viewC
     <>
       <div className="flex items-center justify-between md:hidden">
         <div className="flex items-center gap-2">
-          <ProductMetaItem icon={Eye} iconSize={14} label={`조회 ${viewCount}`} textClassName="text-xs font-normal" />
-          <ProductMetaItem icon={Heart} iconSize={14} label={`찜 ${favoriteCount}`} textClassName="text-xs font-normal" />
+          <ProductMetaItem
+            icon={Eye}
+            iconSize={14}
+            label={`조회 ${viewCount}`}
+            textClassName="text-xs font-normal"
+            iconClassName="text-gray-400"
+          />
+          <ProductMetaItem
+            icon={Heart}
+            iconSize={14}
+            label={`찜 ${favoriteCount}`}
+            textClassName="text-xs font-normal"
+            iconClassName="text-gray-400"
+          />
         </div>
         <button
           type="button"
           onClick={() => setIsReportOpen(true)}
-          className="flex cursor-pointer items-center gap-1 text-xs text-gray-400 hover:text-red-500"
+          className="cursor-pointer text-xs text-gray-400 hover:text-red-500"
         >
-          <Flag size={14} />
-          <span>신고하기</span>
+          신고하기
         </button>
       </div>
       <ProductReportModal

--- a/src/features/product-detail/components/ProductTitle.tsx
+++ b/src/features/product-detail/components/ProductTitle.tsx
@@ -8,8 +8,8 @@ interface ProductTitleProps {
 
 export default function ProductTitle({ title, price }: ProductTitleProps) {
   return (
-    <div className="flex flex-col gap-2">
-      <h1 className="heading-h4 leading-none text-gray-900">{title}</h1>
+    <div className="flex flex-col gap-4 md:gap-2">
+      <h1 className="md:heading-h4 text-2xl leading-7 font-bold text-gray-900 md:leading-none">{title}</h1>
       <strong className="text-primary-300 heading-h3 max-w-[90%] overflow-hidden leading-none">
         <span className="leading-none">{formatPrice(price)}</span>원
       </strong>


### PR DESCRIPTION
## Summary

### 루트 / 글로벌
- `app/layout.tsx`의 `viewport` export에 `width: 'device-width'`, `initialScale: 1` 추가 — 모바일이 데스크탑 너비로 렌더 후 축소되던 문제 해결

### 메인페이지
- `HomeHero` 모바일 이미지 크기 축소 (`h-97.5` → `h-48`), `translate-y` 분기
- `CategoryFilter` 모바일 카테고리 이미지가 원형 안에 가득 차도록 (`rounded-full overflow-hidden`, `h-full w-full object-cover`)
- `ProductPetTypeTabs` 모바일 padding 정리 (`pt-3 pb-1`)
- `ProductsSection` 정렬 영역을 인라인으로 통일, 모바일 토글과 양끝 정렬, `SelectDropdown` 제거
- `Tabs` `card-pill` variant 모바일 패딩·폰트 굵기 정돈 (`max-md:px-4 max-md:py-1 max-md:font-normal`)
- "판매중" 라벨 `group-hover:text-[#825500]` 제거 — 모바일 sticky hover로 색이 잔류하던 문제 해결
- `DetailFilter` 모바일 outer wrapper에 카드 배경/border/rounded 추가 — 접혔을 때도 영역 가시성 확보
- 세부 필터 섹션 간격 `gap-8` → `gap-5` (모바일), wrapper padding 축소
- 필터 chip 패딩 모바일 축소 (`max-md:px-2.5 max-md:py-1.5`)
- 각 필터 wrapper 내부 gap 모바일 제거 (`max-md:gap-0`)
- `LocationFilter` 모바일 가로 2칸 배치, placeholder "시/도를 먼저 선택해주세요" → "시/도 먼저 선택"

### 상품 상세 페이지
- `MainImage` 거래상태 오버레이 `z-30` → `z-10` — 헤더(`z-30`)와 충돌해 스크롤 시 헤더 위로 올라가던 문제 해결
- 모바일 신고하기 버튼에서 `Flag` 아이콘 제거 — 데스크탑과 통일
- 메타 아이콘 톤 `text-gray-400`로 모바일/데스크탑 통일

### 상품 카드 (공용)
- 메타 텍스트 굵기 모바일 `font-normal md:font-medium`
- 찜 버튼: 원형 배경 제거, 하트 `stroke-white` + `drop-shadow-md`, 위치 `top-0.5 right-0.5`, 아이콘 size 16 → 20
- 카드 hover 효과(`hover:-translate-y-1`, `hover:shadow-xl`, 이미지 `group-hover:scale-110`)를 `md:hover:`/`md:group-hover:`로 한정 — 모바일 sticky 효과 방지

### `EmptyState`
- 모바일 패딩/아이콘 크기 축소: `py-10 px-5`, 아이콘 컨테이너 `h-16 w-16`, 아이콘 `size={32}`. 데스크탑은 기존 유지

## Test plan
- [ ] 모바일에서 메인페이지가 360px 뷰포트에 가득 차게 표시 (viewport meta 적용 확인)
- [ ] 상품 상세 페이지에서 거래상태 오버레이가 헤더 아래에 표시 (스크롤 시 헤더가 오버레이 위에 보임)
- [ ] 모바일 메인페이지 카테고리 이미지가 원형 안에 가득 차게 표시
- [ ] 모바일 메인페이지 정렬 옵션(`최신순` 등)이 인라인으로 표시, 판매중 토글과 양끝 정렬
- [ ] 모바일 메인페이지 세부 필터가 접혔을 때도 카드 배경 노출, 펼치면 같은 카드 안에서 내용이 보임
- [ ] 모바일 메인페이지 지역 필터 시/도·구군 select가 가로 2칸으로 배치
- [ ] 모바일 상품 카드 hover/transform 효과가 발생하지 않음 (Chrome devtools 모바일 시뮬레이션 + 실제 모바일 둘 다)
- [ ] 모바일 "판매중" 토글 클릭 시 라벨 색 변화 없음 (토글 트랙·노브만 색 변경)
- [ ] 모바일 상품 카드 찜 버튼이 흰 stroke 하트 + drop-shadow, 원형 배경 없음
- [ ] 모바일 메인페이지 빈 상태(검색 결과 없음) 카드가 데스크탑 대비 컴팩트하게 표시
- [ ] 데스크탑 메인페이지/상세페이지 디자인이 기존 그대로 유지

closes #752