### PR TITLE
refactor: 모바일 헤더 풀스크린 오버레이(검색·알림) 도입 및 메인페이지 헤더 톤 정비

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -37,6 +37,12 @@ export default function RootLayout({
     <html lang="ko">
       <head>
         <link rel="preconnect" href="https://df1xl13ui5mlo.cloudfront.net" />
+        {/* 메인페이지 새로고침 시 브라우저 scroll restoration 비활성화 — hydration 전에 적용해 헤더 색 깜빡임 방지 */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `if(location.pathname==='/'&&'scrollRestoration' in history){history.scrollRestoration='manual';}`,
+          }}
+        />
       </head>
       <body>
         <Providers>

--- a/src/components/bottom-nav/BottomNav.tsx
+++ b/src/components/bottom-nav/BottomNav.tsx
@@ -41,16 +41,14 @@ export default function BottomNav() {
 
   if (isXl) return null
 
-  const shouldHide =
-    HIDE_BOTTOMNAV_PATHS.includes(pathname) ||
-    HIDE_BOTTOMNAV_PATTERNS.some((pattern) => pattern.test(pathname))
+  const shouldHide = HIDE_BOTTOMNAV_PATHS.includes(pathname) || HIDE_BOTTOMNAV_PATTERNS.some((pattern) => pattern.test(pathname))
 
   if (shouldHide) return null
 
   return (
     <nav
       className={cn(
-        'fixed bottom-0 left-0 right-0 border-t border-gray-200 bg-white pb-[env(safe-area-inset-bottom)]',
+        'fixed right-0 bottom-0 left-0 border-t border-gray-200 bg-white pb-[env(safe-area-inset-bottom)]',
         Z_INDEX.HEADER
       )}
       aria-label="하단 메뉴"
@@ -63,12 +61,12 @@ export default function BottomNav() {
               key={href}
               href={href}
               className={cn(
-                'flex flex-1 flex-col items-center justify-center gap-0.5',
+                'flex flex-1 flex-col items-center justify-center gap-1',
                 isActive ? 'text-primary-200' : 'text-gray-400'
               )}
             >
               <Icon className="h-5 w-5" strokeWidth={isActive ? 2.5 : 2} />
-              <span className="text-xs font-medium">{label}</span>
+              <span className="text-xs text-gray-500">{label}</span>
             </Link>
           )
         })}

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -10,6 +10,7 @@ import { useMediaQuery } from '@/hooks/useMediaQuery'
 import { Suspense, useEffect, useState, useSyncExternalStore } from 'react'
 import IconButton from '@/components/commons/button/IconButton'
 import SearchBar from '@/components/header/components/SearchBar'
+import MobileSearchOverlay from '@/components/header/components/MobileSearchOverlay'
 import { Search } from 'lucide-react'
 import UserControls from '@/components/header/components/UserControls'
 import MobileNavigation from '@/components/header/components/MobileNavigation'
@@ -60,7 +61,7 @@ const HIDE_SEARCHBAR_ALWAYS_PATTERNS = [COMMUNITY_DETAIL, COMMUNITY_EDIT, /^\/pr
 
 // 홈 페이지에서 hero를 헤더 뒤로 깔기 위한 스크롤 임계값 (px)
 // 80px 정도 스크롤하면 솔리드 배경으로 전환 — 헤더 자신의 높이만큼
-const SOLID_BG_SCROLL_THRESHOLD = 80
+const SOLID_BG_SCROLL_THRESHOLD = 60
 
 // useSyncExternalStore용 subscribe 함수 (모듈 스코프 — 안정적 참조)
 const subscribeToScroll = (callback: () => void) => {
@@ -75,7 +76,6 @@ export default function Header() {
   const isXl = useMediaQuery('(min-width: 1280px)')
   const [isSideOpen, setIsSideOpen] = useState(false)
   const [isSearchOpen, setIsSearchOpen] = useState(false)
-  const searchBarHeight = 40
   const pathname = usePathname()
 
   // 가시성 계산
@@ -119,14 +119,11 @@ export default function Header() {
     }
 
     const baseHeight = 72
-    const expandedHeight = baseHeight + 12 + searchBarHeight + 12
 
     let nextHeight: number
     if (isHome) {
       // 홈: hero가 헤더 영역까지 차지하도록 padding-top 0
       nextHeight = 0
-    } else if (!isXl && isSearchOpen) {
-      nextHeight = expandedHeight
     } else {
       nextHeight = baseHeight
     }
@@ -136,7 +133,7 @@ export default function Header() {
     return () => {
       document.documentElement.style.removeProperty('--header-height')
     }
-  }, [showHeader, isSearchOpen, isXl, isHome])
+  }, [showHeader, isHome])
 
   if (!showHeader) return null
 
