### PR TITLE
refactor: 모바일 마이페이지 디자인 리뉴얼 (#758)

### DIFF
--- a/src/components/profile/ProfileData.tsx
+++ b/src/components/profile/ProfileData.tsx
@@ -166,7 +166,7 @@ export default function ProfileData({
   return (
     <aside
       aria-label="프로필"
-      className="bg-surface/95 border-outline-variant/40 flex h-fit flex-col rounded-none border-b px-5 py-5 md:max-w-72 md:min-w-72 md:rounded-xl md:border"
+      className="md:bg-surface/95 border-outline-variant/40 flex h-fit flex-col rounded-2xl border bg-white px-5 py-5 md:max-w-72 md:min-w-72 md:rounded-none md:rounded-xl md:border-b"
     >
       <AnimatePresence>
         {imageUpdateError ? (

--- a/src/features/UserPage.tsx
+++ b/src/features/UserPage.tsx
@@ -36,8 +36,7 @@ function UserPage() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const tabParam = searchParams.get('tab') as UserPageTabId | null
-  const activeTab: UserPageTabId =
-    tabParam && USER_PAGE_TABS.some((t) => t.id === tabParam) ? tabParam : 'tab-sales'
+  const activeTab: UserPageTabId = tabParam && USER_PAGE_TABS.some((t) => t.id === tabParam) ? tabParam : 'tab-sales'
   const isSalesTab = activeTab === 'tab-sales'
 
   const [, setIsWithdrawModalOpen] = useState(false)
@@ -156,7 +155,7 @@ function UserPage() {
 
   return (
     <>
-      <div className="pb-4xl relative pt-0 md:pt-8">
+      <div className="md:pb-4xl relative pt-0 md:pt-8">
         <div className="mx-auto max-w-7xl">
           <AnimatePresence>
             {unblockError ? (
@@ -168,7 +167,7 @@ function UserPage() {
             ) : null}
           </AnimatePresence>
         </div>
-        <div className="mx-auto flex max-w-7xl flex-col gap-0 md:flex-row md:gap-8">
+        <div className="mx-auto flex min-h-screen max-w-7xl flex-col gap-7 bg-gray-100/30 p-3 md:min-h-0 md:flex-row md:gap-8 md:bg-transparent md:p-0">
           <ProfileData
             setIsWithdrawModalOpen={setIsWithdrawModalOpen}
             setIsReportModalOpen={setIsReportModalOpen}
@@ -177,11 +176,11 @@ function UserPage() {
             isMyProfile={isMyProfile}
             unblockUser={unblockUser}
           />
-          <section className="flex w-full flex-col gap-6" aria-labelledby="user-product-heading">
+          <section className="flex w-full flex-col gap-1 md:gap-6" aria-labelledby="user-product-heading">
             <h4 id="user-product-heading" className="sr-only">
               {userData?.nickname}님의 {activeTabLabel}
             </h4>
-            <div className="flex flex-wrap items-center justify-between gap-3 px-5 md:px-0">
+            <div className="flex flex-wrap items-center justify-between gap-3">
               <Tabs
                 tabs={USER_PAGE_TABS}
                 activeTab={activeTab}
@@ -191,11 +190,11 @@ function UserPage() {
               />
               <p className="text-sm text-gray-500">총 {totalProducts}개</p>
             </div>
-            <div className="rounded-xl border-outline-variant/40 p-5 md:border">
+            <div className="border-outline-variant/40 rounded-xl py-5 md:border md:p-5">
               <div className="gap-lg flex flex-col">
                 {allProducts.length ? (
                   <>
-                    <ul className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+                    <ul className="grid grid-cols-3 gap-4 md:grid-cols-2 lg:grid-cols-4">
                       {allProducts.map((product) => (
                         <li key={product.id}>
                           <ProductCard data={product} vertical hideProductType />
@@ -212,8 +211,18 @@ function UserPage() {
           </section>
         </div>
       </div>
-      <UserReportModal isOpen={isReportModalOpen} onCancel={() => setIsReportModalOpen(false)} userNickname={userData.nickname} userId={Number(id)} />
-      <BlockModal isOpen={isBlockModalOpen} onCancel={() => setIsBlockModalOpen(false)} userNickname={userData.nickname} userId={Number(id)} />
+      <UserReportModal
+        isOpen={isReportModalOpen}
+        onCancel={() => setIsReportModalOpen(false)}
+        userNickname={userData.nickname}
+        userId={Number(id)}
+      />
+      <BlockModal
+        isOpen={isBlockModalOpen}
+        onCancel={() => setIsBlockModalOpen(false)}
+        userNickname={userData.nickname}
+        userId={Number(id)}
+      />
       <Footer />
     </>
   )

--- a/src/features/community/CommunityDetail.tsx
+++ b/src/features/community/CommunityDetail.tsx
@@ -158,7 +158,7 @@ export default function CommunityDetail({ initialPostData, initialCommentData }:
 
   return (
     <>
-      <div className="min-h-screen bg-white pt-8 pb-16 md:pb-0">
+      <div className="min-h-screen bg-white pt-5 pb-16 md:pt-8 md:pb-0">
         <div className="px-lg md:pb-4xl mx-auto max-w-7xl pb-0">
           <div className="flex flex-col justify-center gap-1 md:gap-3.5">
             <button
@@ -173,65 +173,69 @@ export default function CommunityDetail({ initialPostData, initialCommentData }:
               <Badge className="bg-primary-400 w-fit rounded-full text-xs text-white md:font-semibold">
                 {getBoardType(data.boardType as 'QUESTION' | 'INFO')}
               </Badge>
-              <h1 className="text-xl leading-snug font-bold md:text-2xl">{data.title}</h1>
-              <div className="border-outline-variant/40 flex items-end justify-between border-b pb-4">
-                <div className="flex items-center gap-3.5">
-                  <ProfileAvatar
-                    imageUrl={data.authorProfileImageUrl}
-                    nickname={data.authorNickname}
-                    size="lg"
-                    className="h-10 w-10 md:h-10 md:w-10"
-                  />
-                  {/* 유저 정보 */}
-                  <div className="flex flex-col gap-2">
-                    <p className="text-xs leading-none font-bold text-[#1c1b1b] md:text-base md:font-medium">
-                      {data.authorNickname}
-                    </p>
-                    <div className="flex items-center gap-0.5 md:gap-1">
-                      <p className="text-xs leading-none text-[#827565]">{getTimeAgo(data.createdAt)}</p>
-                      <span aria-hidden="true" className="text-xs">
-                        ·
-                      </span>
-                      <p className="text-xs leading-none text-[#827565]">조회 {data.viewCount}</p>
+              <div className="flex flex-col-reverse gap-3.5 md:flex-col">
+                <h1 className="border-outline-variant/40 border-b pb-4 text-xl leading-snug font-bold md:border-0 md:p-0 md:text-2xl">
+                  {data.title}
+                </h1>
+                <div className="md:border-outline-variant/40 flex items-end justify-between md:border-b md:pb-4">
+                  <div className="flex items-center gap-3.5">
+                    <ProfileAvatar
+                      imageUrl={data.authorProfileImageUrl}
+                      nickname={data.authorNickname}
+                      size="lg"
+                      className="h-10 w-10 md:h-10 md:w-10"
+                    />
+                    {/* 유저 정보 */}
+                    <div className="flex flex-col gap-2">
+                      <p className="text-sm leading-none font-bold text-[#1c1b1b] md:text-base md:font-medium">
+                        {data.authorNickname}
+                      </p>
+                      <div className="flex items-center gap-0.5 md:gap-1">
+                        <p className="text-xs leading-none text-[#827565]">{getTimeAgo(data.createdAt)}</p>
+                        <span aria-hidden="true" className="text-xs">
+                          ·
+                        </span>
+                        <p className="text-xs leading-none text-[#827565]">조회 {data.viewCount}</p>
+                      </div>
                     </div>
                   </div>
-                </div>
-                <div className="flex items-center gap-1">
-                  {user?.id === data?.authorId ? (
-                    <>
+                  <div className="flex items-center gap-1">
+                    {user?.id === data?.authorId ? (
+                      <>
+                        <button
+                          className="text-primary-container cursor-pointer text-xs font-medium hover:underline"
+                          type="button"
+                          onClick={() => handlePostEdit(Number(id))}
+                        >
+                          수정
+                        </button>
+                        <span aria-hidden="true" className="text-xs">
+                          ·
+                        </span>
+                        <button
+                          className="text-primary-container cursor-pointer text-xs font-medium hover:underline"
+                          type="button"
+                          onClick={() => setIsPostDeleteModalOpen(true)}
+                        >
+                          삭제
+                        </button>
+                      </>
+                    ) : (
                       <button
-                        className="text-primary-container cursor-pointer text-xs font-medium hover:underline"
+                        className="cursor-pointer text-xs font-medium text-gray-500 hover:underline"
                         type="button"
-                        onClick={() => handlePostEdit(Number(id))}
+                        onClick={() => {
+                          if (!user) {
+                            openLoginModal()
+                          } else {
+                            setIsReportModalOpen(true)
+                          }
+                        }}
                       >
-                        수정
+                        신고하기
                       </button>
-                      <span aria-hidden="true" className="text-xs">
-                        ·
-                      </span>
-                      <button
-                        className="text-primary-container cursor-pointer text-xs font-medium hover:underline"
-                        type="button"
-                        onClick={() => setIsPostDeleteModalOpen(true)}
-                      >
-                        삭제
-                      </button>
-                    </>
-                  ) : (
-                    <button
-                      className="cursor-pointer text-xs font-medium text-gray-500 hover:underline"
-                      type="button"
-                      onClick={() => {
-                        if (!user) {
-                          openLoginModal()
-                        } else {
-                          setIsReportModalOpen(true)
-                        }
-                      }}
-                    >
-                      신고하기
-                    </button>
-                  )}
+                    )}
+                  </div>
                 </div>
               </div>
               {/* <h1 className="text-lg leading-snug font-bold">{data.title}</h1> */}

--- a/src/features/community/CommunityPage.tsx
+++ b/src/features/community/CommunityPage.tsx
@@ -190,7 +190,7 @@ export default function CommunityPage({ initialQuestionData, initialInfoData }: 
   return (
     <div className="min-h-screen bg-white">
       <h1 className="sr-only">커뮤니티 페이지</h1>
-      <main className="mx-auto w-full max-w-7xl px-4 py-8">
+      <main className="mx-auto w-full max-w-7xl px-4 py-5 md:py-8">
         {/* Header */}
         <section className="mb-4">
           {/* <h2 className="mb-6 text-lg font-bold tracking-tight text-primary">질문/정보</h2> */}
@@ -262,7 +262,7 @@ export default function CommunityPage({ initialQuestionData, initialInfoData }: 
           {communityPosts.length === 0 ? (
             <EmptyState icon={MessageSquareText} title="아직 게시글이 없어요" description="첫 번째 이야기를 나눠보세요!" />
           ) : (
-            <ul className="grid grid-cols-1 gap-4">
+            <ul className="grid grid-cols-1 gap-2 md:gap-4">
               {communityPosts.map((post) => (
                 <li key={post.id}>
                   <Link
@@ -283,7 +283,7 @@ export default function CommunityPage({ initialQuestionData, initialInfoData }: 
                         </div>
 
                         {/* Title */}
-                        <h3 className="group-hover:text-primary mb-1 line-clamp-2 text-base leading-snug font-bold text-[#1c1b1b] transition-colors md:mb-2 md:text-lg md:font-semibold">
+                        <h3 className="group-hover:text-primary mb-1 line-clamp-2 text-base leading-snug font-semibold text-[#1c1b1b] transition-colors md:mb-2 md:text-lg">
                           {post.title}
                         </h3>
 

--- a/src/features/my-page/MyPage.tsx
+++ b/src/features/my-page/MyPage.tsx
@@ -30,7 +30,7 @@ import Button from '@/components/commons/button/Button'
 import { cn } from '@/lib/utils/cn'
 import { useMediaQuery } from '@/hooks/useMediaQuery'
 import { Z_INDEX } from '@/constants/ui'
-import { ArrowLeft, Receipt, Handbag, ChevronRight, Heart, MessageSquareText, UserX, Headphones } from 'lucide-react'
+import { ArrowLeft, Tag, Handbag, ChevronRight, Heart, MessageSquareText, UserX, Headphones } from 'lucide-react'
 import Link from 'next/link'
 
 function MyPage() {
@@ -64,14 +64,21 @@ function MyPage() {
   // 모바일 메뉴 클릭 시 풀스크린에 표시할 탭 (null이면 닫힘; 'activity'는 MyActivityPanel 표시)
   const [mobilePanelTab, setMobilePanelTab] = useState<MyPageTabId | 'activity' | null>(null)
   const mobilePanelTitle =
-    mobilePanelTab === 'tab-sales' ? '판매 내역' :
-    mobilePanelTab === 'tab-purchases' ? '구매 내역' :
-    mobilePanelTab === 'tab-wishlist' ? '찜한 상품' :
-    mobilePanelTab === 'tab-blocked' ? '차단 유저' :
-    mobilePanelTab === 'activity' ? '내 글' : ''
-  const mobilePanelTabCode = mobilePanelTab && mobilePanelTab !== 'activity'
-    ? MY_PAGE_TABS.find((tab) => tab.id === mobilePanelTab)?.code ?? 'SELL'
-    : 'SELL'
+    mobilePanelTab === 'tab-sales'
+      ? '판매 내역'
+      : mobilePanelTab === 'tab-purchases'
+        ? '구매 내역'
+        : mobilePanelTab === 'tab-wishlist'
+          ? '찜한 상품'
+          : mobilePanelTab === 'tab-blocked'
+            ? '차단 유저'
+            : mobilePanelTab === 'activity'
+              ? '내 글'
+              : ''
+  const mobilePanelTabCode =
+    mobilePanelTab && mobilePanelTab !== 'activity'
+      ? (MY_PAGE_TABS.find((tab) => tab.id === mobilePanelTab)?.code ?? 'SELL')
+      : 'SELL'
   const mobileTradeStatusTabs =
     mobilePanelTab === 'tab-purchases'
       ? [
@@ -366,10 +373,10 @@ function MyPage() {
 
   return (
     <>
-      <div className="pb-4xl bg-surface pt-0 md:bg-transparent md:pt-8">
+      <div className="pb-4xl bg-gray-100/30 pt-0 md:bg-transparent md:pt-8">
         <h1 className="sr-only">마이페이지</h1>
         <div className="mx-auto flex max-w-7xl flex-col gap-3.5 md:flex-row md:gap-8">
-          <div className="flex flex-col gap-3 px-2 py-3 md:p-0">
+          <div className="flex flex-col gap-2 p-3 md:p-0">
             {/* 모바일: 압축 프로필 카드 (클릭 시 풀스크린 진입) */}
             <button
               type="button"
@@ -377,7 +384,7 @@ function MyPage() {
               aria-label="프로필 자세히 보기"
               className="border-outline-variant/40 flex w-full cursor-pointer flex-col gap-3 rounded-2xl border bg-white p-5 text-left transition-colors hover:bg-gray-50 md:hidden"
             >
-              <div className="flex items-center gap-3.5">
+              <div className="flex items-start gap-3.5">
                 <div className="bg-primary-50 flex h-14 w-14 shrink-0 items-center justify-center overflow-hidden rounded-full">
                   {myData?.profileImageUrl ? (
                     // eslint-disable-next-line @next/next/no-img-element
@@ -386,83 +393,84 @@ function MyPage() {
                     <span className="text-xl font-semibold text-[#825500]">{myData?.nickname?.charAt(0).toUpperCase()}</span>
                   )}
                 </div>
-                <div className="flex flex-col gap-0.5">
+                <div className="flex flex-1 flex-col gap-0.5">
                   <p className="text-base font-bold text-[#1c1b1b]">{myData?.nickname}</p>
                   <p className="text-sm text-gray-500">{`${myData?.addressSido ?? ''} ${myData?.addressGugun ?? ''}`.trim()}</p>
                 </div>
+                <ChevronRight size={25} strokeWidth={1.5} className="text-on-surface-muted" />
               </div>
               {myData?.introduction ? <p className="line-clamp-1 text-sm text-gray-500">{myData.introduction}</p> : null}
             </button>
 
             {/* 모바일 전용 섹션 */}
-            <section className="flex flex-col gap-3.5 md:hidden" aria-label="마이페이지 모바일 콘텐츠">
-              <div className="border-outline-variant/40 rounded-2xl border bg-white p-5">
-                <h2 className="mb-3 text-base font-bold text-[#1c1b1b]">내 상품 관리</h2>
+            <section className="flex flex-col gap-2 md:hidden" aria-label="마이페이지 모바일 콘텐츠">
+              <div className="border-outline-variant/40 flex flex-col gap-2 rounded-2xl border bg-white p-5">
+                <h2 className="text-sm font-bold text-[#1c1b1b]">내 상품 관리</h2>
                 <div className="flex flex-col">
                   <button
                     type="button"
                     onClick={() => setMobilePanelTab('tab-sales')}
-                    className="text-on-surface flex cursor-pointer items-center gap-3 py-3"
+                    className="text-on-surface flex cursor-pointer items-center gap-3 py-2"
                   >
-                    <Receipt size={20} strokeWidth={1.5} />
-                    <span className="flex-1 text-left text-sm">판매 내역</span>
-                    <ChevronRight size={18} className="text-on-surface-muted" />
+                    <Tag size={20} strokeWidth={1.5} />
+                    <span className="flex-1 text-left text-base">판매 내역</span>
+                    <ChevronRight size={25} strokeWidth={1.5} className="text-on-surface-muted" />
                   </button>
                   <button
                     type="button"
                     onClick={() => setMobilePanelTab('tab-purchases')}
-                    className="text-on-surface flex cursor-pointer items-center gap-3 py-3"
+                    className="text-on-surface flex cursor-pointer items-center gap-3 py-2"
                   >
                     <Handbag size={20} strokeWidth={1.5} />
-                    <span className="flex-1 text-left text-sm">구매내역</span>
-                    <ChevronRight size={18} className="text-on-surface-muted" />
+                    <span className="flex-1 text-left text-base">구매내역</span>
+                    <ChevronRight size={25} strokeWidth={1.5} className="text-on-surface-muted" />
                   </button>
                   <button
                     type="button"
                     onClick={() => setMobilePanelTab('tab-wishlist')}
-                    className="text-on-surface flex cursor-pointer items-center gap-3 py-3"
+                    className="text-on-surface flex cursor-pointer items-center gap-3 py-2"
                   >
                     <Heart size={20} strokeWidth={1.5} />
-                    <span className="flex-1 text-left text-sm">찜한 상품</span>
-                    <ChevronRight size={18} className="text-on-surface-muted" />
+                    <span className="flex-1 text-left text-base">찜한 상품</span>
+                    <ChevronRight size={25} strokeWidth={1.5} className="text-on-surface-muted" />
                   </button>
                 </div>
               </div>
 
-              <div className="border-outline-variant/40 rounded-2xl border bg-white p-5">
-                <h2 className="mb-3 text-base font-bold text-[#1c1b1b]">나의 활동</h2>
+              <div className="border-outline-variant/40 flex flex-col gap-2 rounded-2xl border bg-white p-5">
+                <h2 className="text-sm font-bold text-[#1c1b1b]">나의 활동</h2>
                 <div className="flex flex-col">
                   <button
                     type="button"
                     onClick={() => setMobilePanelTab('activity')}
-                    className="text-on-surface flex cursor-pointer items-center gap-3 py-3"
+                    className="text-on-surface flex cursor-pointer items-center gap-3 py-2"
                   >
                     <MessageSquareText size={20} strokeWidth={1.5} />
-                    <span className="flex-1 text-left text-sm">내 글</span>
-                    <ChevronRight size={18} className="text-on-surface-muted" />
+                    <span className="flex-1 text-left text-base">내 글</span>
+                    <ChevronRight size={25} strokeWidth={1.5} className="text-on-surface-muted" />
                   </button>
                   <button
                     type="button"
                     onClick={() => setMobilePanelTab('tab-blocked')}
-                    className="text-on-surface flex cursor-pointer items-center gap-3 py-3"
+                    className="text-on-surface flex cursor-pointer items-center gap-3 py-2"
                   >
                     <UserX size={20} strokeWidth={1.5} />
-                    <span className="flex-1 text-left text-sm">차단 유저</span>
-                    <ChevronRight size={18} className="text-on-surface-muted" />
+                    <span className="flex-1 text-left text-base">차단 유저</span>
+                    <ChevronRight size={25} strokeWidth={1.5} className="text-on-surface-muted" />
                   </button>
                 </div>
               </div>
 
-              <div className="border-outline-variant/40 rounded-2xl border bg-white p-5">
-                <h2 className="mb-3 text-base font-bold text-[#1c1b1b]">고객지원</h2>
+              <div className="border-outline-variant/40 flex flex-col gap-2 rounded-2xl border bg-white p-5">
+                <h2 className="text-base font-bold text-[#1c1b1b]">고객지원</h2>
                 <div className="flex flex-col">
                   <a
                     href="mailto:support@cuddlemarket.com?subject=커들마켓 1:1 문의"
                     className="text-on-surface flex items-center gap-3 py-3"
                   >
                     <Headphones size={20} strokeWidth={1.5} />
-                    <span className="flex-1 text-left text-sm">고객센터</span>
-                    <ChevronRight size={18} className="text-on-surface-muted" />
+                    <span className="flex-1 text-left text-base">고객센터</span>
+                    <ChevronRight size={25} strokeWidth={1.5} className="text-on-surface-muted" />
                   </a>
                 </div>
               </div>
@@ -575,7 +583,7 @@ function MyPage() {
       {/* 모바일 ProfileData 풀스크린 — 좌→우 슬라이드 */}
       <div
         className={cn(
-          'bg-surface fixed inset-0 overflow-y-auto px-2 transition-transform duration-300 ease-out md:hidden',
+          'fixed inset-0 overflow-y-auto bg-gray-100/30 transition-transform duration-300 ease-out md:hidden',
           Z_INDEX.MODAL,
           isProfileFullViewOpen ? 'translate-x-0' : '-translate-x-full'
         )}
@@ -583,13 +591,13 @@ function MyPage() {
         aria-label="프로필 자세히"
         aria-hidden={!isProfileFullViewOpen}
       >
-        <div className="sticky top-0 flex h-16 items-center gap-3 border-b border-gray-200 bg-white">
+        <div className="sticky top-0 z-10 flex h-16 items-center gap-3 border-b border-gray-200 bg-white px-2">
           <button type="button" onClick={() => setIsProfileFullViewOpen(false)} aria-label="닫기" className="cursor-pointer">
             <ArrowLeft size={20} />
           </button>
           <span className="text-base font-bold">프로필</span>
         </div>
-        <div className="flex flex-col gap-3 py-4">
+        <div className="flex flex-col gap-2 px-2 py-2">
           <ProfileData
             setIsWithdrawModalOpen={setIsWithdrawModalOpen}
             data={myData!}
@@ -621,25 +629,22 @@ function MyPage() {
         aria-hidden={!mobilePanelTab}
       >
         <div className="sticky top-0 flex h-16 items-center gap-3 border-b border-gray-200 bg-white px-4">
-          <button
-            type="button"
-            onClick={() => setMobilePanelTab(null)}
-            aria-label="닫기"
-            className="cursor-pointer"
-          >
+          <button type="button" onClick={() => setMobilePanelTab(null)} aria-label="닫기" className="cursor-pointer">
             <ArrowLeft size={20} />
           </button>
           <span className="text-base font-bold">{mobilePanelTitle}</span>
         </div>
-        <div className="flex flex-col gap-4 p-4">
+        <div className="flex flex-col">
           {mobilePanelTab === 'tab-sales' || mobilePanelTab === 'tab-purchases' ? (
-            <Tabs
-              tabs={mobileTradeStatusTabs}
-              activeTab={activeTradeStatus}
-              onTabChange={(tabId) => setActiveTradeStatus(tabId as TransactionStatus | 'ALL')}
-              ariaLabel={mobilePanelTab === 'tab-sales' ? '판매 상태 메뉴' : '구매 상태 메뉴'}
-              variant="card-pill"
-            />
+            <div className="p-4">
+              <Tabs
+                tabs={mobileTradeStatusTabs}
+                activeTab={activeTradeStatus}
+                onTabChange={(tabId) => setActiveTradeStatus(tabId as TransactionStatus | 'ALL')}
+                ariaLabel={mobilePanelTab === 'tab-sales' ? '판매 상태 메뉴' : '구매 상태 메뉴'}
+                variant="card-pill"
+              />
+            </div>
           ) : null}
           {mobilePanelTab === 'activity' ? (
             <MyActivityPanel />
@@ -649,13 +654,9 @@ function MyPage() {
               activeMyPageTab={mobilePanelTab}
               activeTradeStatus={activeTradeStatus}
               myProductsData={filteredMyProductsData}
-              myProductsTotal={
-                mobilePanelTab === 'tab-sales' ? filteredMyProductsData?.length : myProductsData?.pages[0]?.total
-              }
+              myProductsTotal={mobilePanelTab === 'tab-sales' ? filteredMyProductsData?.length : myProductsData?.pages[0]?.total}
               myRequestData={filteredMyRequestData}
-              myRequestTotal={
-                activeTradeStatus === 'ALL' ? myRequestData?.pages[0]?.total : filteredMyRequestData?.length
-              }
+              myRequestTotal={activeTradeStatus === 'ALL' ? myRequestData?.pages[0]?.total : filteredMyRequestData?.length}
               myFavoriteData={myFavoriteData?.pages.flatMap((page) => page.content)}
               myFavoriteTotal={myFavoriteData?.pages[0]?.total}
               myBlockedData={myBlockedData?.pages.flatMap((page) => page.content)}

--- a/src/features/my-page/MyPage.tsx
+++ b/src/features/my-page/MyPage.tsx
@@ -376,7 +376,7 @@ function MyPage() {
       <div className="pb-4xl bg-gray-100/30 pt-0 md:bg-transparent md:pt-8">
         <h1 className="sr-only">마이페이지</h1>
         <div className="mx-auto flex max-w-7xl flex-col gap-3.5 md:flex-row md:gap-8">
-          <div className="flex flex-col gap-2 p-3 md:p-0">
+          <div className="flex flex-col gap-2 p-2 md:p-0">
             {/* 모바일: 압축 프로필 카드 (클릭 시 풀스크린 진입) */}
             <button
               type="button"

--- a/src/features/my-page/MyPage.tsx
+++ b/src/features/my-page/MyPage.tsx
@@ -28,6 +28,10 @@ import InlineNotification from '@/components/commons/InlineNotification'
 import Spinner from '@/components/commons/spinner/Spinner'
 import Button from '@/components/commons/button/Button'
 import { cn } from '@/lib/utils/cn'
+import { useMediaQuery } from '@/hooks/useMediaQuery'
+import { Z_INDEX } from '@/constants/ui'
+import { ArrowLeft, Receipt, Handbag, ChevronRight, Heart, MessageSquareText, UserX, Headphones } from 'lucide-react'
+import Link from 'next/link'
 
 function MyPage() {
   const [deleteError, setDeleteError] = useState<React.ReactNode | null>(null)
@@ -52,6 +56,35 @@ function MyPage() {
   const navParam = searchParams.get('nav') as MyPageNavId | null
   const activeMyPageTab = tabParam && MY_PAGE_TABS.some((tab) => tab.id === tabParam) ? tabParam : 'tab-sales'
   const activeMyPageNav = navParam && MY_PAGE_NAV.some((tab) => tab.id === navParam) ? navParam : 'nav-dash'
+
+  // 모바일에서는 사이드 nav 숨김 + 대시보드 강제 노출
+  const isMobile = useMediaQuery('(max-width: 767px)')
+  const effectiveNav: MyPageNavId = isMobile ? 'nav-dash' : activeMyPageNav
+  const [isProfileFullViewOpen, setIsProfileFullViewOpen] = useState(false)
+  // 모바일 메뉴 클릭 시 풀스크린에 표시할 탭 (null이면 닫힘; 'activity'는 MyActivityPanel 표시)
+  const [mobilePanelTab, setMobilePanelTab] = useState<MyPageTabId | 'activity' | null>(null)
+  const mobilePanelTitle =
+    mobilePanelTab === 'tab-sales' ? '판매 내역' :
+    mobilePanelTab === 'tab-purchases' ? '구매 내역' :
+    mobilePanelTab === 'tab-wishlist' ? '찜한 상품' :
+    mobilePanelTab === 'tab-blocked' ? '차단 유저' :
+    mobilePanelTab === 'activity' ? '내 글' : ''
+  const mobilePanelTabCode = mobilePanelTab && mobilePanelTab !== 'activity'
+    ? MY_PAGE_TABS.find((tab) => tab.id === mobilePanelTab)?.code ?? 'SELL'
+    : 'SELL'
+  const mobileTradeStatusTabs =
+    mobilePanelTab === 'tab-purchases'
+      ? [
+          { id: 'ALL', label: '전체', code: 'ALL' },
+          { id: 'SELLING', label: '요청중', code: 'SELLING' },
+          { id: 'COMPLETED', label: '구매완료', code: 'COMPLETED' },
+        ]
+      : [
+          { id: 'ALL', label: '전체', code: 'ALL' },
+          { id: 'SELLING', label: '판매중', code: 'SELLING' },
+          { id: 'RESERVED', label: '예약중', code: 'RESERVED' },
+          { id: 'COMPLETED', label: '판매완료', code: 'COMPLETED' },
+        ]
   const activeTabCode = MY_PAGE_TABS.find((tab) => tab.id === activeMyPageTab)?.code ?? 'SELL'
 
   const {
@@ -99,7 +132,7 @@ function MyPage() {
     },
     getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.page + 1 : undefined),
     initialPageParam: 0,
-    enabled: activeMyPageTab === 'tab-purchases' || activeMyPageNav === 'nav-dash',
+    enabled: activeMyPageTab === 'tab-purchases' || effectiveNav === 'nav-dash',
   })
 
   const {
@@ -116,7 +149,7 @@ function MyPage() {
     },
     getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.page + 1 : undefined),
     initialPageParam: 0,
-    enabled: activeMyPageTab === 'tab-wishlist' || activeMyPageNav === 'nav-dash',
+    enabled: activeMyPageTab === 'tab-wishlist' || effectiveNav === 'nav-dash',
   })
 
   const {
@@ -333,22 +366,123 @@ function MyPage() {
 
   return (
     <>
-      <div className="pb-4xl pt-0 md:pt-8">
+      <div className="pb-4xl bg-surface pt-0 md:bg-transparent md:pt-8">
         <h1 className="sr-only">마이페이지</h1>
         <div className="mx-auto flex max-w-7xl flex-col gap-3.5 md:flex-row md:gap-8">
-          <div className="flex flex-col gap-3">
-            <ProfileData
-              setIsWithdrawModalOpen={setIsWithdrawModalOpen}
-              data={myData!}
-              isMyProfile
-              enableImageUpload
-              summaryCounts={{
-                sales: myProductsData?.pages[0]?.total ?? 0,
-                purchases: myRequestData?.pages[0]?.total ?? 0,
-                wishlist: myFavoriteData?.pages[0]?.total ?? 0,
-              }}
-            />
-            <div role="tablist" aria-label="마이페이지 메뉴" className="flex flex-col gap-1">
+          <div className="flex flex-col gap-3 px-2 py-3 md:p-0">
+            {/* 모바일: 압축 프로필 카드 (클릭 시 풀스크린 진입) */}
+            <button
+              type="button"
+              onClick={() => setIsProfileFullViewOpen(true)}
+              aria-label="프로필 자세히 보기"
+              className="border-outline-variant/40 flex w-full cursor-pointer flex-col gap-3 rounded-2xl border bg-white p-5 text-left transition-colors hover:bg-gray-50 md:hidden"
+            >
+              <div className="flex items-center gap-3.5">
+                <div className="bg-primary-50 flex h-14 w-14 shrink-0 items-center justify-center overflow-hidden rounded-full">
+                  {myData?.profileImageUrl ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img src={myData.profileImageUrl} alt={myData.nickname} className="h-full w-full object-cover" />
+                  ) : (
+                    <span className="text-xl font-semibold text-[#825500]">{myData?.nickname?.charAt(0).toUpperCase()}</span>
+                  )}
+                </div>
+                <div className="flex flex-col gap-0.5">
+                  <p className="text-base font-bold text-[#1c1b1b]">{myData?.nickname}</p>
+                  <p className="text-sm text-gray-500">{`${myData?.addressSido ?? ''} ${myData?.addressGugun ?? ''}`.trim()}</p>
+                </div>
+              </div>
+              {myData?.introduction ? <p className="line-clamp-1 text-sm text-gray-500">{myData.introduction}</p> : null}
+            </button>
+
+            {/* 모바일 전용 섹션 */}
+            <section className="flex flex-col gap-3.5 md:hidden" aria-label="마이페이지 모바일 콘텐츠">
+              <div className="border-outline-variant/40 rounded-2xl border bg-white p-5">
+                <h2 className="mb-3 text-base font-bold text-[#1c1b1b]">내 상품 관리</h2>
+                <div className="flex flex-col">
+                  <button
+                    type="button"
+                    onClick={() => setMobilePanelTab('tab-sales')}
+                    className="text-on-surface flex cursor-pointer items-center gap-3 py-3"
+                  >
+                    <Receipt size={20} strokeWidth={1.5} />
+                    <span className="flex-1 text-left text-sm">판매 내역</span>
+                    <ChevronRight size={18} className="text-on-surface-muted" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setMobilePanelTab('tab-purchases')}
+                    className="text-on-surface flex cursor-pointer items-center gap-3 py-3"
+                  >
+                    <Handbag size={20} strokeWidth={1.5} />
+                    <span className="flex-1 text-left text-sm">구매내역</span>
+                    <ChevronRight size={18} className="text-on-surface-muted" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setMobilePanelTab('tab-wishlist')}
+                    className="text-on-surface flex cursor-pointer items-center gap-3 py-3"
+                  >
+                    <Heart size={20} strokeWidth={1.5} />
+                    <span className="flex-1 text-left text-sm">찜한 상품</span>
+                    <ChevronRight size={18} className="text-on-surface-muted" />
+                  </button>
+                </div>
+              </div>
+
+              <div className="border-outline-variant/40 rounded-2xl border bg-white p-5">
+                <h2 className="mb-3 text-base font-bold text-[#1c1b1b]">나의 활동</h2>
+                <div className="flex flex-col">
+                  <button
+                    type="button"
+                    onClick={() => setMobilePanelTab('activity')}
+                    className="text-on-surface flex cursor-pointer items-center gap-3 py-3"
+                  >
+                    <MessageSquareText size={20} strokeWidth={1.5} />
+                    <span className="flex-1 text-left text-sm">내 글</span>
+                    <ChevronRight size={18} className="text-on-surface-muted" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setMobilePanelTab('tab-blocked')}
+                    className="text-on-surface flex cursor-pointer items-center gap-3 py-3"
+                  >
+                    <UserX size={20} strokeWidth={1.5} />
+                    <span className="flex-1 text-left text-sm">차단 유저</span>
+                    <ChevronRight size={18} className="text-on-surface-muted" />
+                  </button>
+                </div>
+              </div>
+
+              <div className="border-outline-variant/40 rounded-2xl border bg-white p-5">
+                <h2 className="mb-3 text-base font-bold text-[#1c1b1b]">고객지원</h2>
+                <div className="flex flex-col">
+                  <a
+                    href="mailto:support@cuddlemarket.com?subject=커들마켓 1:1 문의"
+                    className="text-on-surface flex items-center gap-3 py-3"
+                  >
+                    <Headphones size={20} strokeWidth={1.5} />
+                    <span className="flex-1 text-left text-sm">고객센터</span>
+                    <ChevronRight size={18} className="text-on-surface-muted" />
+                  </a>
+                </div>
+              </div>
+            </section>
+
+            {/* 데스크탑: 기존 ProfileData */}
+            <div className="hidden md:block">
+              <ProfileData
+                setIsWithdrawModalOpen={setIsWithdrawModalOpen}
+                data={myData!}
+                isMyProfile
+                enableImageUpload
+                summaryCounts={{
+                  sales: myProductsData?.pages[0]?.total ?? 0,
+                  purchases: myRequestData?.pages[0]?.total ?? 0,
+                  wishlist: myFavoriteData?.pages[0]?.total ?? 0,
+                }}
+              />
+            </div>
+            <div role="tablist" aria-label="마이페이지 메뉴" className="hidden flex-col gap-1 md:flex">
               {MY_PAGE_NAV.map((tab) => {
                 const isActive = activeMyPageNav === tab.id
                 const Icon = myPageIconMap[tab.code]
@@ -376,7 +510,7 @@ function MyPage() {
               })}
             </div>
           </div>
-          <section className="relative flex flex-1 flex-col gap-3.5 md:gap-7">
+          <section className="relative hidden flex-1 flex-col gap-3.5 md:flex md:gap-7">
             <AnimatePresence>
               {unblockError ? (
                 <div className="absolute top-11 left-1/2 z-50 w-11/12 -translate-x-1/2 md:w-auto md:pt-8">
@@ -386,7 +520,7 @@ function MyPage() {
                 </div>
               ) : null}
             </AnimatePresence>
-            {(activeMyPageNav === 'nav-sales' || activeMyPageNav === 'nav-purchases') &&
+            {(effectiveNav === 'nav-sales' || effectiveNav === 'nav-purchases') &&
             (activeMyPageTab === 'tab-sales' || activeMyPageTab === 'tab-purchases') ? (
               <div className="px-5 md:px-0">
                 <Tabs
@@ -399,13 +533,13 @@ function MyPage() {
               </div>
             ) : null}
 
-            {activeMyPageNav === 'nav-dash' ? (
+            {effectiveNav === 'nav-dash' ? (
               <MyDashboard
                 myProducts={myProductsData?.pages.flatMap((page) => page.content)}
                 myRequests={myRequestData?.pages.flatMap((page) => page.content)}
                 myFavorites={myFavoriteData?.pages.flatMap((page) => page.content)}
               />
-            ) : activeMyPageNav === 'nav-activity' ? (
+            ) : effectiveNav === 'nav-activity' ? (
               <MyActivityPanel />
             ) : (
               <MyPagePanel
@@ -438,6 +572,101 @@ function MyPage() {
         error={deleteError}
         onClearError={() => setDeleteError(null)}
       />
+      {/* 모바일 ProfileData 풀스크린 — 좌→우 슬라이드 */}
+      <div
+        className={cn(
+          'bg-surface fixed inset-0 overflow-y-auto px-2 transition-transform duration-300 ease-out md:hidden',
+          Z_INDEX.MODAL,
+          isProfileFullViewOpen ? 'translate-x-0' : '-translate-x-full'
+        )}
+        role="dialog"
+        aria-label="프로필 자세히"
+        aria-hidden={!isProfileFullViewOpen}
+      >
+        <div className="sticky top-0 flex h-16 items-center gap-3 border-b border-gray-200 bg-white">
+          <button type="button" onClick={() => setIsProfileFullViewOpen(false)} aria-label="닫기" className="cursor-pointer">
+            <ArrowLeft size={20} />
+          </button>
+          <span className="text-base font-bold">프로필</span>
+        </div>
+        <div className="flex flex-col gap-3 py-4">
+          <ProfileData
+            setIsWithdrawModalOpen={setIsWithdrawModalOpen}
+            data={myData!}
+            isMyProfile
+            enableImageUpload
+            summaryCounts={{
+              sales: myProductsData?.pages[0]?.total ?? 0,
+              purchases: myRequestData?.pages[0]?.total ?? 0,
+              wishlist: myFavoriteData?.pages[0]?.total ?? 0,
+            }}
+          />
+          <MyDashboard
+            myProducts={myProductsData?.pages.flatMap((page) => page.content)}
+            myRequests={myRequestData?.pages.flatMap((page) => page.content)}
+            myFavorites={myFavoriteData?.pages.flatMap((page) => page.content)}
+          />
+        </div>
+      </div>
+      {/* 모바일 마이페이지 메뉴 → 풀스크린 패널 (우→좌 슬라이드) */}
+      <div
+        className={cn(
+          'fixed inset-0 overflow-y-auto bg-white transition-transform duration-300 ease-out md:hidden',
+          Z_INDEX.MODAL,
+          mobilePanelTab ? 'translate-x-0' : 'translate-x-full'
+        )}
+        role="dialog"
+        aria-modal="true"
+        aria-label={mobilePanelTitle || '마이페이지 상세'}
+        aria-hidden={!mobilePanelTab}
+      >
+        <div className="sticky top-0 flex h-16 items-center gap-3 border-b border-gray-200 bg-white px-4">
+          <button
+            type="button"
+            onClick={() => setMobilePanelTab(null)}
+            aria-label="닫기"
+            className="cursor-pointer"
+          >
+            <ArrowLeft size={20} />
+          </button>
+          <span className="text-base font-bold">{mobilePanelTitle}</span>
+        </div>
+        <div className="flex flex-col gap-4 p-4">
+          {mobilePanelTab === 'tab-sales' || mobilePanelTab === 'tab-purchases' ? (
+            <Tabs
+              tabs={mobileTradeStatusTabs}
+              activeTab={activeTradeStatus}
+              onTabChange={(tabId) => setActiveTradeStatus(tabId as TransactionStatus | 'ALL')}
+              ariaLabel={mobilePanelTab === 'tab-sales' ? '판매 상태 메뉴' : '구매 상태 메뉴'}
+              variant="card-pill"
+            />
+          ) : null}
+          {mobilePanelTab === 'activity' ? (
+            <MyActivityPanel />
+          ) : mobilePanelTab ? (
+            <MyPagePanel
+              activeTabCode={mobilePanelTabCode}
+              activeMyPageTab={mobilePanelTab}
+              activeTradeStatus={activeTradeStatus}
+              myProductsData={filteredMyProductsData}
+              myProductsTotal={
+                mobilePanelTab === 'tab-sales' ? filteredMyProductsData?.length : myProductsData?.pages[0]?.total
+              }
+              myRequestData={filteredMyRequestData}
+              myRequestTotal={
+                activeTradeStatus === 'ALL' ? myRequestData?.pages[0]?.total : filteredMyRequestData?.length
+              }
+              myFavoriteData={myFavoriteData?.pages.flatMap((page) => page.content)}
+              myFavoriteTotal={myFavoriteData?.pages[0]?.total}
+              myBlockedData={myBlockedData?.pages.flatMap((page) => page.content)}
+              myBlockedTotal={myBlockedData?.pages[0]?.total}
+              {...paginationProps}
+              handleConfirmModal={handleConfirmModal}
+              unblockUser={unblockUser}
+            />
+          ) : null}
+        </div>
+      </div>
       <WithdrawModal
         isOpen={isWithdrawModalOpen}
         onConfirm={handleWithdraw}

--- a/src/features/my-page/components/MyDashboard.tsx
+++ b/src/features/my-page/components/MyDashboard.tsx
@@ -48,7 +48,7 @@ export default function MyDashboard({ myProducts, myRequests, myFavorites }: MyD
   const currentConfig = TAB_CONFIG[activeTab]
 
   return (
-    <div className="flex flex-col gap-8">
+    <div className="flex flex-col gap-3 md:gap-8">
       {/* 거래 내역 요약 */}
       <section className="bg-surface-container-lowest border-outline-variant/40 rounded-2xl border p-6">
         <UnderlineTabs
@@ -83,7 +83,7 @@ export default function MyDashboard({ myProducts, myRequests, myFavorites }: MyD
       </section>
 
       {/* 활동 요약 */}
-      <section className="grid grid-cols-1 gap-8 lg:grid-cols-2">
+      <section className="grid grid-cols-1 gap-3 md:gap-8 lg:grid-cols-2">
         <div className="bg-surface-container-lowest border-outline-variant/40 rounded-2xl border p-6 md:p-8">
           <div className="mb-6 flex items-center justify-between">
             <h2 className="text-on-surface text-base font-bold">나의 커뮤니티 글</h2>

--- a/src/features/my-page/components/MyPagePanel.tsx
+++ b/src/features/my-page/components/MyPagePanel.tsx
@@ -163,7 +163,10 @@ export default function MyPagePanel({
       role="tabpanel"
       id={`panel-${activeTabCode}`}
       aria-labelledby={activeMyPageTab}
-      className={cn('border-outline-variant/40 flex flex-col rounded-xl px-5 py-5 md:border md:p-5', hasContent && 'gap-4')}
+      className={cn(
+        'border-outline-variant/40 flex flex-col rounded-xl px-4 py-5 md:border md:p-5 md:px-5',
+        hasContent && 'gap-4'
+      )}
     >
       {config ? (
         <MyPageTitle
@@ -198,7 +201,7 @@ export default function MyPagePanel({
                     productCount <= 1 && 'overflow-visible'
                   )}
                 >
-                  <ul className="flex flex-col items-stretch justify-start divide-y divide-gray-200 md:gap-2.5 md:divide-y-0">
+                  <ul className="flex flex-col items-stretch justify-start gap-2 divide-y divide-gray-200 md:gap-2.5 md:divide-y-0">
                     {productData.content.map((product) => (
                       <MyList key={product.id} {...product} activeTab={activeMyPageTab} handleConfirmModal={handleConfirmModal} />
                     ))}

--- a/src/features/product-detail/ProductDetail.tsx
+++ b/src/features/product-detail/ProductDetail.tsx
@@ -44,7 +44,7 @@ function ProductDetail({ initialData }: ProductDetailProps) {
 
   return (
     <>
-      <div className="px-lg pb-4xl mx-auto max-w-7xl pt-8">
+      <div className="px-lg pb-4xl mx-auto max-w-7xl pt-5 md:pt-8">
         <div className="flex flex-col gap-20">
           <div className="flex flex-col gap-4">
             <Breadcrumb


### PR DESCRIPTION
## 📌 관련 이슈
closes #758

## ♻️ 변경 사항

### 모바일 마이페이지 전면 재구성
- 사이드 nav(`MY_PAGE_NAV` tablist)를 모바일에서 숨기고 `nav-dash` 강제 — `effectiveNav` 분기로 `useInfiniteQuery.enabled`까지 반영
- 데스크탑 `ProfileData` ↔ 모바일 압축 카드 분기 (`md:hidden` / `hidden md:block`)
- panel section을 모바일에서 숨김 — MyDashboard/MyPagePanel/MyActivityPanel 전부

### 모바일 압축 프로필 카드
- 아바타 + 닉네임 + 주소 + 자기소개 1줄 요약
- 클릭 시 풀스크린 오버레이(좌→우 슬라이드)로 전체 `ProfileData` 노출 (카메라/활동 카운트/프로필 수정/회원탈퇴 포함)

### 모바일 전용 메뉴 카드 3섹션
- **내 상품 관리**: 판매 내역 / 구매 내역 / 찜한 상품
- **나의 활동**: 내 글 / 차단 유저
- **고객지원**: 고객센터(mailto)
- 각 항목 클릭 시 풀스크린 패널(우→좌 슬라이드)로 진입
- 헤더(← 닫기 + 타이틀) + 본문(`MyPagePanel` 또는 `MyActivityPanel`)
- 판매/구매 패널에는 거래 상태 탭(전체/판매중/예약중/판매완료 또는 전체/요청중/구매완료) 노출

### 디테일 폴리싱
- `ProfileData`: 모바일에서 `rounded-2xl` + `border` 적용, 데스크탑은 기존 톤 유지
- `MyDashboard`: 모바일 섹션 간격 축소 (`gap-8` → `gap-3 md:gap-8`)

## 🛠 변경 파일
- `src/features/my-page/MyPage.tsx`
- `src/features/my-page/components/MyDashboard.tsx`
- `src/components/profile/ProfileData.tsx`

## ✅ 테스트
- [ ] 모바일(< 768px)에서 압축 카드 + 메뉴 3섹션 노출 확인
- [ ] 압축 카드 클릭 → 프로필 풀스크린 오버레이 좌→우 슬라이드 확인
- [ ] 메뉴 항목 클릭 → 우→좌 슬라이드 + 거래 상태 탭 동작 확인
- [ ] 데스크탑(≥ 768px)에서 기존 사이드 nav + ProfileData + panel 정상 노출 확인