### PR TITLE
refactor: 모바일 ProfileData 풀스크린 슬라이드 방향 정정 (#768)

### DIFF
--- a/src/features/my-page/MyPage.tsx
+++ b/src/features/my-page/MyPage.tsx
@@ -615,12 +615,12 @@ function MyPage() {
         error={deleteError}
         onClearError={() => setDeleteError(null)}
       />
-      {/* 모바일 ProfileData 풀스크린 — 좌→우 슬라이드 */}
+      {/* 모바일 ProfileData 풀스크린 — 우→좌 슬라이드 */}
       <div
         className={cn(
           'fixed inset-0 overflow-y-auto bg-gray-100/30 transition-transform duration-300 ease-out md:hidden',
           Z_INDEX.MODAL,
-          isProfileFullViewOpen ? 'translate-x-0' : '-translate-x-full'
+          isProfileFullViewOpen ? 'translate-x-0' : 'translate-x-full'
         )}
         role="dialog"
         aria-label="프로필 자세히"


### PR DESCRIPTION
## 📌 관련 이슈
closes #768

## ♻️ 변경 사항
모바일 ProfileData 풀스크린 오버레이의 닫힘 상태 transform을 `-translate-x-full`(좌측 대기) → `translate-x-full`(우측 대기)로 변경. 같은 화면의 메뉴 풀스크린 패널(우→좌 슬라이드)과 진입/이탈 방향을 통일.

- `MyPage.tsx`: `isProfileFullViewOpen ? 'translate-x-0' : 'translate-x-full'`
- 주석 "좌→우 슬라이드" → "우→좌 슬라이드"

## 🛠 변경 파일
- `src/features/my-page/MyPage.tsx` (2줄)

## ✅ 테스트
- [ ] 모바일 마이페이지 → 프로필 압축 카드 탭 → 우측에서 슬라이드 인
- [ ] 닫기 → 우측으로 슬라이드 아웃 (메뉴 패널과 방향 일치)