### PR TITLE
fix: 회원탈퇴 모달 사유 드롭다운 클릭/높이 버그 수정

### DIFF
--- a/src/components/commons/select/SelectDropdown.tsx
+++ b/src/components/commons/select/SelectDropdown.tsx
@@ -226,7 +226,9 @@ export default function SelectDropdown({
 
       {isOpen && !disabled && dropdownStyle
         ? createPortal(
-            <div ref={optionsRef}>
+            // fixed로 흐름에서 빼야 함: dialog에 portal될 때 이 wrapper가
+            // flex 자식으로 잡혀 gap(예: gap-4=16px)을 추가하는 부작용 방지.
+            <div ref={optionsRef} className="fixed">
               <SelectOptions
                 options={options}
                 selectedValue={value}
@@ -236,7 +238,10 @@ export default function SelectDropdown({
                 style={dropdownStyle}
               />
             </div>,
-            document.body
+            // <dialog showModal()>은 top-layer에 렌더돼 z-index로 못 이김.
+            // dialog 안에서 열린 경우엔 그 dialog에 portal해야 옵션이 위로 뜨고 클릭됨.
+            // dialog 밖(일반 페이지)에선 기존처럼 body에 portal.
+            selectRef.current?.closest('dialog') ?? document.body
           )
         : null}
     </div>


### PR DESCRIPTION
## 📌 개요

회원탈퇴 모달(`<dialog>`)에서 탈퇴 사유 드롭다운(`SelectDropdown`)의 옵션을 **선택할 수 없고**, 드롭다운을 열면 **모달 높이가 늘어나는** 버그를 수정합니다.

## 🔧 작업 내용

- [x] `<dialog showModal()>`은 브라우저 top-layer에 렌더돼 z-index로 못 이기는데, 옵션 목록이 `document.body`에 portal돼 backdrop 뒤에 깔려 클릭이 막히던 문제 → 가장 가까운 `<dialog>`에 portal하도록 수정
- [x] portal wrapper가 dialog의 flex 자식으로 잡혀 `gap`만큼 모달 높이가 늘어나던 부작용 → `fixed`로 흐름에서 제외

## 📎 관련 이슈

- 별도 이슈 없음 (데모 작업 중 발견한 실서비스 버그)

## 💬 리뷰어 참고 사항

- 데모 PR(#770)에도 동일 변경이 포함돼 있으나, 이 수정은 실서비스 버그라 별도로 분리해 올립니다. 이 PR이 develop에 먼저 머지되면 #770은 자동 정합됩니다.
- `SelectDropdown`은 dialog 밖(일반 페이지)에선 기존처럼 `document.body`에 portal하므로 다른 사용처에 영향 없습니다.