@@ -144,10 +141,13 @@ export default function Header() {
     <>
       <header
         className={cn(
-          'fixed top-0 flex w-full items-center justify-center pt-3 transition-colors duration-300 xl:pb-3',
-          !isXl && (isSearchOpen ? 'pb-0' : 'pb-3'),
+          'fixed top-0 flex w-full items-center justify-center py-3 transition-colors duration-300',
           // 홈 페이지 상단: 투명 (hero 위에 떠있음). 그 외: 솔리드 (cream bg + 보더)
-          showSolid ? 'border-outline-variant/40 bg-surface/95 border-b backdrop-blur-sm' : 'bg-transparent',
+          showSolid
+            ? 'border-outline-variant/40 bg-surface/95 border-b backdrop-blur-sm'
+            : isHome
+              ? 'bg-hero-surface'
+              : 'bg-transparent',
           Z_INDEX.HEADER
         )}
       >
@@ -218,28 +218,11 @@ export default function Header() {
             ) : null}
           </div>
 
-          {/* 모바일 검색바 - 아코디언 */}
-          {!hideSearchBar ? (
-            <div
-              className="overflow-hidden transition-all duration-300 xl:hidden"
-              style={{
-                height: isSearchOpen ? `${searchBarHeight}px` : '0',
-                marginTop: isSearchOpen ? '12px' : '0',
-                marginBottom: isSearchOpen ? '12px' : '0',
-              }}
-            >
-              <Suspense>
-                <SearchBar
-                  id="search-mobile"
-                  className="h-10 xl:hidden"
-                  inputClass="py-1 text-[15px] bg-white"
-                  wrapperClassName={cn('rounded-full bg-white', showSolid ? 'border border-[#d4c4b2]' : 'border-0')}
-                />
-              </Suspense>
-            </div>
-          ) : null}
         </div>
       </header>
+      {!hideSearchBar ? (
+        <MobileSearchOverlay isOpen={isSearchOpen} onClose={() => setIsSearchOpen(false)} />
+      ) : null}
       <MobileNavigation isOpen={isSideOpen} onClose={() => setIsSideOpen(false)} />
     </>
   )

