### PR TITLE
fix: 채팅 페이지 모바일 폴리싱 및 연결 대응 (#765)

### DIFF
--- a/src/components/commons/InlineNotification.tsx
+++ b/src/components/commons/InlineNotification.tsx
@@ -55,12 +55,15 @@ export default function InlineNotification({ type, children, onClose, durationMs
         <div className={styles.iconWrapper}>
           <Icon className={cn('h-2 w-2 shrink-0', styles.icon)} />
         </div>
-        <div className="break-keep text-sm">{children}</div>
+        <div className="text-xs md:text-sm md:break-keep">{children}</div>
         <button
           type="button"
           aria-label="알림 닫기"
           onClick={onClose}
-          className={cn('ml-auto shrink-0 cursor-pointer rounded p-1 transition-colors focus:outline-none focus-visible:ring-2', styles.text)}
+          className={cn(
+            'ml-auto shrink-0 cursor-pointer rounded p-1 transition-colors focus:outline-none focus-visible:ring-2',
+            styles.text
+          )}
         >
           <X className="h-4 w-4" />
         </button>

--- a/src/components/commons/card/ChatProductCard.tsx
+++ b/src/components/commons/card/ChatProductCard.tsx
@@ -45,10 +45,8 @@ export default function ChatProductCard({ productImageUrl, productTitle, product
         />
       </div>
       <div className="min-w-0 flex-1">
-        <p className={`text-hero-surface truncate text-sm font-bold`}>{productTitle}</p>
-        <p className={`${priceClasses[size]} text-hero-surface`}>
-          {productPrice != null ? `${formatPrice(productPrice)}원` : ''}
-        </p>
+        <p className={`truncate text-sm font-medium md:font-bold`}>{productTitle}</p>
+        <p className={`${priceClasses[size]} text-[#684d21]`}>{productPrice != null ? `${formatPrice(productPrice)}원` : ''}</p>
       </div>
     </>
   )

--- a/src/features/chatting-page/ChattingPage.tsx
+++ b/src/features/chatting-page/ChattingPage.tsx
@@ -184,7 +184,10 @@ export default function ChattingPage() {
   }
 
   const handleBack = () => {
-    router.push('/chat')
+    // 채팅방 진입은 handleSelectRoom의 router.push('/chat/[id]')로 이뤄지므로
+    // 목록으로 돌아갈 때 push('/chat')를 쓰면 history에 중복 엔트리가 쌓여
+    // 이후 router.back()이 떠난 채팅방으로 되돌아간다. 정상 뒤로가기로 처리.
+    router.back()
   }
 
   useEffect(() => {
@@ -260,7 +263,7 @@ export default function ChattingPage() {
         </div>
         <section
           className={cn(
-            'relative flex w-full flex-col overflow-hidden border-l border-gray-300 md:flex md:w-224',
+            'relative flex w-full flex-col overflow-hidden border-l border-gray-300 max-md:flex-1 md:flex md:w-224',
             isChatOpen ? 'flex' : 'hidden'
           )}
         >
@@ -312,7 +315,13 @@ export default function ChattingPage() {
                     type="button"
                     aria-label="전송"
                     className="bg-primary hover:bg-primary/90 flex size-9 shrink-0 cursor-pointer items-center justify-center rounded-full transition-colors"
-                    onClick={handleSend}
+                    // onClick 대신 onPointerDown + preventDefault:
+                    // 모바일에서 textarea 포커스 중 버튼 탭 시 blur로 키보드가 닫히며
+                    // fixed 입력창이 점프해 click이 취소되는 문제를 차단한다.
+                    onPointerDown={(e) => {
+                      e.preventDefault()
+                      handleSend()
+                    }}
                   >
                     <Send size={16} className="text-white" />
                   </button>

--- a/src/features/chatting-page/components/ChatLog.tsx
+++ b/src/features/chatting-page/components/ChatLog.tsx
@@ -9,6 +9,7 @@ import { IMAGE_SIZES, imageLoader, toResizedWebpUrl, PLACEHOLDER_IMAGES } from '
 import { AnimatePresence } from 'framer-motion'
 import InlineNotification from '@/components/commons/InlineNotification'
 import Spinner from '@/components/commons/spinner/Spinner'
+import { MessageCircleMore } from 'lucide-react'
 
 interface ChatLogProps {
   isLoadingMessages: boolean
@@ -174,21 +175,34 @@ export function ChatLog({
     )
   }
 
+  // 메시지가 한 번도 오간 적 없는 빈 채팅방 — 빈 상태 안내로 영역을 채워
+  // 휑함과 배경색 경계 노출을 함께 해소한다.
+  if (!isLoadingMessages && roomMessages.length === 0) {
+    return (
+      <div className="flex h-full flex-1 flex-col items-center justify-center gap-3 px-6 text-center">
+        <div className="flex flex-col gap-1">
+          <p className="text-sm font-semibold text-[#1c1b1b] md:text-base">아직 주고받은 메시지가 없어요</p>
+          <p className="text-xs text-gray-500 md:text-sm">첫 메시지를 보내 대화를 시작해보세요</p>
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div ref={scrollRef} onScroll={handleScroll} className="flex h-full flex-col gap-4 overflow-y-auto">
       <AnimatePresence>
         {connectionError ? (
-          <div className="sticky top-0 left-1/2 z-10 w-fit -translate-x-1/2">
+          <div className="sticky top-5 z-10 mx-auto w-80 max-w-[calc(100%-1.5rem)] md:top-0">
             <InlineNotification type="error" onClose={() => onClearConnectionError?.()}>
               <div className="flex flex-col gap-0.5">
-                <p className="text-base font-semibold">채팅 서버 연결에 문제가 발생했습니다.</p>
+                <p className="text-sm font-semibold md:text-base">채팅 서버 연결에 문제가 발생했습니다.</p>
                 <p>{connectionError}</p>
               </div>
             </InlineNotification>
           </div>
         ) : null}
         {imageUploadError ? (
-          <div className="sticky top-0 left-1/2 z-10 w-fit -translate-x-1/2">
+          <div className="sticky top-0 z-10 mx-auto w-80 max-w-[calc(100%-1.5rem)]">
             <InlineNotification type="error" onClose={() => onClearImageUploadError?.()}>
               {imageUploadError}
             </InlineNotification>

--- a/src/features/chatting-page/components/ChatRooms.tsx
+++ b/src/features/chatting-page/components/ChatRooms.tsx
@@ -48,10 +48,10 @@ export function ChatRooms({
   }
 
   return (
-    <section className="relative flex flex-col rounded-none p-6 md:max-w-96 md:min-w-96">
+    <section className="relative flex flex-col rounded-none py-3 md:max-w-96 md:min-w-96 md:p-6">
       <h2 className={cn('hidden md:static md:block', Z_INDEX.HEADER)}>채팅목록</h2>
-      <div className="scrollbar-hide flex-1 overflow-y-scroll py-5">
-        <ul className="flex flex-col gap-2">
+      <div className="scrollbar-hide flex-1 overflow-y-scroll md:py-5">
+        <ul className="flex flex-col md:gap-2">
           {rooms &&
             rooms.map((room) => {
               const roomData = getRoomData(room)
@@ -59,7 +59,7 @@ export function ChatRooms({
                 <li
                   key={roomData.chatRoomId}
                   className={cn(
-                    'flex cursor-pointer flex-col gap-2 rounded-3xl border border-[#eae2dc] px-4 py-3.5',
+                    'flex cursor-pointer flex-col gap-2 border-[#eae2dc] px-4 py-3.5 md:rounded-3xl md:border',
                     roomData.chatRoomId === selectedRoomId && 'border-outline-variant/40 md:bg-[#7c571a]'
                   )}
                   onClick={() => handleSelectRoom(room)}
@@ -69,11 +69,11 @@ export function ChatRooms({
                       <ProfileAvatar imageUrl={roomData?.opponentProfileImageUrl} nickname={roomData?.opponentNickname ?? ''} />
                     </div>
                     <div className="flex min-w-0 flex-1 flex-col gap-3">
-                      <div className="flex flex-col gap-2">
+                      <div className="flex flex-col gap-0.5 md:gap-2">
                         <div className="flex items-center justify-between gap-1">
                           <p
                             className={cn(
-                              'text-base leading-none font-semibold',
+                              'text-[15px] leading-none font-semibold md:text-base',
                               roomData.chatRoomId === selectedRoomId ? 'text-hero-surface' : 'text-gray-800'
                             )}
                           >
@@ -106,8 +106,8 @@ export function ChatRooms({
                       </div>
                       <div
                         className={cn(
-                          'flex w-full items-center gap-3 overflow-hidden rounded-2xl border border-[#9f854f] p-2.5',
-                          roomData.chatRoomId === selectedRoomId ? 'border border-[#9f854f] bg-[#96793f]' : 'bg-[#f6f3f2]'
+                          'bg-surface-container-low flex w-full items-center gap-3 overflow-hidden rounded-2xl border border-[#ebe5e0] p-2.5',
+                          roomData.chatRoomId === selectedRoomId && 'border-[#9f854f] bg-[#96793f]'
                         )}
                       >
                         <ChatProductCard

--- a/src/store/chatSocketStore.ts
+++ b/src/store/chatSocketStore.ts
@@ -39,7 +39,10 @@ export const chatSocketStore = create<ChatSocketState>((set, get) => ({
     if (get().socket?.active) return
 
     const socket = new Client({
-      webSocketFactory: () => new SockJS(url, null, { transports: ['websocket'] }),
+      // transports를 ['websocket']로 강제하면 SockJS의 fallback(xhr-streaming/polling)이
+      // 비활성화된다. 모바일 네트워크(공유기/통신사 프록시)가 WebSocket Upgrade를 차단하면
+      // 연결이 즉시 실패하므로, 기본 transport 체인을 사용해 polling fallback을 허용한다.
+      webSocketFactory: () => new SockJS(url),
       connectHeaders: {
         Authorization: `Bearer ${accessToken}`,
       },


### PR DESCRIPTION
## 📌 관련 이슈
closes #765

## 🐛 변경 사항
- **뒤로가기 history 버그**: 채팅방 ← (`handleBack`) `router.push('/chat')` → `router.back()`. push로 history 중복 누적되어 이후 뒤로가기가 떠난 채팅방으로 복귀하던 문제 해결
- **빈 채팅방 레이아웃**: `<section>`에 `max-md:flex-1` 추가로 컨테이너 높이 확보 → `bg-surface` 배경 경계 노출 해소 + 빈 상태 UI 추가
- **모바일 전송 버튼**: `onClick` → `onPointerDown`+`preventDefault`. 실기기에서 textarea blur로 키보드 닫히며 click 취소되던 문제 해결
- **연결 에러 토스트**: `sticky left-1/2 -translate-x-1/2`(좌측 잘림) → `mx-auto w-80 max-w-[calc(100%-1.5rem)]`(중앙 카드), 폰트 모바일 대응
- **SockJS**: `transports:['websocket']` 강제 제거 → `new SockJS(url)`로 polling fallback 허용

## 🛠 변경 파일
- `src/features/chatting-page/ChattingPage.tsx`, `components/ChatLog.tsx`, `components/ChatRooms.tsx`
- `src/components/commons/card/ChatProductCard.tsx`, `src/components/commons/InlineNotification.tsx`
- `src/store/chatSocketStore.ts`

## 📎 비고 (백엔드 별도 대응 필요)
모바일 실기기 WS 연결 실패의 **근본 원인은 백엔드 STOMP `allowedOrigins`에 LAN Origin(`http://192.168.*.*:3000`) 미허용**. 프론트 fallback만으로는 핸드셰이크 거부를 못 넘으므로, `cmarket_api`에서 `setAllowedOriginPatterns` 보완 필요.

## ✅ 테스트
- [ ] 채팅방→목록 뒤로가기 history 정상 (떠난 방 복귀 X)
- [ ] 빈 채팅방 진입 시 빈 상태 UI + 배경 경계 없음
- [ ] 데스크탑 전송 정상, 토스트 중앙 표시