### PR TITLE
refactor: 모바일 유저페이지 상품 탭/카드 톤 정비 (#760)

### DIFF
--- a/src/features/UserPage.tsx
+++ b/src/features/UserPage.tsx
@@ -11,6 +11,7 @@ import LoadMoreButton from '@/components/commons/button/LoadMoreButton'
 import EmptyState from '@/components/EmptyState'
 import { Package } from 'lucide-react'
 import Tabs from '@/components/Tabs'
+import { UnderlineTabs } from '@/components/UnderlineTabs'
 import dynamic from 'next/dynamic'
 const UserReportModal = dynamic(() => import('@/components/modal/UserReportModal'))
 const BlockModal = dynamic(() => import('@/components/modal/BlockModal'))
@@ -180,7 +181,15 @@ function UserPage() {
             <h4 id="user-product-heading" className="sr-only">
               {userData?.nickname}님의 {activeTabLabel}
             </h4>
-            <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="md:hidden">
+              <UnderlineTabs
+                tabs={USER_PAGE_TABS}
+                activeTab={activeTab}
+                onTabChange={handleTabChange}
+                ariaLabel="유저 상품 종류 메뉴"
+              />
+            </div>
+            <div className="hidden flex-wrap items-center justify-between gap-3 md:flex">
               <Tabs
                 tabs={USER_PAGE_TABS}
                 activeTab={activeTab}
@@ -194,10 +203,10 @@ function UserPage() {
               <div className="gap-lg flex flex-col">
                 {allProducts.length ? (
                   <>
-                    <ul className="grid grid-cols-3 gap-4 md:grid-cols-2 lg:grid-cols-4">
+                    <ul className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
                       {allProducts.map((product) => (
                         <li key={product.id}>
-                          <ProductCard data={product} vertical hideProductType />
+                          <ProductCard data={product} hideProductType />
                         </li>
                       ))}
                     </ul>


### PR DESCRIPTION
## 📌 관련 이슈
closes #760

## ♻️ 변경 사항

### 모바일 유저페이지 탭 톤 통일
- 모바일에서 탭을 `UnderlineTabs` (밑줄 톤)로 교체
- 데스크탑은 기존 `Tabs` (card-pill) + "총 N개" 텍스트 유지
- `md:hidden` / `hidden md:flex` 분기

### 모바일 상품 카드 가로 정렬
- 상품 grid: `grid-cols-3 md:grid-cols-2 lg:grid-cols-4` → `grid-cols-1 md:grid-cols-2 lg:grid-cols-4` (모바일 1열)
- `ProductCard.vertical` prop 제거 → 모바일은 `flex-row-reverse` (썸네일 좌·정보 우), 데스크탑은 `md:flex-col-reverse` 자동 분기

## 🛠 변경 파일
- `src/features/UserPage.tsx`

## ✅ 테스트
- [ ] 모바일(< 768px)에서 underline tab + 가로 상품 카드 노출 확인
- [ ] 데스크탑(≥ 768px)에서 기존 card-pill tab + 세로 상품 카드 유지 확인
- [ ] 판매상품/판매요청 탭 전환 동작 확인