--- a/src/components/header/components/MobileNotificationsOverlay.tsx
+++ b/src/components/header/components/MobileNotificationsOverlay.tsx
@@ -1,0 +1,189 @@
+'use client'
+
+import { useEffect } from 'react'
+import { X } from 'lucide-react'
+import { cn } from '@/lib/utils/cn'
+import { Z_INDEX } from '@/constants/ui'
+import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query'
+import { fetchGraphQL } from '@/lib/api/graphql'
+import { useUserStore } from '@/store/userStore'
+import { useIntersectionObserver } from '@/hooks/useIntersectionObserver'
+import type { NotificationItem as NotificationItemType } from '@/types/notifications'
+import NotificationItem from './notification-section/NotificationItem'
+import { useRouter, usePathname } from 'next/navigation'
+import { getNavigationPath } from '@/lib/utils/getNavigationPath'
+import NotificationsSkeleton from './notification-section/NotificationsSkeleton'
+import { chatSocketStore } from '@/store/chatSocketStore'
+
+interface MobileNotificationsOverlayProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+/**
+ * 모바일 전용 풀스크린 알림 오버레이.
+ *
+ * - 좌측에서 우측으로 슬라이드 인 (`-translate-x-full` → `translate-x-0`)
+ * - 닫기 버튼/ESC로 닫힘
+ * - 열렸을 때 body 스크롤 잠금
+ * - 데스크탑(`xl`)에서는 항상 숨김 (그쪽은 `NotificationsDropdown` 사용)
+ */
+export default function MobileNotificationsOverlay({ isOpen, onClose }: MobileNotificationsOverlayProps) {
+  const queryClient = useQueryClient()
+  const user = useUserStore((state) => state.user)
+  const router = useRouter()
+  const pathname = usePathname()
+
+  const {
+    data: notificationsData,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading,
+    refetch,
+  } = useInfiniteQuery({
+    queryKey: ['notifications'],
+    queryFn: async ({ pageParam }) => {
+      const data = await fetchGraphQL<{ notifications: any }>(
+        `
+        query Notifications($page: Int!, $size: Int!) {
+          notifications(page: $page, size: $size) {
+            content { notificationId notificationType title content relatedEntityType relatedEntityId isRead readAt createdAt }
+            page hasNext
+          }
+        }
+      `,
+        { page: pageParam, size: 10 }
+      )
+      return data.notifications
+    },
+    getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.page + 1 : undefined),
+    initialPageParam: 0,
+    enabled: !!user && isOpen,
+  })
+
+  const observerTargetRef = useIntersectionObserver({
+    enabled: hasNextPage ?? false,
+    hasNextPage: hasNextPage ?? false,
+    isFetchingNextPage,
+    onIntersect: () => fetchNextPage(),
+    threshold: 0.5,
+  })
+
+  // ESC 키로 닫기
+  useEffect(() => {
+    if (!isOpen) return
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [isOpen, onClose])
+
+  // 열림 동안 body 스크롤 잠금
+  useEffect(() => {
+    if (!isOpen) return
+    const prev = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = prev
+    }
+  }, [isOpen])
+
+  const handleMarkAllAsRead = async () => {
+    await fetchGraphQL(`
+      mutation MarkAllNotificationsRead {
+        markAllNotificationsRead { success }
+      }
+    `)
+    queryClient.setQueryData<{ unreadCount: number }>(['notifications', 'unreadCount'], { unreadCount: 0 })
+    refetch()
+  }
+
+  const handleReadNotification = async (notification: NotificationItemType) => {
+    if (!notification.isRead) {
+      queryClient.setQueryData<{ unreadCount: number }>(['notifications', 'unreadCount'], (prev) => ({
+        unreadCount: Math.max((prev?.unreadCount ?? 0) - 1, 0),
+      }))
+    }
+    if (notification.relatedEntityType === 'CHAT_ROOM') {
+      chatSocketStore.getState().clearUnreadCount(notification.relatedEntityId)
+    }
+    const currentPath = pathname
+    const targetPath = getNavigationPath(notification)
+    onClose()
+
+    if (currentPath === targetPath) {
+      if (notification.relatedEntityType === 'POST') {
+        queryClient.invalidateQueries({ queryKey: ['community', String(notification.relatedEntityId)] })
+      }
+    } else {
+      router.push(targetPath)
+    }
+    await fetchGraphQL(
+      `
+      mutation MarkNotificationRead($notificationId: Int!) {
+        markNotificationRead(notificationId: $notificationId) { success }
+      }
+    `,
+      { notificationId: notification.notificationId }
+    )
+    refetch()
+  }
+
+  return (
+    <div
+      className={cn(
+        'fixed inset-0 bg-white transition-transform duration-300 ease-out xl:hidden',
+        Z_INDEX.MODAL,
+        isOpen ? 'translate-x-0' : '-translate-x-full'
+      )}
+      role="dialog"
+      aria-modal="true"
+      aria-label="알림"
+      aria-hidden={!isOpen}
+    >
+      <div className="flex h-16 items-center justify-between border-b border-gray-200 px-2 pr-4">
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="알림 닫기"
+            className="flex h-10 w-10 cursor-pointer items-center justify-center rounded-full text-gray-600 hover:bg-gray-100"
+          >
+            <X size={24} />
+          </button>
+          <h2 className="text-lg font-semibold text-gray-900">알림</h2>
+        </div>
+        <button
+          type="button"
+          onClick={handleMarkAllAsRead}
+          className="text-primary-600 cursor-pointer text-sm"
+        >
+          모두 읽음
+        </button>
+      </div>
+
+      <div className="flex h-[calc(100%-4rem)] flex-col overflow-y-auto" role="tabpanel">
+        {isLoading ? (
+          <NotificationsSkeleton />
+        ) : notificationsData?.pages.some((page) => page.content.length > 0) ? (
+          <>
+            {notificationsData?.pages.flatMap((page) =>
+              page.content.map((notification: NotificationItemType) => (
+                <NotificationItem
+                  key={notification.notificationId}
+                  {...notification}
+                  handleReadNotification={handleReadNotification}
+                />
+              ))
+            )}
+            <div ref={observerTargetRef} className="h-1" />
+          </>
+        ) : (
+          <div className="flex h-32 items-center justify-center text-sm text-gray-500">표시할 알림이 없습니다.</div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/header/components/MobileSearchOverlay.tsx
+++ b/src/components/header/components/MobileSearchOverlay.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import { Suspense, useEffect } from 'react'
+import { X } from 'lucide-react'
+import { cn } from '@/lib/utils/cn'
+import { Z_INDEX } from '@/constants/ui'
+import SearchBar from './SearchBar'
+
+interface MobileSearchOverlayProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+/**
+ * 모바일 전용 풀스크린 검색 오버레이.
+ *
+ * - 우측에서 좌측으로 슬라이드 인 (`translate-x-full` → `translate-x-0`)
+ * - 검색 실행(Enter) 또는 닫기 버튼/ESC로 닫힘
+ * - 열렸을 때 body 스크롤 잠금 + 검색 input 자동 포커스
+ * - 데스크탑(`xl`)에서는 항상 숨김
+ */
+export default function MobileSearchOverlay({ isOpen, onClose }: MobileSearchOverlayProps) {
+  // ESC 키로 닫기
+  useEffect(() => {
+    if (!isOpen) return
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [isOpen, onClose])
+
+  // 열림 동안 body 스크롤 잠금
+  useEffect(() => {
+    if (!isOpen) return
+    const prev = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = prev
+    }
+  }, [isOpen])
+
+  // 슬라이드 인 끝난 뒤 input 자동 포커스
+  useEffect(() => {
+    if (!isOpen) return
+    const t = window.setTimeout(() => {
+      document.getElementById('search-mobile')?.focus()
+    }, 300)
+    return () => window.clearTimeout(t)
+  }, [isOpen])
+
+  return (
+    <div
+      className={cn(
+        'fixed inset-0 bg-white transition-transform duration-300 ease-out xl:hidden',
+        Z_INDEX.MODAL,
+        isOpen ? 'translate-x-0' : 'translate-x-full'
+      )}
+      role="dialog"
+      aria-modal="true"
+      aria-label="검색"
+      aria-hidden={!isOpen}
+    >
+      <div className="flex h-16 items-center gap-3 px-4 pt-3">
+        <div className="flex-1">
+          <Suspense>
+            <SearchBar
+              id="search-mobile"
+              className="h-10"
+              inputClass="py-1 text-[15px] bg-white"
+              wrapperClassName="rounded-full bg-white border border-[#d4c4b2]"
+              onSearch={onClose}
+            />
+          </Suspense>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="검색 닫기"
+          className="flex h-10 w-10 cursor-pointer items-center justify-center rounded-full text-gray-600 hover:bg-gray-100"
+        >
+          <X size={24} />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/header/components/SearchBar.tsx
+++ b/src/components/header/components/SearchBar.tsx
@@ -15,6 +15,7 @@ interface SearchBarProps {
   paramName?: string // URL 파라미터 이름 (기본값: 'keyword')
   inputClass?: string
   wrapperClassName?: string // Input wrapper className 오버라이드 (rounded, bg, border 등)
+  onSearch?: () => void // 검색 실행(Enter) 후 호출. 모바일 오버레이 닫기 등에 사용
 }
 
 export default function SearchBar({
@@ -25,6 +26,7 @@ export default function SearchBar({
   paramName = 'keyword',
   inputClass,
   wrapperClassName,
+  onSearch,
 }: SearchBarProps) {
   const searchParams = useSearchParams()
   const router = useRouter()
@@ -58,6 +60,7 @@ export default function SearchBar({
           router.push(ROUTES.HOME)
         }
       }
+      onSearch?.()
     }
   }
 

--- a/src/components/header/components/UserControls.tsx
+++ b/src/components/header/components/UserControls.tsx
@@ -10,6 +10,7 @@ import { ROUTES } from '@/constants/routes'
 import { MessageCircle, Bell } from 'lucide-react'
 import IconButton from '@/components/commons/button/IconButton'
 import NotificationsDropdown from './notification-section/NotificationsDropdown'
+import MobileNotificationsOverlay from './MobileNotificationsOverlay'
 import { useQuery } from '@tanstack/react-query'
 import { fetchGraphQL } from '@/lib/api/graphql'
 import { useNotificationSSE } from '@/hooks/useNotifications'
@@ -25,6 +26,7 @@ export default function UserControls({ isSideOpen, setIsSideOpen, hideMenuButton
   const [isUserMenuOpen, setIsUserMenuOpen] = useState(false)
   const user = useUserStore((state) => state.user)
   const [isNotificationOpen, setIsNotificationOpen] = useState(false)
+  const [isMobileNotificationOpen, setIsMobileNotificationOpen] = useState(false)
   const { isLogin } = useUserStore()
   const hasHydrated = useUserStore((state) => state._hasHydrated)
   const router = useRouter()
@@ -32,7 +34,7 @@ export default function UserControls({ isSideOpen, setIsSideOpen, hideMenuButton
   useNotificationSSE()
   const handleBellToggle = () => {
     if (isMobile) {
-      router.push(ROUTES.NOTIFICATIONS)
+      setIsMobileNotificationOpen(true)
     } else {
       setIsNotificationOpen((prev) => !prev)
     }
@@ -51,38 +53,46 @@ export default function UserControls({ isSideOpen, setIsSideOpen, hideMenuButton
   })
 
   return (
-    <div className="flex items-center gap-2 xl:gap-4">
-      {hasHydrated && isLogin() ? (
-        <div className="flex items-center gap-1">
-          <Link href={ROUTES.CHAT} className="ml-1 hidden xl:block" aria-label="채팅">
-            <MessageCircle className="text-primary" strokeWidth={1.5} size={20} />
-          </Link>
-          <div className="relative" onClick={handleBellToggle}>
-            <IconButton aria-label="알림" size="lg" className="hover:bg-transparent">
-              <Bell size={20} strokeWidth={1.5} className="text-primary" />
-            </IconButton>
-            {(unreadCountData?.unreadCount ?? 0) > 0 ? (
-              <span
-                className="bg-danger-500 absolute top-1 right-1 size-2 rounded-full"
-                aria-label={`읽지 않은 알림 ${unreadCountData?.unreadCount}개`}
-              />
-            ) : null}
-            {isNotificationOpen ? (
-              <NotificationsDropdown isNotificationOpen={isNotificationOpen} setIsNotificationOpen={setIsNotificationOpen} />
-            ) : null}
+    <>
+      <div className="flex items-center gap-2 xl:gap-4">
+        {hasHydrated && isLogin() ? (
+          <div className="flex items-center gap-1">
+            <Link href={ROUTES.CHAT} className="ml-1 hidden xl:block" aria-label="채팅">
+              <MessageCircle className="text-primary" strokeWidth={1.5} size={20} />
+            </Link>
+            <div className="relative" onClick={handleBellToggle}>
+              <IconButton aria-label="알림" size="lg" className="hover:bg-transparent">
+                <Bell size={isMobile ? 24 : 20} strokeWidth={isMobile ? 2 : 1.5} className="text-primary" />
+              </IconButton>
+              {(unreadCountData?.unreadCount ?? 0) > 0 ? (
+                <span
+                  className="bg-danger-500 absolute top-1 right-1 size-2 rounded-full"
+                  aria-label={`읽지 않은 알림 ${unreadCountData?.unreadCount}개`}
+                />
+              ) : null}
+              {isNotificationOpen ? (
+                <NotificationsDropdown isNotificationOpen={isNotificationOpen} setIsNotificationOpen={setIsNotificationOpen} />
+              ) : null}
+            </div>
+            <UserMenu
+              isNotificationOpen={false}
+              setIsNotificationOpen={setIsNotificationOpen}
+              isUserMenuOpen={isUserMenuOpen}
+              setIsUserMenuOpen={setIsUserMenuOpen}
+              isSideOpen={isSideOpen}
+              setIsSideOpen={setIsSideOpen}
+            />
           </div>
-          <UserMenu
-            isNotificationOpen={false}
-            setIsNotificationOpen={setIsNotificationOpen}
-            isUserMenuOpen={isUserMenuOpen}
-            setIsUserMenuOpen={setIsUserMenuOpen}
-            isSideOpen={isSideOpen}
-            setIsSideOpen={setIsSideOpen}
-          />
-        </div>
-      ) : (
-        <AuthMenu setIsSideOpen={setIsSideOpen} isSideOpen={isSideOpen} hideMenuButton={hideMenuButton} />
-      )}
-    </div>
+        ) : (
+          <AuthMenu setIsSideOpen={setIsSideOpen} isSideOpen={isSideOpen} hideMenuButton={hideMenuButton} />
+        )}
+      </div>
+      {hasHydrated && isLogin() ? (
+        <MobileNotificationsOverlay
+          isOpen={isMobileNotificationOpen}
+          onClose={() => setIsMobileNotificationOpen(false)}
+        />
+      ) : null}
+    </>
   )
 }

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -1,6 +1,6 @@
 import {
   MessageSquarePlus,
-  MessageSquareMore,
+  MessageCircleMore,
   MessageSquareText,
   HeartCrack,
   Tag,
@@ -329,7 +329,7 @@ export const NOTIFICATION_MESSAGES: Record<string, string> = {
 
 export const iconMap = {
   CHAT_NEW_ROOM: MessageSquarePlus,
-  CHAT_NEW_MESSAGE: MessageSquareMore,
+  CHAT_NEW_MESSAGE: MessageCircleMore,
   PRODUCT_FAVORITE_STATUS_CHANGED: HeartCrack,
   PRODUCT_FAVORITE_PRICE_CHANGED: Tag,
   ADMIN_SANCTION: ShieldAlert,

--- a/src/features/home/Home.tsx
+++ b/src/features/home/Home.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useInfiniteQuery } from '@tanstack/react-query'
-import { useState, useCallback, useMemo } from 'react'
+import { useState, useCallback, useMemo, useEffect } from 'react'
 import { DetailFilter } from '@/features/home/components/filter/DetailFilter'
 import { ProductsSection } from '@/features/home/components/product-section/ProductsSection'
 import { fetchGraphQL } from '@/lib/api/graphql'
@@ -26,6 +26,17 @@ function Home() {
   const hasHydrated = useUserStore((state) => state._hasHydrated)
   const isLoggedIn = hasHydrated && isLogin()
   const { searchParams, pathname, push } = useFilterNavigation()
+
+  // 메인페이지 새로고침 시 스크롤 복원 비활성화 — hero가 헤더와 같은 톤이라 항상 처음부터 보여야 자연스러움
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const prev = window.history.scrollRestoration
+    window.history.scrollRestoration = 'manual'
+    window.scrollTo(0, 0)
+    return () => {
+      window.history.scrollRestoration = prev
+    }
+  }, [])
 
   // URL에서 탭 초기값 결정 (시각적 표시용)
   const urlPetType = searchParams.get('petType')
@@ -276,11 +287,11 @@ function Home() {
       {isLoggedIn ? (
         <Link
           href="/product-post"
-          className={`fixed right-8 bottom-8 flex items-center gap-2 rounded-full bg-[#825500] px-5 py-3.5 text-white shadow-lg transition-all hover:brightness-110 active:scale-95 max-md:right-4 max-md:bottom-20 md:px-6 md:py-4 ${Z_INDEX.FLOATING_BUTTON}`}
+          className={`fixed right-8 bottom-8 flex items-center gap-2 rounded-full bg-[#825500] px-4 py-3 text-white shadow-lg transition-all hover:brightness-110 active:scale-95 max-md:right-4 max-md:bottom-20 md:px-6 md:py-4 ${Z_INDEX.FLOATING_BUTTON}`}
           aria-label="상품 등록"
         >
           <Plus size={20} strokeWidth={2.5} />
-          <span className="text-sm font-bold md:text-base">상품 등록</span>
+          <span className="text-base font-bold">상품 등록</span>
         </Link>
       ) : null}
     </>


### PR DESCRIPTION
## Summary

### 모바일 검색 풀스크린 오버레이 (`MobileSearchOverlay` 신규)
- 우→좌 슬라이드 인 (`translate-x-full → translate-x-0`)
- 검색 실행(Enter)·닫기 버튼·ESC로 닫힘, body 스크롤 잠금, input 자동 포커스
- `SearchBar`에 `onSearch?: () => void` prop 추가 → 검색 후 오버레이 자동 닫기
- 기존 모바일 인라인 검색 아코디언 영역 제거, 헤더 높이 분기 단순화 (`expandedHeight`, `searchBarHeight` 제거)

### 모바일 알림 풀스크린 오버레이 (`MobileNotificationsOverlay` 신규)
- 좌→우 슬라이드 인 (`-translate-x-full → translate-x-0`)
- 닫기·ESC로 닫힘, body 스크롤 잠금, 무한 스크롤·모두 읽음·항목 클릭 페이지 이동 지원
- `UserControls.handleBellToggle`: 모바일에서 `router.push('/notifications')` → `setIsMobileNotificationOpen(true)`
- 데스크탑은 기존 `NotificationsDropdown` 그대로 유지

### 메인페이지 헤더 톤 정비
- `isHome` + 스크롤 위 상태에서 헤더 배경을 `bg-hero-surface`로 (hero와 동일 톤)
- 스크롤 임계점 `80 → 60`으로 단축
- 메인페이지 새로고침 시 scroll restoration 비활성화:
  - root layout `<head>`에 inline script로 hydration 전 `history.scrollRestoration='manual'` 설정 (메인페이지 한정)
  - `Home.tsx` `useEffect`에서 `scrollTo(0, 0)` 보험 + cleanup 복원
- 다른 페이지는 영향 없음

### 헤더 아이콘 시각 통일
- 모바일 벨 아이콘 `size 24 / strokeWidth 2`로 통일 (돋보기·햄버거와 동일)
- 데스크탑은 기존 `size 20 / strokeWidth 1.5` 유지

### 알림 아이콘 변경
- `CHAT_NEW_MESSAGE` 아이콘 `MessageSquareMore` → `MessageCircleMore` (데스크탑·모바일 동일)

### 부수 정리
- 헤더 className 모바일 검색 펼침 분기 제거 (`pb-0`/`pb-3` 토글) → `py-3` 단순화
- 헤더 높이 계산 `useEffect` 의존성 정리 (`isSearchOpen`, `isXl` 제거)

## Test plan
- [ ] 모바일 헤더 돋보기 클릭 → 우→좌 슬라이드로 풀스크린 검색 오버레이 등장, input 자동 포커스
- [ ] 검색 입력 후 Enter → 결과 페이지로 이동 + 오버레이 자동 닫힘
- [ ] HomeHero "검색하러 가기" 버튼 클릭 시 `cuddle:open-search` 이벤트로 같은 오버레이 열림
- [ ] 모바일 헤더 벨 클릭 → 좌→우 슬라이드로 풀스크린 알림 오버레이 등장
- [ ] 알림 항목 클릭 → 해당 페이지 이동 + 오버레이 닫힘, 모두 읽음 동작 확인
- [ ] 메인페이지 진입 시 헤더가 `bg-hero-surface` 톤으로 hero와 일체감
- [ ] 메인페이지에서 60px 이상 스크롤 시 헤더가 cream 톤(`bg-surface/95` + blur + border)으로 전환
- [ ] 메인페이지 새로고침 시 항상 맨 위에서 시작 (헤더 톤 깜빡임 없음)
- [ ] 다른 페이지(상품 상세 등)의 scroll restoration은 기존 동작 유지
- [ ] 모바일 헤더에서 돋보기·벨·햄버거 아이콘 크기/굵기가 모두 동일하게 보임
- [ ] 알림 내역에서 채팅 알림 아이콘이 `MessageCircleMore`로 표시 (데스크탑·모바일)
- [ ] 비로그인 사용자는 알림 아이콘이 보이지 않음

closes #754