### PR TITLE
refactor: 질문/정보 페이지 모바일 반응형 정비 및 헤더·댓글 톤 통일

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -16,14 +16,13 @@ import UserControls from '@/components/header/components/UserControls'
 import MobileNavigation from '@/components/header/components/MobileNavigation'
 
 // ========== 공통 동적 경로 패턴 ==========
-const COMMUNITY_DETAIL = /^\/community\/\d+$/
+const COMMUNITY_DETAIL = /^\/community\/\d+(\/[^/]+)?$/
 const COMMUNITY_EDIT = /^\/community\/\d+\/edit$/
 const PRODUCT_EDIT = /^\/products\/\d+\/edit$/
 
 // Header 숨김 패턴 (모바일에서만 숨김)
 const CHAT_ROOM = /^\/chat(\/\d+)?$/
 const HIDE_HEADER_MOBILE_PATTERNS = [
-  COMMUNITY_DETAIL,
   COMMUNITY_EDIT,
   PRODUCT_EDIT,
   CHAT_ROOM,

--- a/src/features/community/CommunityDetail.tsx
+++ b/src/features/community/CommunityDetail.tsx
@@ -159,12 +159,12 @@ export default function CommunityDetail({ initialPostData, initialCommentData }:
   return (
     <>
       <div className="min-h-screen bg-white pt-8 pb-16 md:pb-0">
-        <div className="px-lg pb-4xl mx-auto max-w-7xl">
-          <div className="flex flex-col justify-center gap-3.5">
+        <div className="px-lg md:pb-4xl mx-auto max-w-7xl pb-0">
+          <div className="flex flex-col justify-center gap-1 md:gap-3.5">
             <button
               type="button"
               onClick={() => router.push('/community')}
-              className="text-on-surface-muted hover:text-on-surface mb-6 flex w-fit cursor-pointer items-center gap-1.5 text-sm font-semibold transition-colors"
+              className="text-on-surface-muted hover:text-on-surface mb-6 hidden w-fit cursor-pointer items-center gap-1.5 text-sm font-semibold transition-colors md:flex"
             >
               <ArrowLeft size={16} />
               <span>목록으로 돌아가기</span>
@@ -173,7 +173,7 @@ export default function CommunityDetail({ initialPostData, initialCommentData }:
               <Badge className="bg-primary-400 w-fit rounded-full text-xs text-white md:font-semibold">
                 {getBoardType(data.boardType as 'QUESTION' | 'INFO')}
               </Badge>
-              <h1 className="text-2xl leading-snug font-bold">{data.title}</h1>
+              <h1 className="text-xl leading-snug font-bold md:text-2xl">{data.title}</h1>
               <div className="border-outline-variant/40 flex items-end justify-between border-b pb-4">
                 <div className="flex items-center gap-3.5">
                   <ProfileAvatar
@@ -184,13 +184,15 @@ export default function CommunityDetail({ initialPostData, initialCommentData }:
                   />
                   {/* 유저 정보 */}
                   <div className="flex flex-col gap-2">
-                    <p className="text-sm leading-none font-medium md:text-base">{data.authorNickname}</p>
-                    <div className="flex items-center gap-1">
-                      <p className="text-xs leading-none text-gray-500">{getTimeAgo(data.createdAt)}</p>
+                    <p className="text-xs leading-none font-bold text-[#1c1b1b] md:text-base md:font-medium">
+                      {data.authorNickname}
+                    </p>
+                    <div className="flex items-center gap-0.5 md:gap-1">
+                      <p className="text-xs leading-none text-[#827565]">{getTimeAgo(data.createdAt)}</p>
                       <span aria-hidden="true" className="text-xs">
                         ·
                       </span>
-                      <p className="text-xs leading-none text-gray-500">조회 {data.viewCount}</p>
+                      <p className="text-xs leading-none text-[#827565]">조회 {data.viewCount}</p>
                     </div>
                   </div>
                 </div>
@@ -236,8 +238,8 @@ export default function CommunityDetail({ initialPostData, initialCommentData }:
               <MdPreview value={data.content} className="p-0" />
             </div>
 
-            <section aria-label="댓글" className="flex flex-col gap-3.5 py-5">
-              <div className="text-md flex items-center gap-1 font-semibold">
+            <section aria-label="댓글" className="border-outline-variant/40 flex flex-col gap-3.5 border-t py-5 md:border-t-0">
+              <div className="md:text-md flex items-center gap-1 text-sm font-semibold">
                 <span>댓글</span>
                 <span className="text-primary-container font-semibold">{data.commentCount}</span>
               </div>

--- a/src/features/community/CommunityPage.tsx
+++ b/src/features/community/CommunityPage.tsx
@@ -213,14 +213,14 @@ export default function CommunityPage({ initialQuestionData, initialInfoData }: 
               onKeyDown={handleSearchSubmit}
               placeholder="궁금한 내용을 검색해보세요"
               enterKeyHint="search"
-              className="border-outline-variant/40 bg-surface-container-low w-full rounded-full border py-2 pr-4 pl-11 text-sm text-[#1c1b1b] placeholder:text-sm placeholder:text-[#827565] focus:border-primary focus:ring-2 focus:ring-primary/20 focus:outline-none"
+              className="border-outline-variant/40 bg-surface-container-low focus:border-primary focus:ring-primary/20 w-full rounded-full border py-2 pr-4 pl-11 text-sm text-[#1c1b1b] placeholder:text-sm placeholder:text-[#827565] focus:ring-2 focus:outline-none"
             />
           </div>
         </section>
 
         {/* Sort filter + 글쓰기 (콘텐츠 컨트롤 행) */}
-        <section className="mb-4 flex items-end justify-between gap-3 text-sm">
-          <div className="flex items-center gap-3">
+        <section className="mb-2 flex items-end justify-between gap-3 text-sm md:mb-4">
+          <div className="flex items-center gap-3 max-md:ml-auto">
             {COMMUNITY_SORT_TYPE.map((sort, idx) => {
               const isActive = sort.id === sortBy
               return (
@@ -230,8 +230,10 @@ export default function CommunityPage({ initialQuestionData, initialInfoData }: 
                     type="button"
                     onClick={() => handleSortChange(sort.id)}
                     className={cn(
-                      'cursor-pointer transition-colors',
-                      isActive ? 'font-bold text-primary' : 'font-medium text-on-surface-muted hover:text-primary'
+                      'cursor-pointer font-normal transition-colors',
+                      isActive
+                        ? 'text-primary font-semibold md:font-bold'
+                        : 'text-on-surface-muted hover:text-primary md:font-medium'
                     )}
                   >
                     {sort.label}
@@ -243,7 +245,7 @@ export default function CommunityPage({ initialQuestionData, initialInfoData }: 
           {hasHydrated && isLogin() ? (
             <Link
               href={`${ROUTES.COMMUNITY_POST}?tab=${activeCommunityTypeTab}`}
-              className="hidden items-center gap-1.5 rounded-full bg-primary px-4 py-2 text-sm font-bold whitespace-nowrap text-white shadow-sm transition-opacity hover:opacity-90 active:scale-95 md:flex"
+              className="bg-primary hidden items-center gap-1.5 rounded-full px-4 py-2 text-sm font-bold whitespace-nowrap text-white shadow-sm transition-opacity hover:opacity-90 active:scale-95 md:flex"
             >
               <PenLine size={16} />
               <span>글쓰기</span>
@@ -265,28 +267,28 @@ export default function CommunityPage({ initialQuestionData, initialInfoData }: 
                 <li key={post.id}>
                   <Link
                     href={ROUTES.COMMUNITY_DETAIL_ID(post.id, post.title)}
-                    className="group border-outline-variant/40 block rounded-2xl border bg-white p-5 shadow-sm transition-all hover:shadow-md md:p-4"
+                    className="group border-outline-variant/40 block rounded-2xl border bg-white p-3 shadow-sm transition-all hover:shadow-md md:p-4"
                   >
-                    <div className="grid grid-cols-[minmax(0,1fr)_auto] items-stretch gap-4">
+                    <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-4 md:items-stretch">
                       <div className="min-w-0 flex-1">
                         {/* Author + time */}
                         <div className="mb-3 flex items-end gap-2.5">
                           <div className="bg-chip-surface flex size-9 items-center justify-center rounded-full text-sm font-bold text-[#825500]">
                             {post.authorNickname.charAt(0).toUpperCase()}
                           </div>
-                          <div className="flex flex-col leading-tight">
-                            <span className="text-sm font-bold text-[#1c1b1b]">{post.authorNickname}</span>
+                          <div className="flex flex-col gap-0.5 leading-tight md:gap-0">
+                            <span className="text-xs font-bold text-[#1c1b1b] md:text-sm">{post.authorNickname}</span>
                             <span className="text-xs text-[#827565]">{getTimeAgo(post.createdAt)}</span>
                           </div>
                         </div>
 
                         {/* Title */}
-                        <h3 className="mb-2 line-clamp-2 text-lg leading-snug font-semibold text-[#1c1b1b] transition-colors group-hover:text-primary">
+                        <h3 className="group-hover:text-primary mb-1 line-clamp-2 text-base leading-snug font-bold text-[#1c1b1b] transition-colors md:mb-2 md:text-lg md:font-semibold">
                           {post.title}
                         </h3>
 
                         {/* Preview */}
-                        <p className="line-clamp-2 text-sm leading-relaxed whitespace-pre-line text-on-surface-muted">
+                        <p className="text-on-surface-muted line-clamp-2 text-sm leading-relaxed whitespace-pre-line">
                           {post.contentPreview}
                         </p>
 
@@ -324,12 +326,13 @@ export default function CommunityPage({ initialQuestionData, initialInfoData }: 
         <Link
           href={`${ROUTES.COMMUNITY_POST}?tab=${activeCommunityTypeTab}`}
           className={cn(
-            'fixed right-4 bottom-20 flex items-center justify-center rounded-full bg-primary p-4 text-white shadow-lg md:hidden',
+            'bg-primary fixed right-4 bottom-20 flex items-center gap-2 rounded-full px-4 py-3 text-white shadow-lg transition-all hover:brightness-110 active:scale-95 md:hidden',
             Z_INDEX.FLOATING_BUTTON
           )}
           aria-label="글쓰기"
         >
-          <Plus size={24} />
+          <Plus size={20} strokeWidth={2.5} />
+          <span className="text-base font-bold">글쓰기</span>
         </Link>
       ) : null}
     </div>

--- a/src/features/community/components/CommentForm.tsx
+++ b/src/features/community/components/CommentForm.tsx
@@ -93,17 +93,17 @@ export function CommentForm({
     )
   }
 
-  // 기본 (댓글 입력) — 기존 디자인 유지
+  // 기본 (댓글 입력) — 모바일은 가로 컴팩트 카드, 데스크탑은 세로 카드. 색상은 디자인 시스템 토큰 통일
   return (
-    <form className="md:bg-primary-50 bg-transparent p-0 md:rounded-lg md:pt-5 md:pr-6 md:pb-4 md:pl-4" onSubmit={onSubmit}>
+    <form className="bg-primary-50 rounded-lg px-3 py-2 md:pt-5 md:pr-6 md:pb-4 md:pl-4" onSubmit={onSubmit}>
       <fieldset className="flex items-end gap-3.5 md:block">
         <legend className="sr-only">{legendText}</legend>
         <textarea
           id={id}
           placeholder={placeholder}
           className={cn(
-            'scrollbar-hide w-full flex-1 resize-none rounded-lg bg-[#f0f4ff] px-3 py-2 leading-tight focus:outline-none',
-            'md:bg-primary-50 md:h-auto md:rounded-none md:px-0 md:py-0 md:leading-normal'
+            'scrollbar-hide bg-primary-50 w-full flex-1 resize-none leading-tight focus:outline-none',
+            'md:h-auto md:leading-normal'
           )}
           style={{ height: `${baseHeight}px`, maxHeight: `${maxHeight}px`, overflowY: 'auto' }}
           ref={setRefs}

--- a/src/features/community/components/CommentItem.tsx
+++ b/src/features/community/components/CommentItem.tsx
@@ -15,7 +15,7 @@ function renderContentWithMention(content: string) {
   const [, mention, rest] = match
   return (
     <>
-      <span className="text-primary-container">{mention}</span>
+      <span className="text-primary-container text-sm md:text-base">{mention}</span>
       {rest}
     </>
   )
@@ -64,7 +64,7 @@ export function CommentItem({
         className={cn(
           'flex items-start gap-3.5',
           isReply
-            ? 'bg-surface-container-low rounded-lg px-4.5 py-4.5'
+            ? 'bg-surface-container-low rounded-lg px-2 py-3 md:px-4.5 md:py-4.5'
             : cn(showBorder && 'border-t border-gray-300 pt-3.5', !isRepliesOpen && 'pb-3.5')
         )}
       >
@@ -77,9 +77,9 @@ export function CommentItem({
 
         {/* 유저 정보 및 내용 */}
         <div className="flex flex-col justify-center gap-2">
-          <div className="flex flex-col gap-2">
+          <div className="flex flex-col gap-1 md:gap-2">
             <div className="flex items-center gap-1.5">
-              <p className="text-sm font-semibold md:text-base">{comment.authorNickname}</p>
+              <p className="text-[13px] font-semibold md:text-base">{comment.authorNickname}</p>
               {Number(comment.authorId) === user?.id ? (
                 <p className="bg-primary-200 rounded-full px-2 py-0.5 text-xs font-semibold text-white">내 댓글</p>
               ) : null}
@@ -87,19 +87,21 @@ export function CommentItem({
             <p className="whitespace-pre-wrap">{renderContentWithMention(comment.content)}</p>
           </div>
           <div className="flex items-center gap-1">
-            <p className="text-xs font-medium text-gray-500">{getTimeAgo(comment.createdAt)}</p>
-            <span aria-hidden="true" className="text-xs">
-              ·
-            </span>
+            <p className="text-xs text-gray-500 md:font-medium">{getTimeAgo(comment.createdAt)}</p>
             <div className="flex items-center gap-1">
               {onHandleReply ? (
-                <button
-                  className="text-primary-container cursor-pointer text-xs font-medium hover:underline"
-                  type="button"
-                  onClick={onHandleReply}
-                >
-                  답글 달기
-                </button>
+                <>
+                  <span aria-hidden="true" className="text-xs">
+                    ·
+                  </span>
+                  <button
+                    className="text-primary-container cursor-pointer text-xs hover:underline md:font-medium"
+                    type="button"
+                    onClick={onHandleReply}
+                  >
+                    답글 달기
+                  </button>
+                </>
               ) : null}
 
               {/* 답글 버튼 (대댓글이 아니고, hasChildren이 있을 때만) */}
@@ -109,7 +111,7 @@ export function CommentItem({
                     ·
                   </span>
                   <button
-                    className="text-primary-container cursor-pointer self-start text-xs font-medium hover:underline"
+                    className="text-primary-container cursor-pointer self-start text-xs hover:underline md:font-medium"
                     type="button"
                     onClick={onToggleReplies}
                   >

--- a/src/features/community/components/CommunityPostForm.tsx
+++ b/src/features/community/components/CommunityPostForm.tsx
@@ -200,32 +200,30 @@ export default function CommunityPostForm() {
   return (
     <>
       <h1 className="sr-only">{isEditMode ? '게시글 수정' : '커뮤니티 글쓰기'}</h1>
-      {/* 모바일 서브헤더 */}
+      {/* 모바일 서브헤더 — 댓글 페이지(ReplyOverlay)와 동일한 미니멀 톤 */}
       <div
         className={cn(
-          'bg-primary-200 sticky top-0 mx-auto flex w-full max-w-7xl justify-between px-3.5 py-4 md:hidden',
+          'sticky top-0 flex items-center gap-3 border-b border-gray-200 bg-white px-4 py-3 md:hidden',
           Z_INDEX.HEADER
         )}
       >
-        <button type="button" onClick={() => router.back()} className="flex cursor-pointer items-center gap-1 text-gray-600">
-          <ArrowLeft size={23} className="text-white" />
+        <button type="button" onClick={() => router.back()} aria-label="뒤로가기" className="cursor-pointer">
+          <ArrowLeft size={20} />
         </button>
-        <span className="heading-h4 absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-lg font-extrabold! text-white">
-          커뮤니티
-        </span>
+        <span className="text-base font-bold">{isEditMode ? '게시글 수정' : '게시글 작성'}</span>
       </div>
       {/* 데스크톱 서브헤더 */}
       <div className="hidden md:block">
         <SimpleHeader
-          title="커뮤니티 글쓰기"
-          description="일상 이야기를 마음껏 나눠보세요!"
+          title={isEditMode ? '게시글 수정' : '게시글 작성'}
+          description={isEditMode ? '게시글 내용을 수정해주세요' : '일상 이야기를 마음껏 나눠보세요!'}
           layoutClassname="py-3.5 gap-0 flex-col justify-between pt-8"
           titleClassName="text-[22px] leading-[1.5] font-bold"
           descriptionClassName="text-sm"
         />
       </div>
       <div className="min-h-screen pt-5">
-        <div className="px-lg pb-4xl mx-auto max-w-7xl">
+        <div className="px-lg md:pb-4xl mx-auto max-w-7xl">
           <AnimatePresence>
             {postError ? (
               <InlineNotification type="error" onClose={() => setPostError(null)}>
@@ -236,7 +234,7 @@ export default function CommunityPostForm() {
           <form className="w-full" onSubmit={handleSubmit(onSubmit)}>
             <fieldset className="flex flex-col gap-5">
               <legend className="sr-only">커뮤니티 등록폼</legend>
-              <div className="flex flex-col gap-3.5 rounded-3xl border border-gray-400 px-3.5 py-3.5 shadow-xl md:gap-5 md:px-8 md:py-8">
+              <div className="flex flex-col gap-3.5 rounded-xl border border-gray-400 px-3.5 py-3.5 shadow-xl md:gap-5 md:rounded-3xl md:px-8 md:py-8">
                 <Controller
                   name="boardType"
                   control={control}
@@ -244,7 +242,11 @@ export default function CommunityPostForm() {
                   render={({ field, fieldState }) => (
                     <div className="flex flex-col gap-2">
                       {/* <RequiredLabel labelClass="text-sm md:text-base font-semibold">카테고리</RequiredLabel> */}
-                      <div className="flex gap-2" role="radiogroup" aria-label="카테고리 선택">
+                      <div
+                        className="border-outline-variant/40 flex gap-2 border-b md:gap-6"
+                        role="radiogroup"
+                        aria-label="카테고리 선택"
+                      >
                         {COMMUNITY_TABS.map((category) => {
                           const isActive = field.value === category.code
                           return (
@@ -255,10 +257,10 @@ export default function CommunityPostForm() {
                               aria-checked={isActive}
                               onClick={() => field.onChange(category.code)}
                               className={cn(
-                                'cursor-pointer rounded-full border px-4 py-2 text-sm font-bold transition-colors',
+                                '-mb-px cursor-pointer border-b-2 px-1 pb-2 text-sm font-medium whitespace-nowrap transition-colors md:text-base',
                                 isActive
-                                  ? 'bg-primary/10 text-primary border-primary/20'
-                                  : 'border-outline-variant text-on-surface-muted hover:bg-surface-container-low'
+                                  ? 'border-primary text-primary font-bold'
+                                  : 'text-on-surface-muted hover:text-primary border-transparent'
                               )}
                             >
                               {category.label}


### PR DESCRIPTION
## Summary

### 헤더
- `COMMUNITY_DETAIL` 정규식을 슬러그 포함 매치로 확장 (`/^\/community\/\d+(\/[^/]+)?$/`) — 게시글 상세 URL에서 검색바·돋보기 버튼 정상 숨김
- 모바일에서 게시글 상세는 메인 헤더를 유지하도록 `HIDE_HEADER_MOBILE_PATTERNS`에서 `COMMUNITY_DETAIL` 제거

### 커뮤니티 목록 (`CommunityPage`)
- 모바일 정렬 필터를 우측 정렬 (`max-md:ml-auto`)
- 모바일 글쓰기 FAB을 메인페이지 "상품 등록" 버튼과 동일한 톤(Plus + "글쓰기" 텍스트 + 알약형)으로 통일
- 게시글 카드 grid에 `items-center` 적용해 본문과 썸네일 cross-axis 중앙 정렬

### 게시글 상세 (`CommunityDetail`)
- "목록으로 돌아가기" 버튼 모바일에서 숨김(`hidden md:flex`) — 모바일 표준 네비게이션과 중복

### 댓글 입력 (`CommentForm`)
- 모바일 textarea 배경을 임의 색(`#f0f4ff`) → 디자인 시스템 토큰(`bg-primary-50`)으로 통일
- form 컨테이너에 `bg-primary-50 rounded-lg` 적용해 등록 버튼이 같은 베이지 카드 안에 위치
- 모바일 가로 컴팩트 레이아웃은 유지

### 댓글 항목 (`CommentItem`)
- 시간 옆 구분점 `·`을 "답글 달기" 버튼과 묶어 조건부 렌더 → 답글 달기 prop 없을 때 빈 점이 보이는 버그 해결

### 작성/수정 페이지 (`CommunityPostForm`)
- 모바일 서브헤더 톤을 댓글 페이지(`ReplyOverlay`)와 동일한 미니멀 톤(`bg-white border-b` + 검정 텍스트, `ArrowLeft size={20}`)으로 통일
- 카테고리 선택 UI를 알약(pill) → underline tab 스타일로 (활성 `border-primary text-primary font-bold`)
- 타이틀/설명을 작성/수정 모드 분기 (모바일·데스크탑 동일):
  - 작성: "게시글 작성" / "일상 이야기를 마음껏 나눠보세요!"
  - 수정: "게시글 수정" / "게시글 내용을 수정해주세요"

## Test plan
- [ ] `/community/{id}/{slug}` 게시글 상세 페이지 모바일에서 헤더는 보이고 돋보기 버튼은 숨겨짐
- [ ] 모바일 커뮤니티 목록에서 정렬 옵션이 우측 정렬
- [ ] 모바일 커뮤니티 목록 FAB에 Plus 아이콘 + "글쓰기" 텍스트 표시
- [ ] 모바일 게시글 카드의 본문과 썸네일이 세로 중앙 정렬
- [ ] 모바일 게시글 상세 페이지 본문 영역에 "목록으로 돌아가기" 버튼 없음 (데스크탑은 유지)
- [ ] 모바일 댓글 입력창 + 등록 버튼이 같은 베이지 카드(`bg-primary-50`) 안에 위치
- [ ] 댓글 메타 영역에서 답글 달기 prop 없는 댓글은 `5일 전 · 삭제`(빈 점 X), 있는 댓글은 `5일 전 · 답글 달기 · 삭제`
- [ ] 작성/수정 페이지 모바일 서브헤더가 흰 배경 + 검정 텍스트로 댓글 페이지와 동일 톤
- [ ] 작성/수정 페이지에서 카테고리 선택이 underline tab 스타일
- [ ] 작성 진입 시 타이틀 "게시글 작성", 수정 진입 시 "게시글 수정"
- [ ] description도 모드별 분기 (작성/수정)

closes #756