### PR TITLE
feat: 어드민 데모 모드 + 관련 버그 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@ dist/
 .env.test.local
 .env.production.local
 
+# Secrets (서버 접속 정보·키 — 절대 커밋 금지)
+ssh.md
+*.pem
+
 # Debug
 npm-debug.log*
 yarn-debug.log*

--- a/src/components/commons/select/SelectDropdown.tsx
+++ b/src/components/commons/select/SelectDropdown.tsx
@@ -226,7 +226,9 @@ export default function SelectDropdown({
 
       {isOpen && !disabled && dropdownStyle
         ? createPortal(
-            <div ref={optionsRef}>
+            // fixed로 흐름에서 빼야 함: dialog에 portal될 때 이 wrapper가
+            // flex 자식으로 잡혀 gap(예: gap-4=16px)을 추가하는 부작용 방지.
+            <div ref={optionsRef} className="fixed">
               <SelectOptions
                 options={options}
                 selectedValue={value}
@@ -236,7 +238,10 @@ export default function SelectDropdown({
                 style={dropdownStyle}
               />
             </div>,
-            document.body
+            // <dialog showModal()>은 top-layer에 렌더돼 z-index로 못 이김.
+            // dialog 안에서 열린 경우엔 그 dialog에 portal해야 옵션이 위로 뜨고 클릭됨.
+            // dialog 밖(일반 페이지)에선 기존처럼 body에 portal.
+            selectRef.current?.closest('dialog') ?? document.body
           )
         : null}
     </div>

--- a/src/features/admin/components/WithdrawalsManagement.tsx
+++ b/src/features/admin/components/WithdrawalsManagement.tsx
@@ -1,16 +1,28 @@
 'use client'
 
+import { useState } from 'react'
 import AdminTable from './table/AdminTable'
 import { withdrawalTableConfig } from '../configs/withdrawalTableConfig'
 import { fetchAdminWithdrawals } from '@/lib/api/admin'
 import type { AdminWithdrawal } from '../types/adminApi'
+import WithdrawalDetailModal from './members/WithdrawalDetailModal'
 
 export default function WithdrawalsManagement() {
+  const [selected, setSelected] = useState<AdminWithdrawal | null>(null)
+
   return (
-    <AdminTable<AdminWithdrawal>
-      config={withdrawalTableConfig}
-      queryKey="admin-withdrawals"
-      fetchFn={fetchAdminWithdrawals}
-    />
+    <>
+      <AdminTable<AdminWithdrawal>
+        config={withdrawalTableConfig}
+        queryKey="admin-withdrawals"
+        fetchFn={fetchAdminWithdrawals}
+        onRowClick={(w) => setSelected(w)}
+      />
+      <WithdrawalDetailModal
+        isOpen={selected !== null}
+        withdrawal={selected}
+        onClose={() => setSelected(null)}
+      />
+    </>
   )
 }

--- a/src/features/admin/components/community/CommunityDetailModal.tsx
+++ b/src/features/admin/components/community/CommunityDetailModal.tsx
@@ -4,10 +4,13 @@ import { useEffect, useRef, useState } from 'react'
 import { X, Trash2 } from 'lucide-react'
 import { useQuery } from '@tanstack/react-query'
 import { fetchAdminCommunityDetail } from '@/lib/api/admin'
+import { getMockCommunityPosts } from '@/features/admin/mocks/mockCommunityPosts'
 import { api } from '@/lib/api/api'
 import type { Comment, CommentResponse } from '@/types/community'
 import { BOARD_TYPE_EN_TO_KO } from '../../configs/communityTableConfig'
 import DeleteConfirmDialog from '../common/DeleteConfirmDialog'
+
+const DEMO_MODE = process.env.NEXT_PUBLIC_DEMO_MODE === 'true'
 
 interface CommunityDetailModalProps {
   isOpen: boolean
@@ -49,6 +52,16 @@ async function fetchReplies(commentId: number): Promise<Comment[]> {
 }
 
 async function fetchCommentsWithReplies(postId: number): Promise<Comment[]> {
+  if (DEMO_MODE) {
+    const post = getMockCommunityPosts({ page: 1, pageSize: 1000 }).data.find((p) => p.id === postId)
+    return (post?.comments ?? []).map((c) => ({
+      id: c.id,
+      authorNickname: c.nickname,
+      content: c.content,
+      depth: c.depth,
+      createdAt: c.createdAt,
+    })) as unknown as Comment[]
+  }
   try {
     const { data } = await api.get<CommentResponse>(`/community/posts/${postId}/comments`)
     const parentComments = data.data.comments

--- a/src/features/admin/components/layout/AdminAuthGuard.tsx
+++ b/src/features/admin/components/layout/AdminAuthGuard.tsx
@@ -5,6 +5,19 @@ import { useRouter } from 'next/navigation'
 import { useUserStore } from '@/store/userStore'
 import { ROUTES } from '@/constants/routes'
 
+const DEMO_MODE = process.env.NEXT_PUBLIC_DEMO_MODE === 'true'
+
+const DEMO_ADMIN = {
+  id: 0,
+  email: 'demo@cuddle.market',
+  name: '데모 관리자',
+  nickname: 'demo_admin',
+  birthDate: '1990-01-01',
+  addressSido: '서울특별시',
+  addressGugun: '강남구',
+  userRole: 'ADMIN' as const,
+}
+
 export default function AdminAuthGuard({ children }: { children: React.ReactNode }) {
   const router = useRouter()
   const [isAuthorized, setIsAuthorized] = useState(false)
@@ -17,6 +30,14 @@ export default function AdminAuthGuard({ children }: { children: React.ReactNode
   const userRole = useUserStore((state) => state.user?.userRole)
 
   useEffect(() => {
+    // 데모 모드: 가짜 어드민을 세팅하고 인증 통과 (로그인 불필요)
+    if (DEMO_MODE) {
+      if (useUserStore.getState().user?.userRole !== 'ADMIN') {
+        useUserStore.getState().setUser(DEMO_ADMIN)
+      }
+      setIsAuthorized(true)
+      return
+    }
     if (!hasHydrated) return
 
     if (userRole !== 'ADMIN') {
@@ -26,7 +47,7 @@ export default function AdminAuthGuard({ children }: { children: React.ReactNode
     }
   }, [hasHydrated, userRole, router])
 
-  if (!hasHydrated || !isAuthorized) {
+  if (!isAuthorized) {
     return null
   }
 

--- a/src/features/admin/components/members/WithdrawalDetailModal.tsx
+++ b/src/features/admin/components/members/WithdrawalDetailModal.tsx
@@ -1,0 +1,212 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { X } from 'lucide-react'
+import { useQueryClient } from '@tanstack/react-query'
+import type { AdminWithdrawal } from '../../types/adminApi'
+import { WITHDRAWAL_REASON_EN_TO_KO } from '../../configs/withdrawalTableConfig'
+import { restoreWithdrawnUser } from '@/lib/api/admin'
+import Field from '../common/Field'
+import { formatDate } from '../common/formatDate'
+
+interface WithdrawalDetailModalProps {
+  isOpen: boolean
+  withdrawal: AdminWithdrawal | null
+  onClose: () => void
+}
+
+const ROLE_EN_TO_KO: Record<string, string> = { USER: '일반회원', ADMIN: '관리자' }
+
+function RestoreConfirmDialog({
+  isOpen,
+  userName,
+  isLoading,
+  onConfirm,
+  onCancel,
+}: {
+  isOpen: boolean
+  userName: string
+  isLoading: boolean
+  onConfirm: () => void
+  onCancel: () => void
+}) {
+  const confirmRef = useRef<HTMLDialogElement>(null)
+
+  useEffect(() => {
+    const dialog = confirmRef.current
+    if (isOpen && !dialog?.open) {
+      dialog?.showModal()
+    } else if (!isOpen && dialog?.open) {
+      dialog?.close()
+    }
+  }, [isOpen])
+
+  return (
+    <dialog
+      ref={confirmRef}
+      className="m-auto w-full max-w-fit flex-col gap-4 rounded-xl bg-white p-6 shadow-2xl backdrop:bg-gray-900/50 open:flex"
+      onClick={(e) => {
+        if (e.target === confirmRef.current) onCancel()
+      }}
+      onClose={(e) => {
+        e.stopPropagation()
+        onCancel()
+      }}
+    >
+      <h4 className="text-lg font-semibold text-gray-900">탈퇴 회원 복구</h4>
+      <p className="text-sm leading-relaxed text-gray-500">
+        <strong>{userName}</strong> 님의 탈퇴를 복구하시겠습니까? 계정이 다시 활성화됩니다.
+      </p>
+      <div className="flex justify-end gap-3">
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={isLoading}
+          className="cursor-pointer rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+        >
+          취소
+        </button>
+        <button
+          type="button"
+          onClick={onConfirm}
+          disabled={isLoading}
+          className="cursor-pointer rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          {isLoading ? '처리중...' : '복구'}
+        </button>
+      </div>
+    </dialog>
+  )
+}
+
+export default function WithdrawalDetailModal({ isOpen, withdrawal, onClose }: WithdrawalDetailModalProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null)
+  const [showRestoreConfirm, setShowRestoreConfirm] = useState(false)
+  const [isRestoring, setIsRestoring] = useState(false)
+  const queryClient = useQueryClient()
+
+  useEffect(() => {
+    const dialog = dialogRef.current
+    if (isOpen && withdrawal && !dialog?.open) {
+      dialog?.showModal()
+    } else if (!isOpen && dialog?.open) {
+      dialog?.close()
+    }
+  }, [isOpen, withdrawal])
+
+  const handleClose = () => {
+    setShowRestoreConfirm(false)
+    onClose()
+  }
+
+  const handleRestore = async () => {
+    if (!withdrawal) return
+    setIsRestoring(true)
+    try {
+      await restoreWithdrawnUser(withdrawal.id)
+      alert('탈퇴가 복구되었습니다.')
+      await queryClient.invalidateQueries({ queryKey: ['admin-withdrawals'] })
+      setShowRestoreConfirm(false)
+      handleClose()
+    } catch {
+      alert('복구에 실패했습니다.')
+    } finally {
+      setIsRestoring(false)
+    }
+  }
+
+  return (
+    <dialog
+      ref={dialogRef}
+      className="m-auto w-full max-w-170 flex-col rounded-xl bg-white p-0 shadow-xl backdrop:bg-gray-900/70 open:flex"
+      onClick={(e) => {
+        if (e.target === dialogRef.current) dialogRef.current.close()
+      }}
+      onClose={handleClose}
+    >
+      {withdrawal && (
+        <>
+          {/* Header */}
+          <div className="flex items-center justify-between border-b border-gray-200 px-6 py-4">
+            <h3 className="text-lg font-semibold text-gray-900">탈퇴 회원 상세 정보</h3>
+            <button
+              type="button"
+              onClick={() => dialogRef.current?.close()}
+              className="cursor-pointer rounded-md p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+            >
+              <X size={20} />
+            </button>
+          </div>
+
+          {/* Body */}
+          <div className="px-6 py-5">
+            {/* Profile */}
+            <div className="mb-6 flex items-center gap-4">
+              <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-full bg-gray-200 text-xl font-bold text-gray-500">
+                {withdrawal.nickname.charAt(0)}
+              </div>
+              <div>
+                <p className="text-lg font-semibold text-gray-900">{withdrawal.name}</p>
+                <p className="text-sm text-gray-500">{withdrawal.email}</p>
+              </div>
+            </div>
+
+            {/* Fields grid */}
+            <div className="grid grid-cols-2 gap-x-5 gap-y-4">
+              <Field label="회원 ID" value={String(withdrawal.id)} />
+              <Field label="이름" value={withdrawal.name} />
+              <Field label="닉네임" value={withdrawal.nickname} />
+              <Field label="이메일" value={withdrawal.email} />
+              {withdrawal.birthDate && <Field label="생년월일" value={formatDate(withdrawal.birthDate)} />}
+              {(withdrawal.addressSido || withdrawal.addressGugun) && (
+                <Field label="지역" value={`${withdrawal.addressSido ?? ''} ${withdrawal.addressGugun ?? ''}`.trim()} />
+              )}
+              <Field label="권한" value={ROLE_EN_TO_KO[withdrawal.role] ?? withdrawal.role} />
+              <Field
+                label="탈퇴 사유"
+                value={WITHDRAWAL_REASON_EN_TO_KO[withdrawal.withdrawalReason] ?? withdrawal.withdrawalReason}
+              />
+              <Field label="탈퇴 일시" value={formatDate(withdrawal.deletedAt)} />
+            </div>
+
+            {/* 탈퇴 상세 사유 (테이블엔 없고 모달에서만 보이는 핵심 정보) */}
+            <div className="mt-4">
+              <p className="mb-1.5 text-sm font-medium text-gray-500">탈퇴 상세 사유</p>
+              <div className="min-h-20 rounded-lg border border-gray-200 bg-gray-50/50 px-3 py-2.5 text-sm leading-relaxed whitespace-pre-line text-gray-900">
+                {withdrawal.withdrawalDetailReason || (
+                  <span className="text-gray-400">입력된 상세 사유가 없습니다.</span>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* Footer */}
+          <div className="flex justify-end gap-3 border-t border-gray-200 bg-gray-50 px-6 py-4">
+            <button
+              type="button"
+              onClick={() => dialogRef.current?.close()}
+              className="cursor-pointer rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+            >
+              닫기
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowRestoreConfirm(true)}
+              className="cursor-pointer rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+            >
+              탈퇴 복구
+            </button>
+          </div>
+
+          <RestoreConfirmDialog
+            isOpen={showRestoreConfirm}
+            userName={withdrawal.name}
+            isLoading={isRestoring}
+            onConfirm={handleRestore}
+            onCancel={() => setShowRestoreConfirm(false)}
+          />
+        </>
+      )}
+    </dialog>
+  )
+}

--- a/src/features/admin/components/reports/UserReportDetailModal.tsx
+++ b/src/features/admin/components/reports/UserReportDetailModal.tsx
@@ -6,15 +6,7 @@ import type { AdminReport } from '../../types/adminApi'
 import { formatDate } from '../common/formatDate'
 import Field from '../common/Field'
 import DeleteConfirmDialog from '../common/DeleteConfirmDialog'
-
-const USER_REPORT_REASON_EN_TO_KO: Record<string, string> = {
-  ABUSE_OR_HATE: '욕설/비방/혐오',
-  SPAM_OR_AD: '스팸/광고',
-  INAPPROPRIATE_CONTENT: '음란물/불건전',
-  REPETITIVE_POST: '도배 게시물',
-  SELF_HARM_OR_SUICIDE: '자해/자살 의도',
-  ETC: '기타',
-}
+import { USER_REPORT_REASON_EN_TO_KO } from '../../configs/userReportTableConfig'
 
 interface UserReportDetailModalProps {
   isOpen: boolean

--- a/src/features/admin/mocks/mockCommunityPosts.ts
+++ b/src/features/admin/mocks/mockCommunityPosts.ts
@@ -113,7 +113,7 @@ function generateComments(postSeed: number, postCreatedAt: string): MockCommunit
       id: parentId,
       nickname: `${COMMENT_NICKNAMES[(postSeed + i) % COMMENT_NICKNAMES.length]}${postSeed + i}`,
       content: COMMENT_CONTENTS[(postSeed + i) % COMMENT_CONTENTS.length],
-      depth: 0,
+      depth: 1,
       parentId: null,
       createdAt: parentCreatedAt,
     })
@@ -126,7 +126,7 @@ function generateComments(postSeed: number, postCreatedAt: string): MockCommunit
           id: ++idCounter,
           nickname: `${COMMENT_NICKNAMES[(postSeed + i + j + 3) % COMMENT_NICKNAMES.length]}${postSeed + i + j + 3}`,
           content: REPLY_CONTENTS[(postSeed + i + j) % REPLY_CONTENTS.length],
-          depth: 1,
+          depth: 2,
           parentId,
           createdAt: randomDate(new Date(parentCreatedAt), new Date('2026-03-01')),
         })

--- a/src/features/admin/mocks/mockProductSellReports.ts
+++ b/src/features/admin/mocks/mockProductSellReports.ts
@@ -7,6 +7,12 @@ const REASON_CODES = [
   'PROFESSIONAL_SELLER', 'ETC',
 ]
 
+const PRODUCT_NAMES = [
+  '강아지 자동 급식기', '고양이 원목 캣타워', '노즈워크 코지 매트', '반려견 노이즈 캐리어',
+  '대형견 하네스 세트', '고양이 자동 화장실', '반려동물 빗 슬리커 브러시', '강아지 방수 레인코트',
+  '고양이 낚싯대 장난감', '대형 강아지 방석 쿠션', '반려견 유모차', '고양이 사료 정수기',
+]
+
 const STATUSES: AdminReport['status'][] = ['PENDING', 'REVIEWED', 'REJECTED', 'ACTION_TAKEN']
 
 function randomDate(start: Date, end: Date): string {
@@ -22,7 +28,7 @@ function generateProductSellReports(count: number): AdminReport[] {
     targetType: 'PRODUCT' as const,
     targetId: 300 + i,
     targetNickname: `판매자${300 + i}`,
-    title: null,
+    title: PRODUCT_NAMES[i % PRODUCT_NAMES.length],
     boardType: null,
     reasonCodes: [REASON_CODES[i % REASON_CODES.length]],
     detailReason: i % 3 === 0 ? '상품 신고 상세 사유입니다.' : null,

--- a/src/features/admin/mocks/mockUserReports.ts
+++ b/src/features/admin/mocks/mockUserReports.ts
@@ -2,8 +2,8 @@ import type { AdminTableResponse, SortState, FilterState } from '../types/adminT
 import type { AdminReport } from '../types/adminApi'
 
 const REASON_CODES = [
-  'ABUSE_OR_HATE', 'SPAM_OR_AD', 'INAPPROPRIATE_CONTENT',
-  'REPETITIVE_POST', 'SELF_HARM_OR_SUICIDE', 'ETC',
+  'HARASSMENT', 'FRAUD', 'INAPPROPRIATE_CONTENT',
+  'SPAM', 'OFFENSIVE_PROFILE', 'UNDERAGE', 'OTHER',
 ]
 
 const STATUSES: AdminReport['status'][] = ['PENDING', 'REVIEWED', 'REJECTED', 'ACTION_TAKEN']

--- a/src/lib/api/admin.ts
+++ b/src/lib/api/admin.ts
@@ -14,6 +14,17 @@ import type {
   ApiResponse,
   PageResponse,
 } from '@/features/admin/types/adminApi'
+import { getMockProducts } from '@/features/admin/mocks/mockProducts'
+import { getMockCommunityPosts } from '@/features/admin/mocks/mockCommunityPosts'
+import { getMockUsers } from '@/features/admin/mocks/mockUsers'
+import { getMockWithdrawals } from '@/features/admin/mocks/mockWithdrawals'
+import { getMockUserReports } from '@/features/admin/mocks/mockUserReports'
+import { getMockProductSellReports } from '@/features/admin/mocks/mockProductSellReports'
+import { getMockCommunityReports } from '@/features/admin/mocks/mockCommunityReports'
+import { mockMemberStats, mockWithdrawalReasons } from '@/features/admin/mocks/mockMemberStats'
+
+// 데모 모드: NEXT_PUBLIC_DEMO_MODE=true 인 배포에서만 목업 데이터로 어드민을 보여줌
+const DEMO_MODE = process.env.NEXT_PUBLIC_DEMO_MODE === 'true'
 
 interface FetchParams {
   page: number
@@ -94,9 +105,41 @@ const REPORT_STATUS_KO_TO_EN: Record<string, string> = {
   '조치완료': 'ACTION_TAKEN',
 }
 
+const CONDITION_KO_TO_EN: Record<string, string> = {
+  '새 상품': 'NEW',
+  '거의 새것': 'LIKE_NEW',
+  '사용감 있음': 'USED',
+  '수리 필요': 'NEED_REPAIR',
+}
+
+// 신고 처리상태: config badge value는 한글이라 목업 영문 status를 한글로 변환
+const REPORT_STATUS_EN_TO_KO: Record<string, string> = {
+  PENDING: '대기중',
+  REVIEWED: '검토완료',
+  REJECTED: '거절',
+  ACTION_TAKEN: '조치완료',
+}
+
 // ========== 상품 API ==========
 
 export async function fetchAdminProducts(params: FetchParams): Promise<AdminTableResponse<AdminProduct>> {
+  if (DEMO_MODE) {
+    const mock = getMockProducts(params)
+    return {
+      ...mock,
+      data: mock.data.map((p) => ({
+        ...p,
+        // 테이블 config는 title/sellerNickname 키를 기대
+        title: p.name,
+        sellerNickname: p.nickname,
+        // badge 색상은 영문 value에 매칭되므로 한글 → 영문 변환
+        productType: PRODUCT_TYPE_KO_TO_EN[p.productType] ?? p.productType,
+        tradeStatus: TRADE_STATUS_KO_TO_EN[p.tradeStatus] ?? p.tradeStatus,
+        productStatus: CONDITION_KO_TO_EN[p.condition] ?? p.condition,
+      })),
+    } as unknown as AdminTableResponse<AdminProduct>
+  }
+
   const searchParams = new URLSearchParams({
     page: String(params.page - 1),
     size: String(params.pageSize),
@@ -135,6 +178,19 @@ export async function fetchAdminProductDetail(id: number): Promise<ProductDetail
 // ========== 커뮤니티 API ==========
 
 export async function fetchAdminCommunityPosts(params: FetchParams): Promise<AdminTableResponse<CommunityItem>> {
+  if (DEMO_MODE) {
+    const mock = getMockCommunityPosts(params)
+    return {
+      ...mock,
+      data: mock.data.map((p) => ({
+        ...p,
+        authorNickname: p.nickname,
+        commentCount: p.comments?.length ?? 0,
+        boardType: BOARD_TYPE_KO_TO_EN[p.boardType] ?? p.boardType,
+      })),
+    } as unknown as AdminTableResponse<CommunityItem>
+  }
+
   const searchParams = new URLSearchParams({
     page: String(params.page - 1),
     size: String(params.pageSize),
@@ -156,6 +212,16 @@ export async function fetchAdminCommunityPosts(params: FetchParams): Promise<Adm
 }
 
 export async function fetchAdminCommunityDetail(id: number): Promise<CommunityDetailItem | null> {
+  if (DEMO_MODE) {
+    const mock = getMockCommunityPosts({ page: 1, pageSize: 1000 }).data.find((p) => p.id === id)
+    if (!mock) return null
+    return {
+      ...mock,
+      authorNickname: mock.nickname,
+      boardType: BOARD_TYPE_KO_TO_EN[mock.boardType] ?? mock.boardType,
+      imageUrls: [mock.image, ...(mock.subImages ?? [])].filter(Boolean),
+    } as unknown as CommunityDetailItem
+  }
   try {
     const { data } = await api.get<CommunityDetailItemResponse>(`/community/posts/${id}`)
     return data.data
@@ -164,9 +230,24 @@ export async function fetchAdminCommunityDetail(id: number): Promise<CommunityDe
   }
 }
 
+// 데모 모드 전용: 필터 드롭다운의 한글 value를 mock 데이터의 영문 코드로 변환.
+// (실제 분기가 백엔드 호출 전 KO_TO_EN 하는 것과 동일한 변환을 mock 호출 전에 적용해야
+//  한글 필터값과 영문 mock 값이 맞아 필터가 동작함)
+function mapDemoFilters(params: FetchParams, maps: Record<string, Record<string, string>>): FetchParams {
+  if (!params.filters) return params
+  const mapped: FilterState = { ...params.filters }
+  for (const [key, map] of Object.entries(maps)) {
+    const v = params.filters[key]
+    if (v) mapped[key] = map[v] ?? v
+  }
+  return { ...params, filters: mapped }
+}
+
 // ========== 회원 관리 API ==========
 
 export async function fetchAdminUsers(params: FetchParams): Promise<AdminTableResponse<AdminUser>> {
+  if (DEMO_MODE) return getMockUsers(mapDemoFilters(params, { status: USER_STATUS_KO_TO_EN, role: USER_ROLE_KO_TO_EN }))
+
   const searchParams = new URLSearchParams({
     page: String(params.page - 1),
     size: String(params.pageSize),
@@ -187,12 +268,15 @@ export async function fetchAdminUsers(params: FetchParams): Promise<AdminTableRe
 }
 
 export async function grantAdminRole(userId: number): Promise<void> {
+  if (DEMO_MODE) return
   await api.patch(`/admin/users/${userId}/role`)
 }
 
 // ========== 탈퇴 회원 API ==========
 
 export async function fetchAdminWithdrawals(params: FetchParams): Promise<AdminTableResponse<AdminWithdrawal>> {
+  if (DEMO_MODE) return getMockWithdrawals(mapDemoFilters(params, { withdrawalReason: WITHDRAWAL_REASON_KO_TO_EN }))
+
   const searchParams = new URLSearchParams({
     page: String(params.page - 1),
     size: String(params.pageSize),
@@ -216,6 +300,7 @@ export async function fetchAdminWithdrawalDetail(userId: number): Promise<AdminW
 }
 
 export async function restoreWithdrawnUser(userId: number): Promise<void> {
+  if (DEMO_MODE) return
   await api.post(`/admin/withdrawals/${userId}/restore`)
 }
 
@@ -225,6 +310,23 @@ export async function fetchAdminReports(
   params: FetchParams,
   targetType?: 'USER' | 'PRODUCT' | 'COMMUNITY_POST',
 ): Promise<AdminTableResponse<AdminReport>> {
+  if (DEMO_MODE) {
+    const demoParams = mapDemoFilters(params, { status: REPORT_STATUS_KO_TO_EN })
+    const result =
+      targetType === 'USER'
+        ? getMockUserReports(demoParams)
+        : targetType === 'PRODUCT'
+          ? getMockProductSellReports(demoParams)
+          : getMockCommunityReports(demoParams)
+    return {
+      ...result,
+      data: result.data.map((r) => ({
+        ...r,
+        status: (REPORT_STATUS_EN_TO_KO[r.status] ?? r.status) as typeof r.status,
+      })),
+    } as unknown as AdminTableResponse<AdminReport>
+  }
+
   const searchParams = new URLSearchParams({
     page: String(params.page - 1),
     size: String(params.pageSize),
@@ -263,17 +365,22 @@ export async function reviewReport(
   reportId: number,
   body: { status: string; rejectedReason?: string; actionNote?: string },
 ): Promise<void> {
+  if (DEMO_MODE) return
   await api.patch(`/admin/reports/${reportId}/review`, body)
 }
 
 // ========== 통계 API ==========
 
 export async function fetchMemberStats(): Promise<MemberTrendStat[]> {
+  if (DEMO_MODE) return mockMemberStats
+
   const { data } = await api.get<ApiResponse<MemberTrendStat[]>>('/admin/statistics/trends')
   return data.data
 }
 
 export async function fetchWithdrawalReasons(): Promise<WithdrawalReasonStat[]> {
+  if (DEMO_MODE) return mockWithdrawalReasons
+
   const { data } = await api.get<ApiResponse<WithdrawalReasonStat[]>>('/admin/statistics/withdrawal-reasons')
   return data.data
 }
@@ -281,6 +388,15 @@ export async function fetchWithdrawalReasons(): Promise<WithdrawalReasonStat[]> 
 // ========== 대시보드 API ==========
 
 export async function fetchDashboardStats(): Promise<DashboardSummary> {
+  if (DEMO_MODE)
+    return {
+      totalUserCount: 1284,
+      activeUserCount: 1102,
+      withdrawnUserCount: 182,
+      totalProductCount: 3471,
+      activeProductCount: 2980,
+    }
+
   const { data } = await api.get<ApiResponse<DashboardSummary>>('/admin/statistics/summary')
   return data.data
 }


### PR DESCRIPTION
## 📌 개요

포트폴리오에서 면접관이 로그인 없이 어드민 화면을 둘러볼 수 있도록 `NEXT_PUBLIC_DEMO_MODE=true` 환경에서 동작하는 데모 모드를 추가하고, 그 과정에서 발견한 어드민 관련 버그들을 함께 수정했습니다.

## 🔧 작업 내용

- [x] 데모 인증 우회 + mock 데이터 분기 (AdminAuthGuard, admin.ts)
- [x] 탈퇴 회원 상세 모달 신규 + 탈퇴 복구 버튼 (WithdrawalDetailModal, WithdrawalsManagement)
- [x] 커뮤니티 관리: 닉네임/댓글수 매핑, 상세 모달·댓글 데모 분기, 대댓글 들여쓰기(depth), 유형 badge 색
- [x] 필터 동작: 한글 드롭다운값 → 영문 mock값 변환 (회원/탈퇴/신고 6종, mapDemoFilters)
- [x] 유저신고 상세 모달 신고항목 한글 매핑 단일화
- [x] 판매상품 신고 상품명 mock 추가
- [x] SelectDropdown: dialog top-layer portal 수정 + flex gap 부작용 방지
- [x] .gitignore: ssh.md/*.pem 비밀 차단

## 📎 관련 이슈

- 단독 데모 작업으로 별도 이슈 없음

## 💬 리뷰어 참고 사항

- 모든 데모 코드는 `NEXT_PUBLIC_DEMO_MODE === 'true'`로 가드되어 있어, 미설정(실서비스) 환경에선 기존 동작 그대로입니다.
- 이 브랜치는 별도 Vercel 데모 프로젝트로 배포 예정 (DEMO_MODE=true). develop 머지 여부는 검토 후 결정.
- `SelectDropdown` 수정은 실서비스 회원탈퇴 모달의 사유 드롭다운 버그(`<dialog>` top-layer ↔ portal 충돌)도 함께 고칩니다.